### PR TITLE
feat: spawn_agent tool — agent-spawns-agent with sandbox isolation (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+logs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "clap",
  "fs2",
  "futures-util",
+ "libc",
  "reqwest",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tiktoken-rs = "0.9"
 agent-client-protocol = "0.10.2"
 tokio-util = { version = "0.7", features = ["compat"] }
 fs2 = "0.4"
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Create or reuse a git worktree and run Claude Code to write/fix code.
+# Usage:
+#   scripts/dev.sh <task-name> "<prompt>"
+#
+# Creates worktree at ~/amaebi-wt/<task-name> on branch feat/<task-name>.
+# If the worktree already exists, reuses it (for fix iterations).
+# Claude Code writes code and commits. Does NOT run tests or push.
+
+set -euo pipefail
+
+TASK="${1:-}"
+PROMPT="${2:-}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKTREE_BASE="$HOME/amaebi-wt"
+WORKDIR="$WORKTREE_BASE/$TASK"
+BRANCH="feat/$TASK"
+CLAUDE="${CLAUDE:-$HOME/.local/bin/claude}"
+
+if [[ -z "$TASK" || -z "$PROMPT" ]]; then
+    echo "Usage: scripts/dev.sh <task-name> \"<prompt>\""
+    echo "  task-name: short slug (e.g. fix-context-limit)"
+    echo "  prompt:    task description for Claude Code"
+    exit 1
+fi
+
+step() { echo ""; echo "==> $1"; }
+
+# Step 1: setup worktree
+step "worktree: $WORKDIR (branch: $BRANCH)"
+if [[ -d "$WORKDIR" ]]; then
+    echo "    reusing existing worktree"
+else
+    cd "$REPO_ROOT"
+    git worktree add "$WORKDIR" -b "$BRANCH"
+    echo "    created"
+fi
+
+# Step 2: run Claude Code
+step "coder (Claude Code)"
+cd "$WORKDIR"
+exec "$CLAUDE" --permission-mode bypassPermissions --print "$PROMPT"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,6 +17,13 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORKDIR="$REPO_ROOT"
 
+# Log file: logs/test-YYYY-MM-DD-HHMMSS.log
+LOG_DIR="$REPO_ROOT/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/test-$(date +%Y-%m-%d-%H%M%S).log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+echo "==> Log: $LOG_FILE"
+
 # This image is provided by OpenClaw. Set AMAEBI_DEV_IMAGE to use a custom image.
 # The default openclaw-sandbox-dev:bookworm-slim ships Rust/Cargo pre-installed
 # and is not publicly distributed — contact the OpenClaw team or build your own.
@@ -69,7 +76,9 @@ fi
 # which breaks `cargo build`. Build artifacts written into the bind-mounted
 # workspace will be root-owned, but that is an acceptable trade-off for a local
 # dev-test runner.
-if docker run --rm \
+echo "    image:   $DEV_IMAGE"
+echo "    workdir: $WORKDIR"
+CONTAINER_ID=$(docker run --rm -d \
     -w "$WORKDIR" \
     --user 0:0 \
     -v "$REPO_ROOT:$REPO_ROOT:rw" \
@@ -80,8 +89,12 @@ if docker run --rm \
     -e CARGO_HOME=/home/user/.cargo \
     -e RUST_BACKTRACE=1 \
     "$DEV_IMAGE" \
-    sh -c "cargo check && cargo test${FILTER:+ $FILTER} && cargo clippy -- -D warnings"
-then ok; else fail; fi
+    sh -c "cargo check && cargo test${FILTER:+ $FILTER} && cargo clippy -- -D warnings && echo __TESTS_PASSED__")
+echo "    container: $CONTAINER_ID"
+docker logs -f "$CONTAINER_ID"
+EXIT_CODE=$(docker wait "$CONTAINER_ID")
+docker rm "$CONTAINER_ID" &>/dev/null || true
+if [[ "$EXIT_CODE" == "0" ]]; then ok; else fail; fi
 
 # Step 2 (optional): Docker integration tests — run on host (needs docker daemon)
 if [[ "$RUN_DOCKER" == "1" ]]; then
@@ -94,6 +107,8 @@ if [[ "$RUN_DOCKER" == "1" ]]; then
         exit 1
     fi
 
+    echo "    image:   amaebi-sandbox:bookworm-slim"
+    echo "    running: cargo test -- --ignored"
     if "$HOST_CARGO" test -- --ignored; then ok; else fail; fi
 fi
 

--- a/src/agent_server.rs
+++ b/src/agent_server.rs
@@ -266,10 +266,16 @@ impl acp::Agent for AmaebiAgent {
         let (steer_tx, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(1);
         drop(steer_tx);
         tokio::task::spawn_local(async move {
-            let outcome =
-                run_agentic_loop(&state, &model, messages, &mut write_half, &mut steer_rx)
-                    .await
-                    .map_err(|e| format!("{e:#}"));
+            let outcome = run_agentic_loop(
+                &state,
+                &model,
+                messages,
+                &mut write_half,
+                &mut steer_rx,
+                true,
+            )
+            .await
+            .map_err(|e| format!("{e:#}"));
             let _ = result_tx.send(outcome);
             // Dropping write_half closes the pipe, signalling EOF to the reader.
         });

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -59,7 +59,7 @@ const MAX_SUMMARY_CHARS: usize = 500;
 /// State shared across all concurrent client connections via `Arc`.
 pub struct DaemonState {
     pub http: reqwest::Client,
-    pub tokens: TokenCache,
+    pub tokens: Arc<TokenCache>,
     /// Tool executor — `LocalExecutor` now; swappable with `DockerExecutor` in Phase 4.
     pub executor: Box<dyn ToolExecutor>,
     /// Persistent SQLite connection opened once at startup.
@@ -88,12 +88,28 @@ impl DaemonState {
             .await
             .unwrap_or_else(|e| Err(anyhow::anyhow!("DB init panicked: {e}")))
             .context("opening memory DB")?;
+
+        let db = Arc::new(Mutex::new(conn));
+        let compacting_sessions: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+
+        let tokens = Arc::new(TokenCache::new());
+
+        let spawn_ctx = Arc::new(tools::SpawnContext {
+            http: http.clone(),
+            db: Arc::clone(&db),
+            compacting_sessions: Arc::clone(&compacting_sessions),
+            tokens: Arc::clone(&tokens),
+        });
+
+        let mut executor = tools::LocalExecutor::new();
+        executor.spawn_ctx = Some(spawn_ctx);
+
         Ok(Self {
             http,
-            tokens: TokenCache::new(),
-            executor: Box::new(tools::LocalExecutor::new()),
-            db: Arc::new(Mutex::new(conn)),
-            compacting_sessions: Arc::new(Mutex::new(HashSet::new())),
+            tokens,
+            executor: Box::new(executor),
+            db,
+            compacting_sessions,
         })
     }
 }
@@ -414,7 +430,9 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                 let mut sink = tokio::io::sink();
                 let (_, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(1);
 
-                match run_agentic_loop(&state, &model, messages, &mut sink, &mut steer_rx).await {
+                match run_agentic_loop(&state, &model, messages, &mut sink, &mut steer_rx, true)
+                    .await
+                {
                     Ok((final_text, _)) => {
                         let user_text = truncate_chars(prompt.clone(), MAX_PROMPT_CHARS);
                         let assistant_text = truncate_chars(final_text.clone(), MAX_RESPONSE_CHARS);
@@ -573,7 +591,8 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                 inject_skill_files(&mut messages).await;
             }
 
-            match run_agentic_loop(&state, &model, messages, &mut writer, &mut steer_rx).await {
+            match run_agentic_loop(&state, &model, messages, &mut writer, &mut steer_rx, true).await
+            {
                 Ok((response_text, _)) => {
                     let user_text = truncate_chars(prompt.clone(), MAX_PROMPT_CHARS);
                     let assistant_text = truncate_chars(response_text.clone(), MAX_RESPONSE_CHARS);
@@ -768,7 +787,8 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
             // Used as a fallback when the API returns prompt_tokens = 0.
             let pre_send_tokens = count_message_tokens(&messages);
 
-            match run_agentic_loop(&state, &model, messages, &mut writer, &mut steer_rx).await {
+            match run_agentic_loop(&state, &model, messages, &mut writer, &mut steer_rx, true).await
+            {
                 Ok((response_text, prompt_tokens)) => {
                     let user_text = truncate_chars(prompt.clone(), MAX_PROMPT_CHARS);
                     let assistant_text = truncate_chars(response_text.clone(), MAX_RESPONSE_CHARS);
@@ -1120,11 +1140,12 @@ pub(crate) async fn run_agentic_loop<W>(
     mut messages: Vec<Message>,
     writer: &mut W,
     steer_rx: &mut tokio::sync::mpsc::Receiver<Option<String>>,
+    include_spawn_agent: bool,
 ) -> Result<(String, usize)>
 where
     W: AsyncWriteExt + Unpin,
 {
-    let schemas = tools::tool_schemas();
+    let schemas = tools::tool_schemas(include_spawn_agent);
     let final_text;
     let mut tools_were_used = false;
     let mut conclusion_nudge_sent = false;
@@ -1463,141 +1484,213 @@ where
                 messages.push(Message::assistant(assistant_text, api_calls));
 
                 let tool_calls_snapshot = &tool_calls;
-                let mut interrupted_at: Option<usize> = None;
-                let mut steer_text: Option<String> = None;
 
-                for (i, tc) in tool_calls_snapshot.iter().enumerate() {
-                    // Check for a mid-execution steer before running this tool.
-                    // If the user pressed Ctrl-C and typed a correction, honour
-                    // it immediately: skip this and all remaining tools.
-                    if let Ok(msg) = steer_rx.try_recv() {
-                        tracing::debug!(
-                            "mid-execution steer received; interrupting tool chain at index {i}"
-                        );
-                        // Stash the steer text — we must emit placeholder tool_result
-                        // entries for ALL skipped calls before appending the user message,
-                        // because the API requires assistant(tool_calls) →
-                        // tool(tool_result…) → user/assistant ordering.
-                        // msg is None for interrupt-only (no text to inject).
-                        steer_text = msg;
-                        if steer_text.is_some() {
-                            write_frame(writer, &Response::SteerAck).await?;
-                        }
-                        interrupted_at = Some(i);
-                        break;
+                // When every call in this batch is spawn_agent AND all of them
+                // opt in with `parallel=true`, run them concurrently.
+                // Default is sequential — the caller must explicitly request
+                // parallel execution for each call in the batch.
+                let all_spawn_agent = tool_calls_snapshot.len() > 1
+                    && tool_calls_snapshot
+                        .iter()
+                        .all(|tc| tc.name == "spawn_agent")
+                    && tool_calls_snapshot.iter().all(|tc| {
+                        tc.parse_args()
+                            .ok()
+                            .and_then(|v| v["parallel"].as_bool())
+                            .unwrap_or(false)
+                    });
+
+                if all_spawn_agent {
+                    // Emit all ToolUse frames sequentially first: the writer
+                    // is not Sync so we cannot interleave writes.
+                    for tc in tool_calls_snapshot.iter() {
+                        write_frame(
+                            writer,
+                            &Response::ToolUse {
+                                name: tc.name.clone(),
+                                detail: String::new(),
+                            },
+                        )
+                        .await?;
                     }
 
-                    tracing::debug!(tool = %tc.name, "executing tool");
-
-                    let tool_detail = {
-                        let args: serde_json::Value =
-                            serde_json::from_str(&tc.arguments).unwrap_or(serde_json::Value::Null);
-                        match tc.name.as_str() {
-                            "shell_command" => args
-                                .get("command")
-                                .and_then(|v| v.as_str())
-                                .map(|s| {
-                                    if s.len() > 80 {
-                                        format!("{}…", &s[..80])
-                                    } else {
-                                        s.to_string()
-                                    }
-                                })
-                                .unwrap_or_default(),
-                            "read_file" => args
-                                .get("path")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            "edit_file" => args
-                                .get("path")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            "tmux_send_keys" => args
-                                .get("keys")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            "tmux_capture_pane" => args
-                                .get("target")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            _ => String::new(),
-                        }
-                    };
-                    write_frame(
-                        writer,
-                        &Response::ToolUse {
-                            name: tc.name.clone(),
-                            detail: tool_detail,
+                    // Execute all spawn_agent calls concurrently, collecting
+                    // results in original order.
+                    // Steer interrupts are not checked here — they only apply
+                    // to the sequential path where we can abort cleanly before
+                    // the next tool runs.
+                    let results = futures_util::future::join_all(tool_calls_snapshot.iter().map(
+                        |tc| async move {
+                            let args = match tc.parse_args() {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        tool = %tc.name,
+                                        error = %e,
+                                        "bad tool arguments"
+                                    );
+                                    return format!("argument error: {e:#}");
+                                }
+                            };
+                            match state.executor.execute(&tc.name, args).await {
+                                Ok(output) => {
+                                    tracing::debug!(
+                                        tool = %tc.name,
+                                        output_len = output.len(),
+                                        "tool succeeded"
+                                    );
+                                    truncate_chars(output, MAX_TOOL_OUTPUT_CHARS)
+                                }
+                                Err(e) => {
+                                    tracing::warn!(tool = %tc.name, error = %e, "tool failed");
+                                    format!("error: {e:#}")
+                                }
+                            }
                         },
-                    )
-                    .await?;
+                    ))
+                    .await;
 
-                    let args = match tc.parse_args() {
-                        Ok(v) => v,
-                        Err(e) => {
-                            tracing::warn!(tool = %tc.name, error = %e, "bad tool arguments");
+                    for (tc, result) in tool_calls_snapshot.iter().zip(results) {
+                        messages.push(Message::tool_result(&tc.id, result));
+                    }
+                } else {
+                    // Sequential path: honour steer interrupts between tools.
+                    let mut interrupted_at: Option<usize> = None;
+                    let mut steer_text: Option<String> = None;
+
+                    for (i, tc) in tool_calls_snapshot.iter().enumerate() {
+                        // Check for a mid-execution steer before running this tool.
+                        // If the user pressed Ctrl-C and typed a correction, honour
+                        // it immediately: skip this and all remaining tools.
+                        if let Ok(msg) = steer_rx.try_recv() {
+                            tracing::debug!(
+                                "mid-execution steer received; interrupting tool chain at index {i}"
+                            );
+                            // Stash the steer text — we must emit placeholder tool_result
+                            // entries for ALL skipped calls before appending the user message,
+                            // because the API requires assistant(tool_calls) →
+                            // tool(tool_result…) → user/assistant ordering.
+                            // msg is None for interrupt-only (no text to inject).
+                            steer_text = msg;
+                            if steer_text.is_some() {
+                                write_frame(writer, &Response::SteerAck).await?;
+                            }
+                            interrupted_at = Some(i);
+                            break;
+                        }
+
+                        tracing::debug!(tool = %tc.name, "executing tool");
+
+                        let tool_detail = {
+                            let args: serde_json::Value = serde_json::from_str(&tc.arguments)
+                                .unwrap_or(serde_json::Value::Null);
+                            match tc.name.as_str() {
+                                "shell_command" => args
+                                    .get("command")
+                                    .and_then(|v| v.as_str())
+                                    .map(|s| {
+                                        if s.len() > 80 {
+                                            format!("{}…", &s[..80])
+                                        } else {
+                                            s.to_string()
+                                        }
+                                    })
+                                    .unwrap_or_default(),
+                                "read_file" => args
+                                    .get("path")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or_default()
+                                    .to_string(),
+                                "edit_file" => args
+                                    .get("path")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or_default()
+                                    .to_string(),
+                                "tmux_send_keys" => args
+                                    .get("keys")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or_default()
+                                    .to_string(),
+                                "tmux_capture_pane" => args
+                                    .get("target")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or_default()
+                                    .to_string(),
+                                _ => String::new(),
+                            }
+                        };
+                        write_frame(
+                            writer,
+                            &Response::ToolUse {
+                                name: tc.name.clone(),
+                                detail: tool_detail,
+                            },
+                        )
+                        .await?;
+
+                        let args = match tc.parse_args() {
+                            Ok(v) => v,
+                            Err(e) => {
+                                tracing::warn!(tool = %tc.name, error = %e, "bad tool arguments");
+                                messages.push(Message::tool_result(
+                                    &tc.id,
+                                    format!("argument error: {e:#}"),
+                                ));
+                                continue;
+                            }
+                        };
+
+                        let result = match state.executor.execute(&tc.name, args).await {
+                            Ok(output) => {
+                                tracing::debug!(
+                                    tool = %tc.name,
+                                    output_len = output.len(),
+                                    "tool succeeded"
+                                );
+                                truncate_chars(output, MAX_TOOL_OUTPUT_CHARS)
+                            }
+                            Err(e) => {
+                                tracing::warn!(tool = %tc.name, error = %e, "tool failed");
+                                format!("error: {e:#}")
+                            }
+                        };
+
+                        messages.push(Message::tool_result(&tc.id, result));
+                    }
+
+                    // If the user injected a steer mid-chain, push placeholder
+                    // tool results for the tools that were never executed.  The
+                    // OpenAI API requires a tool_result for every tool_call in the
+                    // assistant message, even if we didn't actually run them.
+                    if let Some(skip_from) = interrupted_at {
+                        for tc in &tool_calls_snapshot[skip_from..] {
                             messages.push(Message::tool_result(
                                 &tc.id,
-                                format!("argument error: {e:#}"),
+                                "[interrupted by user before execution]",
                             ));
-                            continue;
                         }
-                    };
-
-                    let result = match state.executor.execute(&tc.name, args).await {
-                        Ok(output) => {
-                            tracing::debug!(
-                                tool = %tc.name,
-                                output_len = output.len(),
-                                "tool succeeded"
-                            );
-                            truncate_chars(output, MAX_TOOL_OUTPUT_CHARS)
-                        }
-                        Err(e) => {
-                            tracing::warn!(tool = %tc.name, error = %e, "tool failed");
-                            format!("error: {e:#}")
-                        }
-                    };
-
-                    messages.push(Message::tool_result(&tc.id, result));
-                }
-
-                // If the user injected a steer mid-chain, push placeholder
-                // tool results for the tools that were never executed.  The
-                // OpenAI API requires a tool_result for every tool_call in the
-                // assistant message, even if we didn't actually run them.
-                if let Some(skip_from) = interrupted_at {
-                    for tc in &tool_calls_snapshot[skip_from..] {
-                        messages.push(Message::tool_result(
-                            &tc.id,
-                            "[interrupted by user before execution]",
-                        ));
-                    }
-                    // When the interrupt carried steer text, use it directly.
-                    // When it was interrupt-only (None), block until the user
-                    // sends a correction before starting the next model turn —
-                    // proceeding immediately would race against incoming steer
-                    // text and re-enter the model without user guidance.
-                    let effective_steer = if let Some(text) = steer_text {
-                        Some(text)
-                    } else {
-                        loop {
-                            match steer_rx.recv().await {
-                                Some(Some(t)) => {
-                                    write_frame(writer, &Response::SteerAck).await?;
-                                    break Some(t);
+                        // When the interrupt carried steer text, use it directly.
+                        // When it was interrupt-only (None), block until the user
+                        // sends a correction before starting the next model turn —
+                        // proceeding immediately would race against incoming steer
+                        // text and re-enter the model without user guidance.
+                        let effective_steer = if let Some(text) = steer_text {
+                            Some(text)
+                        } else {
+                            loop {
+                                match steer_rx.recv().await {
+                                    Some(Some(t)) => {
+                                        write_frame(writer, &Response::SteerAck).await?;
+                                        break Some(t);
+                                    }
+                                    Some(None) => continue, // another bare interrupt; keep waiting
+                                    None => break None,     // channel closed; proceed without steer
                                 }
-                                Some(None) => continue, // another bare interrupt; keep waiting
-                                None => break None,     // channel closed; proceed without steer
                             }
+                        };
+                        if let Some(text) = effective_steer {
+                            messages.push(Message::user(text));
                         }
-                    };
-                    if let Some(text) = effective_steer {
-                        messages.push(Message::user(text));
                     }
                 }
 
@@ -1806,7 +1899,7 @@ async fn run_cron_job(state: Arc<DaemonState>, job: &cron::CronJob) {
     let mut sink = tokio::io::sink();
     let (_, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(1);
 
-    let result = run_agentic_loop(&state, &model, messages, &mut sink, &mut steer_rx).await;
+    let result = run_agentic_loop(&state, &model, messages, &mut sink, &mut steer_rx, true).await;
 
     let (output, run_ok) = match result {
         Ok((final_text, _)) => {
@@ -2285,8 +2378,8 @@ mod tests {
         let msgs = simulate_mid_steer(3, 1, Some("new direction"));
 
         assert_eq!(msgs[0].role, "assistant", "first message must be assistant");
-        for i in 1..=3 {
-            assert_eq!(msgs[i].role, "tool", "messages[{i}] must be role=tool");
+        for (i, msg) in msgs.iter().enumerate().take(4).skip(1) {
+            assert_eq!(msg.role, "tool", "messages[{i}] must be role=tool");
         }
         assert_eq!(
             msgs.last().unwrap().role,

--- a/src/sandbox/docker.rs
+++ b/src/sandbox/docker.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -19,6 +20,8 @@ pub struct DockerSandboxConfig {
     pub ro_paths: Vec<PathBuf>,
     /// Additional paths mounted read-write at the same path inside the container.
     pub rw_paths: Vec<PathBuf>,
+    /// Environment variables to inject into the container.
+    pub env: HashMap<String, String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -52,9 +55,17 @@ impl DockerSandbox {
             .to_str()
             .ok_or_else(|| anyhow::anyhow!("workspace path is not valid UTF-8"))?;
 
+        let uid = unsafe { libc::getuid() };
+        let gid = unsafe { libc::getgid() };
+
         let mut docker = Command::new("docker");
         docker.args(["run", "-d", "--rm", "--network", "none"]);
+        docker.args(["--user", &format!("{uid}:{gid}")]);
         docker.args(["-v", &format!("{workspace_str}:{workspace_str}:rw")]);
+
+        for (key, value) in &self.config.env {
+            docker.args(["-e", &format!("{key}={value}")]);
+        }
 
         for rw_path in &self.config.rw_paths {
             let s = rw_path
@@ -207,6 +218,7 @@ mod tests {
             workspace: workspace.path().to_path_buf(),
             ro_paths: vec![],
             rw_paths: vec![],
+            env: HashMap::new(),
         })
     }
 
@@ -294,6 +306,48 @@ mod tests {
         );
     }
 
+    /// Environment variables passed via `DockerSandboxConfig.env` must be
+    /// visible inside the container.
+    #[tokio::test]
+    #[ignore]
+    async fn docker_sandbox_env_var_is_set() {
+        let dir = TempDir::new().unwrap();
+        let sandbox = DockerSandbox::new(DockerSandboxConfig {
+            image: "amaebi-sandbox:bookworm-slim".to_string(),
+            workspace: dir.path().to_path_buf(),
+            ro_paths: vec![],
+            rw_paths: vec![],
+            env: HashMap::from([("TEST_VAR".to_string(), "hello123".to_string())]),
+        });
+        let out = sandbox.spawn("echo $TEST_VAR", dir.path()).await.unwrap();
+        assert!(
+            out.stdout.contains("hello123"),
+            "expected 'hello123' in stdout, got: {:?}",
+            out.stdout
+        );
+    }
+
+    /// The container must run as the current host UID.
+    #[tokio::test]
+    #[ignore]
+    async fn docker_sandbox_user_matches_host() {
+        let dir = TempDir::new().unwrap();
+        let sandbox = test_sandbox(&dir);
+        let out = sandbox.spawn("id -u", dir.path()).await.unwrap();
+        let host_uid = unsafe { libc::getuid() }.to_string();
+        assert!(
+            out.stdout.trim() == host_uid,
+            "expected uid {host_uid}, got: {:?}",
+            out.stdout
+        );
+    }
+
+    // TODO: docker_spawn_agent_no_recursion — verify that a child agent
+    // launched inside a DockerSandbox does not have spawn_agent available.
+    // This requires wiring a full agentic loop into the sandbox test, which
+    // is more integration-level than unit-level; covered at the daemon level
+    // by the `spawn_agent_child_cannot_spawn` integration test instead.
+
     #[tokio::test]
     #[ignore]
     async fn docker_sandbox_cannot_access_other_workspace() {
@@ -310,6 +364,7 @@ mod tests {
             workspace: workspace.path().to_path_buf(),
             ro_paths: vec![],
             rw_paths: vec![],
+            env: HashMap::new(),
         });
 
         let cmd = format!(

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,9 +1,30 @@
-use std::path::PathBuf;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
 use tokio::process::Command;
 
-use crate::sandbox::{docker::DockerSandboxConfig, DockerSandbox, Sandbox};
+use crate::sandbox::{docker::DockerSandboxConfig, DockerSandbox, NoopSandbox, Sandbox};
+
+// ---------------------------------------------------------------------------
+// SpawnContext — shared state injected by the daemon for spawn_agent support
+// ---------------------------------------------------------------------------
+
+/// Context passed to `LocalExecutor` so the `spawn_agent` tool can launch a
+/// child agentic loop without holding a reference back to `DaemonState`
+/// (which would create a circular type dependency).
+pub struct SpawnContext {
+    /// HTTP client inherited from the parent daemon.
+    pub http: reqwest::Client,
+    /// Shared SQLite memory-DB connection.
+    pub db: Arc<Mutex<rusqlite::Connection>>,
+    /// Tracks sessions that currently have a compaction task in flight.
+    pub compacting_sessions: Arc<Mutex<HashSet<String>>>,
+    /// Shared Copilot token cache — reused by child agents to avoid redundant
+    /// token fetches.
+    pub tokens: Arc<crate::auth::TokenCache>,
+}
 
 // ---------------------------------------------------------------------------
 // ToolExecutor trait
@@ -39,10 +60,18 @@ pub struct LocalExecutor {
     /// Optional sandbox backend. When `Some`, `shell_command` runs inside the
     /// sandbox instead of directly on the host.
     pub sandbox: Option<Box<dyn Sandbox>>,
+    /// Optional context for the `spawn_agent` tool.  Injected by the daemon
+    /// at startup; `None` in child agents to prevent unbounded recursion.
+    pub spawn_ctx: Option<Arc<SpawnContext>>,
+    /// Default working directory for `shell_command` when a sandbox is active.
+    /// Set to the agent's workspace in child executors so sandbox cwd matches
+    /// the mounted workspace rather than the daemon process cwd.
+    pub default_cwd: Option<PathBuf>,
 }
 
 impl LocalExecutor {
     pub fn new() -> Self {
+        let mut default_cwd: Option<PathBuf> = None;
         let sandbox: Option<Box<dyn Sandbox>> = match std::env::var("AMAEBI_SANDBOX").as_deref() {
             Ok("docker") => {
                 let image = std::env::var("AMAEBI_SANDBOX_IMAGE")
@@ -50,16 +79,22 @@ impl LocalExecutor {
                 let workspace = std::env::var("AMAEBI_SANDBOX_WORKSPACE")
                     .map(PathBuf::from)
                     .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
+                default_cwd = Some(workspace.clone());
                 Some(Box::new(DockerSandbox::new(DockerSandboxConfig {
                     image,
                     workspace,
                     ro_paths: vec![],
                     rw_paths: vec![],
+                    env: HashMap::new(),
                 })))
             }
             _ => None,
         };
-        Self { sandbox }
+        Self {
+            sandbox,
+            spawn_ctx: None,
+            default_cwd,
+        }
     }
 }
 
@@ -68,11 +103,20 @@ impl ToolExecutor for LocalExecutor {
     async fn execute(&self, name: &str, args: serde_json::Value) -> Result<String> {
         tracing::debug!(tool = %name, "executing tool");
         match name {
-            "shell_command" => shell_command(args, self.sandbox.as_deref()).await,
+            "shell_command" => {
+                shell_command(args, self.sandbox.as_deref(), self.default_cwd.as_deref()).await
+            }
             "tmux_capture_pane" => tmux_capture_pane(args).await,
             "tmux_send_keys" => tmux_send_keys(args).await,
             "read_file" => read_file(args).await,
             "edit_file" => edit_file(args).await,
+            "spawn_agent" => match &self.spawn_ctx {
+                Some(ctx) => spawn_agent(args, ctx).await,
+                None => anyhow::bail!(
+                    "spawn_agent is not available in this context \
+                     (child agents cannot spawn further agents)"
+                ),
+            },
             other => anyhow::bail!("unknown tool: {other}"),
         }
     }
@@ -85,7 +129,11 @@ impl ToolExecutor for LocalExecutor {
 /// Run an arbitrary shell command, capturing stdout+stderr.
 /// If a sandbox is provided the command runs inside it; otherwise it runs
 /// directly on the host via `sh -c`.
-async fn shell_command(args: serde_json::Value, sandbox: Option<&dyn Sandbox>) -> Result<String> {
+async fn shell_command(
+    args: serde_json::Value,
+    sandbox: Option<&dyn Sandbox>,
+    default_cwd: Option<&Path>,
+) -> Result<String> {
     let command = args["command"]
         .as_str()
         .context("shell_command: missing string argument 'command'")?;
@@ -93,7 +141,11 @@ async fn shell_command(args: serde_json::Value, sandbox: Option<&dyn Sandbox>) -
     tracing::debug!(command = %command, "running shell command");
 
     let (stdout, stderr, exit_code, success) = if let Some(sb) = sandbox {
-        let cwd = std::env::current_dir().context("shell_command: getting current directory")?;
+        let cwd = if let Some(dcwd) = default_cwd {
+            dcwd.to_path_buf()
+        } else {
+            std::env::current_dir().context("shell_command: getting current directory")?
+        };
         let out = sb.spawn(command, &cwd).await?;
         let success = out.exit_code == 0;
         (out.stdout, out.stderr, out.exit_code, success)
@@ -185,6 +237,214 @@ async fn read_file(args: serde_json::Value) -> Result<String> {
         .with_context(|| format!("read_file: reading '{path}'"))
 }
 
+/// Spawn a child agent session to complete a task in an isolated sandbox.
+///
+/// # Sandbox selection
+///
+/// - When `AMAEBI_SPAWN_SANDBOX=noop` is set, a [`NoopSandbox`] is used
+///   (runs commands directly on the host). Intended for tests.
+/// - Otherwise a [`DockerSandbox`] is created with `--network none`.
+///   If Docker is not available, an error is returned.
+///
+/// # Recursion prevention
+///
+/// The child executor is created with `spawn_ctx: None` so it cannot
+/// call `spawn_agent` itself.
+/// TODO: enforce a depth limit for nested agents if needed.
+async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<String> {
+    let task = args["task"]
+        .as_str()
+        .context("spawn_agent: missing string argument 'task'")?;
+    let workspace = PathBuf::from(
+        args["workspace"]
+            .as_str()
+            .context("spawn_agent: missing string argument 'workspace'")?,
+    );
+
+    // Fix 1: validate workspace path early.
+    if !workspace.is_absolute() {
+        anyhow::bail!(
+            "spawn_agent: workspace must be an absolute path, got: {}",
+            workspace.display()
+        );
+    }
+    if !workspace.exists() {
+        anyhow::bail!(
+            "spawn_agent: workspace does not exist: {}",
+            workspace.display()
+        );
+    }
+    if !workspace.is_dir() {
+        anyhow::bail!(
+            "spawn_agent: workspace is not a directory: {}",
+            workspace.display()
+        );
+    }
+    let workspace = workspace.canonicalize().with_context(|| {
+        format!(
+            "spawn_agent: canonicalizing workspace: {}",
+            workspace.display()
+        )
+    })?;
+
+    // Fix 4: inherit the parent's current model when the tool caller does not
+    // specify one explicitly.
+    let model = args["model"]
+        .as_str()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| std::env::var("AMAEBI_MODEL").unwrap_or_else(|_| "gpt-4o".to_string()));
+
+    let extra_mounts = args["extra_mounts"].as_array().cloned().unwrap_or_default();
+    let mut ro_paths: Vec<PathBuf> = vec![];
+    let mut rw_paths: Vec<PathBuf> = vec![];
+    for mount in &extra_mounts {
+        let path = PathBuf::from(
+            mount["path"]
+                .as_str()
+                .context("extra_mounts[].path must be a string")?,
+        );
+        if !path.is_absolute() {
+            anyhow::bail!(
+                "spawn_agent: extra_mounts path must be absolute, got: {}",
+                path.display()
+            );
+        }
+        if !path.exists() {
+            anyhow::bail!(
+                "spawn_agent: extra_mounts path does not exist: {}",
+                path.display()
+            );
+        }
+        let canonical_path = path
+            .canonicalize()
+            .with_context(|| format!("extra_mounts: canonicalizing path: {}", path.display()))?;
+        let readonly = mount["readonly"].as_bool().unwrap_or(false);
+        if readonly {
+            ro_paths.push(canonical_path);
+        } else {
+            rw_paths.push(canonical_path);
+        }
+    }
+    let env: HashMap<String, String> = if let Some(obj) = args["env"].as_object() {
+        let mut map = HashMap::new();
+        for (k, v) in obj {
+            let val = v.as_str().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "spawn_agent: env value for key {} must be a string, got: {}",
+                    k,
+                    v
+                )
+            })?;
+            map.insert(k.clone(), val.to_string());
+        }
+        map
+    } else {
+        HashMap::new()
+    };
+
+    // Fix 3: build sandbox preamble accurately based on which backend will be used.
+    let using_noop = std::env::var("AMAEBI_SPAWN_SANDBOX").as_deref() == Ok("noop");
+    let mut context_lines = vec![
+        "[Sandbox Context]".to_string(),
+        if using_noop {
+            "You are running with a noop sandbox (no isolation); commands execute directly on the host.".to_string()
+        } else {
+            "You are running inside an isolated Docker sandbox.".to_string()
+        },
+        format!("- Working directory (read-write): {}", workspace.display()),
+    ];
+    for mount in &extra_mounts {
+        if let Some(path) = mount["path"].as_str() {
+            let readonly = mount["readonly"].as_bool().unwrap_or(false);
+            let mode = if readonly { "read-only" } else { "read-write" };
+            context_lines.push(format!("- Mount ({mode}): {path}"));
+        }
+    }
+    if !using_noop {
+        context_lines.push(
+            "- /tmp is isolated from the host; files written here do not persist across sessions"
+                .to_string(),
+        );
+        context_lines.push("- No outbound network access".to_string());
+    }
+    context_lines
+        .push("- Do not attempt to access paths outside the listed mounts above".to_string());
+    context_lines.push(String::new());
+    context_lines.push("Task:".to_string());
+    context_lines.push(task.to_string());
+    let full_task = context_lines.join("\n");
+
+    tracing::info!(task = %task, workspace = %workspace.display(), model = %model, "spawn_agent: starting child agent");
+
+    // Build the child sandbox.
+    let child_sandbox: Box<dyn Sandbox> =
+        if std::env::var("AMAEBI_SPAWN_SANDBOX").as_deref() == Ok("noop") {
+            Box::new(NoopSandbox)
+        } else {
+            let image = std::env::var("AMAEBI_SANDBOX_IMAGE")
+                .unwrap_or_else(|_| "amaebi-sandbox:bookworm-slim".to_string());
+            let docker = DockerSandbox::new(DockerSandboxConfig {
+                image,
+                workspace: workspace.clone(),
+                ro_paths,
+                rw_paths,
+                env,
+            });
+            if !docker.available() {
+                anyhow::bail!("Docker is not available; cannot spawn agent");
+            }
+            Box::new(docker)
+        };
+
+    // Child executor: no spawn_ctx (prevents unbounded recursion), and cwd
+    // defaults to the workspace so sandbox commands start in the right place.
+    let child_executor = LocalExecutor {
+        sandbox: Some(child_sandbox),
+        spawn_ctx: None,
+        default_cwd: Some(workspace.clone()),
+    };
+
+    // Build a minimal DaemonState for the child: reuse the parent's HTTP
+    // client, DB, compacting-sessions set, and shared token cache.  The child
+    // has no spawn_ctx so it cannot recursively spawn further agents.
+    let child_state = crate::daemon::DaemonState {
+        http: ctx.http.clone(),
+        tokens: Arc::clone(&ctx.tokens),
+        executor: Box::new(child_executor),
+        db: Arc::clone(&ctx.db),
+        compacting_sessions: Arc::clone(&ctx.compacting_sessions),
+    };
+
+    let messages = vec![
+        crate::copilot::Message::system(
+            "You are a child agent completing a specific task in an isolated sandbox. \
+             Use available tools to complete the task, then provide a concise summary \
+             of what you did and the outcome.",
+        ),
+        crate::copilot::Message::user(full_task),
+    ];
+
+    let mut sink = tokio::io::sink();
+    // Drop the sender immediately so the child loop treats the session as
+    // non-interactive (no steering, no question-asking).
+    let (_, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(1);
+
+    // Fix 5: child agents do not get spawn_agent in their tool schema to
+    // prevent unbounded recursion at the schema level.
+    let (final_text, _) = crate::daemon::run_agentic_loop(
+        &child_state,
+        &model,
+        messages,
+        &mut sink,
+        &mut steer_rx,
+        false,
+    )
+    .await?;
+
+    tracing::info!(result_len = %final_text.len(), "spawn_agent: child agent completed");
+    Ok(final_text)
+}
+
 /// Overwrite a file with new content.
 async fn edit_file(args: serde_json::Value) -> Result<String> {
     let path = args["path"]
@@ -205,9 +465,12 @@ async fn edit_file(args: serde_json::Value) -> Result<String> {
 // Tool schemas (OpenAI function-calling format)
 // ---------------------------------------------------------------------------
 
-/// Return the JSON schema array to include in every chat request.
-pub fn tool_schemas() -> Vec<serde_json::Value> {
-    vec![
+/// Return the JSON schema array to include in a chat request.
+///
+/// Pass `include_spawn_agent = true` for the parent (daemon) context.
+/// Pass `false` for child agent loops to prevent recursive spawning.
+pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
+    let mut schemas = vec![
         serde_json::json!({
             "type": "function",
             "function": {
@@ -307,7 +570,68 @@ pub fn tool_schemas() -> Vec<serde_json::Value> {
                 }
             }
         }),
-    ]
+    ];
+    if include_spawn_agent {
+        schemas.push(serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "spawn_agent",
+                "description": "Spawn a child agent session to complete a task. \
+                                The child runs in an isolated Docker sandbox \
+                                (--network none) with its own workspace.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "task": {
+                            "type": "string",
+                            "description": "The task for the child agent to complete."
+                        },
+                        "workspace": {
+                            "type": "string",
+                            "description": "Absolute path to the workspace directory \
+                                            (e.g. a git worktree). Will be bind-mounted rw."
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "LLM model to use (optional; defaults to the AMAEBI_MODEL \
+                                            environment variable, or gpt-4o if unset)."
+                        },
+                        "extra_mounts": {
+                            "type": "array",
+                            "description": "Additional directories to mount into the sandbox (optional). \
+                                            Each path must be absolute and exist on the host.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Absolute path on the host."
+                                    },
+                                    "readonly": {
+                                        "type": "boolean",
+                                        "description": "Mount as read-only (default: false)."
+                                    }
+                                },
+                                "required": ["path"]
+                            }
+                        },
+                        "env": {
+                            "type": "object",
+                            "description": "Environment variables to set inside the sandbox container (e.g. HTTP_PROXY).",
+                            "additionalProperties": { "type": "string" }
+                        },
+                        "parallel": {
+                            "type": "boolean",
+                            "description": "If true, this call may run concurrently with other spawn_agent calls \
+                                            in the same batch (default: false)."
+                        }
+                    },
+                    "required": ["task", "workspace"]
+                }
+            }
+        }));
+    }
+    schemas
 }
 
 // ---------------------------------------------------------------------------
@@ -317,13 +641,14 @@ pub fn tool_schemas() -> Vec<serde_json::Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::TempDir;
 
     // ---- tool_schemas ----------------------------------------------------
 
     #[test]
     fn tool_schemas_have_expected_names() {
-        let schemas = tool_schemas();
+        let schemas = tool_schemas(true);
         let names: Vec<&str> = schemas
             .iter()
             .map(|s| s["function"]["name"].as_str().unwrap())
@@ -334,6 +659,7 @@ mod tests {
             "tmux_send_keys",
             "read_file",
             "edit_file",
+            "spawn_agent",
         ] {
             assert!(names.contains(&name), "missing tool: {name}");
         }
@@ -341,7 +667,7 @@ mod tests {
 
     #[test]
     fn tool_schemas_all_have_type_function() {
-        for schema in tool_schemas() {
+        for schema in tool_schemas(true) {
             assert_eq!(
                 schema["type"].as_str().unwrap(),
                 "function",
@@ -353,13 +679,80 @@ mod tests {
 
     #[test]
     fn tool_schemas_all_have_parameters_with_required_array() {
-        for schema in tool_schemas() {
+        for schema in tool_schemas(true) {
             let name = schema["function"]["name"].as_str().unwrap();
             assert!(
                 schema["function"]["parameters"]["required"].is_array(),
                 "missing required array for {name}"
             );
         }
+    }
+
+    // ---- spawn_agent schema -------------------------------------------------
+
+    #[test]
+    fn spawn_agent_schema_has_extra_mounts() {
+        let schemas = tool_schemas(true);
+        let spawn = schemas
+            .iter()
+            .find(|s| s["function"]["name"].as_str() == Some("spawn_agent"))
+            .expect("spawn_agent schema missing");
+        let props = &spawn["function"]["parameters"]["properties"];
+        assert!(
+            props["extra_mounts"].is_object(),
+            "extra_mounts property missing from spawn_agent schema"
+        );
+        assert_eq!(
+            props["extra_mounts"]["type"].as_str(),
+            Some("array"),
+            "extra_mounts should be type array"
+        );
+        // items.required must include "path"
+        let required = &props["extra_mounts"]["items"]["required"];
+        assert!(
+            required
+                .as_array()
+                .is_some_and(|r| r.iter().any(|v| v.as_str() == Some("path"))),
+            "extra_mounts items must require 'path'"
+        );
+    }
+
+    #[test]
+    fn spawn_agent_schema_has_env() {
+        let schemas = tool_schemas(true);
+        let spawn = schemas
+            .iter()
+            .find(|s| s["function"]["name"].as_str() == Some("spawn_agent"))
+            .expect("spawn_agent schema missing");
+        let props = &spawn["function"]["parameters"]["properties"];
+        assert!(
+            props["env"].is_object(),
+            "env property missing from spawn_agent schema"
+        );
+        assert_eq!(
+            props["env"]["type"].as_str(),
+            Some("object"),
+            "env should be type object"
+        );
+        assert!(
+            props["env"]["additionalProperties"].is_object(),
+            "env should have additionalProperties"
+        );
+    }
+
+    #[test]
+    fn spawn_agent_schema_has_parallel() {
+        let schemas = tool_schemas(true);
+        let spawn = schemas
+            .iter()
+            .find(|s| s["function"]["name"].as_str() == Some("spawn_agent"))
+            .expect("spawn_agent schema missing");
+        let props = &spawn["function"]["parameters"]["properties"];
+        assert_eq!(
+            props["parallel"]["type"].as_str(),
+            Some("boolean"),
+            "parallel property should be type boolean in spawn_agent schema"
+        );
     }
 
     // ---- shell_command ---------------------------------------------------
@@ -494,6 +887,7 @@ mod tests {
     // ---- LocalExecutor::new env-var wiring ----------------------------------
 
     #[test]
+    #[serial]
     fn new_without_env_var_has_no_sandbox() {
         std::env::remove_var("AMAEBI_SANDBOX");
         let exec = LocalExecutor::new();
@@ -501,6 +895,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn new_with_docker_env_var_creates_docker_sandbox() {
         std::env::set_var("AMAEBI_SANDBOX", "docker");
         let exec = LocalExecutor::new();
@@ -510,6 +905,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn new_with_sandbox_workspace_env_var_uses_that_path() {
         std::env::set_var("AMAEBI_SANDBOX", "docker");
         std::env::set_var("AMAEBI_SANDBOX_WORKSPACE", "/tmp/my-worktree");
@@ -517,9 +913,15 @@ mod tests {
         std::env::remove_var("AMAEBI_SANDBOX");
         std::env::remove_var("AMAEBI_SANDBOX_WORKSPACE");
         assert!(exec.sandbox.is_some());
+        assert_eq!(
+            exec.default_cwd.as_deref(),
+            Some(std::path::Path::new("/tmp/my-worktree")),
+            "default_cwd should be set to AMAEBI_SANDBOX_WORKSPACE"
+        );
     }
 
     #[test]
+    #[serial]
     fn new_with_unknown_env_var_value_has_no_sandbox() {
         std::env::set_var("AMAEBI_SANDBOX", "unknown");
         let exec = LocalExecutor::new();
@@ -533,10 +935,122 @@ mod tests {
     async fn shell_command_with_noop_sandbox() {
         let exec = LocalExecutor {
             sandbox: Some(Box::new(crate::sandbox::NoopSandbox)),
+            spawn_ctx: None,
+            default_cwd: None,
         };
         let args = serde_json::json!({"command": "echo hello"});
         let result = exec.execute("shell_command", args).await.unwrap();
         assert!(result.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn shell_command_noop_sandbox_uses_default_cwd() {
+        let tmp = TempDir::new().unwrap();
+        let exec = LocalExecutor {
+            sandbox: Some(Box::new(crate::sandbox::NoopSandbox)),
+            spawn_ctx: None,
+            default_cwd: Some(tmp.path().to_path_buf()),
+        };
+        // pwd should print the default_cwd, not the daemon process cwd.
+        let result = exec
+            .execute("shell_command", serde_json::json!({"command": "pwd"}))
+            .await
+            .unwrap();
+        assert!(
+            result
+                .trim()
+                .ends_with(tmp.path().file_name().unwrap().to_str().unwrap()),
+            "expected cwd under tmp, got: {result}"
+        );
+    }
+
+    // ---- tool_schemas include/exclude spawn_agent -----------------------
+
+    #[test]
+    fn tool_schemas_false_excludes_spawn_agent() {
+        let schemas = tool_schemas(false);
+        let names: Vec<&str> = schemas
+            .iter()
+            .map(|s| s["function"]["name"].as_str().unwrap())
+            .collect();
+        assert!(
+            !names.contains(&"spawn_agent"),
+            "spawn_agent should be excluded when include_spawn_agent=false"
+        );
+        // Core tools must still be present.
+        for name in ["shell_command", "read_file", "edit_file"] {
+            assert!(names.contains(&name), "missing core tool: {name}");
+        }
+    }
+
+    #[test]
+    fn tool_schemas_true_includes_spawn_agent() {
+        let schemas = tool_schemas(true);
+        let names: Vec<&str> = schemas
+            .iter()
+            .map(|s| s["function"]["name"].as_str().unwrap())
+            .collect();
+        assert!(
+            names.contains(&"spawn_agent"),
+            "spawn_agent should be present when include_spawn_agent=true"
+        );
+    }
+
+    // ---- spawn_agent workspace validation --------------------------------
+
+    #[tokio::test]
+    #[serial]
+    async fn spawn_agent_rejects_relative_workspace() {
+        let ctx = make_spawn_ctx();
+        let result = spawn_agent(
+            serde_json::json!({"task": "t", "workspace": "relative/path"}),
+            &ctx,
+        )
+        .await;
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("absolute"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn spawn_agent_rejects_nonexistent_workspace() {
+        let ctx = make_spawn_ctx();
+        let result = spawn_agent(
+            serde_json::json!({"task": "t", "workspace": "/tmp/amaebi_test_nonexistent_xyz"}),
+            &ctx,
+        )
+        .await;
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("does not exist"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn spawn_agent_rejects_workspace_that_is_a_file() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("notadir.txt");
+        std::fs::write(&file, "x").unwrap();
+        let ctx = make_spawn_ctx();
+        let result = spawn_agent(
+            serde_json::json!({"task": "t", "workspace": file.to_str().unwrap()}),
+            &ctx,
+        )
+        .await;
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(msg.contains("not a directory"), "got: {msg}");
+    }
+
+    /// Helper: build a minimal SpawnContext suitable for unit tests.
+    fn make_spawn_ctx() -> SpawnContext {
+        SpawnContext {
+            http: reqwest::Client::new(),
+            db: Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap())),
+            compacting_sessions: Arc::new(Mutex::new(HashSet::new())),
+            tokens: Arc::new(crate::auth::TokenCache::new()),
+        }
     }
 
     // ---- unknown tool ---------------------------------------------------

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -6,7 +6,7 @@
 //! 3. Connects a client to the daemon socket.
 //! 4. Exercises the daemon and asserts on the responses / captured requests.
 //!
-//! ## Current tests (8 total)
+//! ## Current tests (18 total)
 //!
 //! 1. `test_basic_chat_roundtrip` — basic chat round-trip
 //! 2. `test_tool_call_roundtrip` — tool-call round-trip (shell echo)
@@ -16,13 +16,24 @@
 //! 6. `test_compaction_preserves_summary` — summary text appears in next turn's messages
 //! 7. `test_hot_tail_preserved_after_compaction` — message count bounded to hot tail after compaction
 //! 8. `test_pre_flight_trim_on_resume` — resume loads history; pre-flight trim fires at low threshold
+//! 9. `spawn_agent_runs_task` — parent spawns child agent; child runs echo; parent gets result
+//! 10. `spawn_agent_child_cannot_spawn` — child agent cannot recursively call spawn_agent
+//! 11. `spawn_agent_uses_specified_model` — child agent uses the model from spawn_agent args
+//! 12. `spawn_agent_missing_workspace_returns_error` — missing workspace arg yields tool error to parent
+//! 13. `spawn_agent_workspace_passed_to_sandbox` — workspace path appears in child agent's LLM context
+//! 14. `spawn_agent_parallel_calls` — two spawn_agent calls with parallel=true run concurrently
+//! 15. `spawn_agent_parallel_timing` — parallel=true batch completes in ~5s not ~10s (ignored)
+//! 16. `cron_job_triggers_llm_call` — scheduled cron job fires and calls the LLM with the task prompt
+//! 17. `cron_job_result_not_sent_to_chat` — cron output goes to inbox only, never to the chat stream
+//! 18. `cron_job_with_spawn_agent` — cron job can call spawn_agent; child runs and returns result
 
 mod support;
 
 use support::{
     helpers::{
-        collect_text, connect_client, send_message, send_message_with_session, send_resume,
-        start_daemon, start_daemon_at_home_with_env, start_daemon_with_env,
+        collect_text, connect_client, seed_cron_job, send_message, send_message_with_session,
+        send_resume, setup_home, start_daemon, start_daemon_at_home_with_env,
+        start_daemon_with_env,
     },
     mock_llm::{MockLlmServer, ScriptedResponse},
 };
@@ -653,4 +664,732 @@ async fn test_pre_flight_trim_on_resume() {
 
     let _ = child3.kill().await;
     let _ = child3.wait().await;
+}
+
+// ---------------------------------------------------------------------------
+// 9. spawn_agent tool — child agent runs a task in a sandbox
+// ---------------------------------------------------------------------------
+
+/// The parent agent calls `spawn_agent`.  The child agent uses `shell_command`
+/// to run `echo hello`, then the child loop ends.  The parent receives the
+/// child's result as the tool output and returns a final response.
+///
+/// Uses `AMAEBI_SPAWN_SANDBOX=noop` so no Docker is required.
+#[tokio::test]
+async fn spawn_agent_runs_task() {
+    let server = MockLlmServer::start().await;
+
+    // 1. Parent agent first turn: LLM asks to spawn a child agent.
+    server.enqueue(ScriptedResponse::tool_call(
+        "call-spawn-001",
+        "spawn_agent",
+        r#"{"task":"run echo hello","workspace":"/tmp"}"#,
+    ));
+    // 2. Child agent first turn: LLM asks to run shell_command.
+    server.enqueue(ScriptedResponse::tool_call(
+        "call-shell-001",
+        "shell_command",
+        r#"{"command":"echo hello"}"#,
+    ));
+    // 3. Child agent second turn (after tool result): LLM returns final text.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["hello"]));
+    // 4. Parent agent second turn (after spawn_agent result): final response.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["Task done: hello"]));
+
+    let daemon = start_daemon_with_env(&server.url(), &[("AMAEBI_SPAWN_SANDBOX", "noop")])
+        .await
+        .expect("start_daemon");
+    let client = connect_client(&daemon.socket);
+
+    let responses = send_message(&client, "run a child task")
+        .await
+        .expect("send_message");
+
+    let text = collect_text(&responses);
+    assert!(
+        text.contains("hello"),
+        "expected 'hello' in response: {text:?}"
+    );
+
+    // Mock should have served exactly 4 requests: 2 for parent, 2 for child.
+    let reqs = server.take_requests();
+    assert_eq!(reqs.len(), 4, "expected 4 LLM requests, got {}", reqs.len());
+}
+
+// ---------------------------------------------------------------------------
+// 10. spawn_agent recursion prevention
+// ---------------------------------------------------------------------------
+
+/// A child agent must NOT be able to call spawn_agent itself.
+///
+/// Scenario:
+///   1. Parent LLM → calls spawn_agent
+///   2. Child LLM → calls spawn_agent (recursion attempt)
+///   3. Child tool executor returns error immediately (no extra LLM call)
+///   4. Child sends tool_result (error) → LLM returns final text reporting error
+///   5. Parent receives child output → LLM returns final response
+///
+/// Uses `AMAEBI_SPAWN_SANDBOX=noop` so no Docker is required.
+#[tokio::test]
+async fn spawn_agent_child_cannot_spawn() {
+    let server = MockLlmServer::start().await;
+
+    // 1. Parent agent first turn: LLM asks to spawn a child agent.
+    server.enqueue(ScriptedResponse::tool_call(
+        "call-spawn-parent",
+        "spawn_agent",
+        r#"{"task":"try to spawn another agent","workspace":"/tmp"}"#,
+    ));
+    // 2. Child agent first turn: LLM asks to spawn_agent (recursion attempt).
+    server.enqueue(ScriptedResponse::tool_call(
+        "call-spawn-child",
+        "spawn_agent",
+        r#"{"task":"nested","workspace":"/tmp"}"#,
+    ));
+    // 3. Child agent second turn: after the tool error is fed back, LLM returns final text.
+    server.enqueue(ScriptedResponse::text_chunks(vec![
+        "Child got error: spawn_agent not available",
+    ]));
+    // 4. Parent agent second turn: after child result, LLM returns final text.
+    server.enqueue(ScriptedResponse::text_chunks(vec![
+        "Parent done. Child reported recursion error.",
+    ]));
+
+    let daemon = start_daemon_with_env(&server.url(), &[("AMAEBI_SPAWN_SANDBOX", "noop")])
+        .await
+        .expect("start_daemon");
+    let client = connect_client(&daemon.socket);
+
+    let responses = send_message(&client, "try to spawn recursively")
+        .await
+        .expect("send_message");
+
+    let text = collect_text(&responses);
+    assert!(
+        text.contains("Parent done."),
+        "expected parent final text in response: {text:?}"
+    );
+
+    // Verify the child received a spawn_agent error in its tool result by
+    // checking the LLM received exactly 4 requests (2 parent + 2 child).
+    let reqs = server.take_requests();
+    assert_eq!(
+        reqs.len(),
+        4,
+        "expected 4 LLM requests (2 parent + 2 child), got {}",
+        reqs.len()
+    );
+
+    // The child's second request (index 2) must contain a tool_result message
+    // whose content includes the "spawn_agent is not available" error.
+    let child_second_req = &reqs[2];
+    let messages = child_second_req
+        .messages()
+        .expect("messages in child second request");
+    let all_content: String = messages
+        .iter()
+        .filter_map(|m| m.get("content").and_then(|c| c.as_str()))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        all_content.contains("spawn_agent is not available"),
+        "expected spawn_agent error in child tool result, got:\n{all_content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 11. spawn_agent model selection
+// ---------------------------------------------------------------------------
+
+/// When spawn_agent is called with a "model" argument, the child agent must use
+/// that model for its LLM requests.
+///
+/// Flow:
+///   1. Parent turn 1 → calls spawn_agent with model:"custom-model-123"
+///   2. Child turn 1 (uses custom-model-123) → returns final text
+///   3. Parent turn 2 → returns final text
+///
+/// Uses `AMAEBI_SPAWN_SANDBOX=noop` so no Docker is required.
+#[tokio::test]
+async fn spawn_agent_uses_specified_model() {
+    let server = MockLlmServer::start().await;
+
+    // 1. Parent LLM turn 1: calls spawn_agent with a specific model override.
+    server.enqueue(ScriptedResponse::tool_call(
+        "call-spawn-model",
+        "spawn_agent",
+        r#"{"task":"simple task","workspace":"/tmp","model":"custom-model-123"}"#,
+    ));
+    // 2. Child LLM turn 1 (should use "custom-model-123"): returns final text.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["Child done."]));
+    // 3. Parent LLM turn 2 (after spawn_agent result): returns final text.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["Parent done."]));
+
+    let daemon = start_daemon_with_env(&server.url(), &[("AMAEBI_SPAWN_SANDBOX", "noop")])
+        .await
+        .expect("start_daemon");
+    let client = connect_client(&daemon.socket);
+
+    let responses = send_message(&client, "run child with custom model")
+        .await
+        .expect("send_message");
+
+    let text = collect_text(&responses);
+    assert!(
+        text.contains("Parent done."),
+        "expected parent final text in response: {text:?}"
+    );
+
+    // 3 requests: parent turn 1, child turn 1, parent turn 2.
+    let reqs = server.take_requests();
+    assert_eq!(reqs.len(), 3, "expected 3 LLM requests, got {}", reqs.len());
+
+    // The child's request (index 1) must use "custom-model-123".
+    let child_req = &reqs[1];
+    assert_eq!(
+        child_req.model(),
+        Some("custom-model-123"),
+        "child agent should use the model specified in spawn_agent args, got: {:?}",
+        child_req.model()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 12. spawn_agent missing workspace returns error
+// ---------------------------------------------------------------------------
+
+/// When spawn_agent is called without the required "workspace" field, the tool
+/// must return an error to the parent agent rather than crashing.
+///
+/// Flow:
+///   1. Parent turn 1 → calls spawn_agent with only "task" (no workspace)
+///   2. Daemon executes spawn_agent → immediate error (no child LLM calls)
+///   3. Parent turn 2 → receives the error as a tool result, returns final text
+///
+/// After the test, the mock server must have exactly 2 requests (both parent),
+/// and the second request's messages must mention "workspace".
+///
+/// Uses `AMAEBI_SPAWN_SANDBOX=noop` so no Docker is required.
+#[tokio::test]
+async fn spawn_agent_missing_workspace_returns_error() {
+    let server = MockLlmServer::start().await;
+
+    // 1. Parent LLM turn 1: calls spawn_agent without the workspace field.
+    server.enqueue(ScriptedResponse::tool_call(
+        "call-spawn-noworkspace",
+        "spawn_agent",
+        r#"{"task":"do something without workspace"}"#,
+    ));
+    // 2. Parent LLM turn 2: receives the tool error result, returns final text.
+    server.enqueue(ScriptedResponse::text_chunks(vec![
+        "Received an error from spawn_agent.",
+    ]));
+
+    let daemon = start_daemon_with_env(&server.url(), &[("AMAEBI_SPAWN_SANDBOX", "noop")])
+        .await
+        .expect("start_daemon");
+    let client = connect_client(&daemon.socket);
+
+    let responses = send_message(&client, "spawn agent without workspace")
+        .await
+        .expect("send_message");
+
+    let text = collect_text(&responses);
+    assert!(
+        text.contains("error"),
+        "expected error indication in response: {text:?}"
+    );
+
+    // Exactly 2 LLM requests: both to the parent (no child was spawned).
+    let reqs = server.take_requests();
+    assert_eq!(
+        reqs.len(),
+        2,
+        "expected exactly 2 LLM requests (no child spawned), got {}",
+        reqs.len()
+    );
+
+    // The second parent request must carry the spawn_agent error as a tool
+    // result; its content should mention "workspace" (the missing field).
+    let second_req = &reqs[1];
+    let messages = second_req.messages().expect("messages in second request");
+    let all_content: String = messages
+        .iter()
+        .filter_map(|m| m.get("content").and_then(|c| c.as_str()))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        all_content.contains("workspace"),
+        "error message should mention 'workspace', got:\n{all_content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 13. spawn_agent workspace path passed to child LLM context
+// ---------------------------------------------------------------------------
+
+/// The workspace path supplied in spawn_agent args must appear in the system
+/// prompt sent to the child agent's LLM (embedded in the "[Sandbox Context]"
+/// preamble that `spawn_agent` prepends to the task).
+///
+/// Flow:
+///   1. Parent turn 1 → calls spawn_agent with a real temp-dir path as workspace
+///   2. Child turn 1 → returns final text (mock; we only care about the request)
+///   3. Parent turn 2 → returns final text
+///
+/// Uses `AMAEBI_SPAWN_SANDBOX=noop` so no Docker is required.
+#[tokio::test]
+async fn spawn_agent_workspace_passed_to_sandbox() {
+    let workspace_dir = tempfile::TempDir::new().expect("temp workspace dir");
+    let workspace_path = workspace_dir
+        .path()
+        .to_str()
+        .expect("utf8 workspace path")
+        .to_string();
+
+    let server = MockLlmServer::start().await;
+
+    // Build the spawn_agent args with a real filesystem path.
+    let args_json = serde_json::json!({
+        "task": "verify workspace",
+        "workspace": workspace_path,
+    })
+    .to_string();
+
+    // 1. Parent LLM turn 1: calls spawn_agent with the workspace path.
+    server.enqueue(ScriptedResponse::tool_call(
+        "call-spawn-ws",
+        "spawn_agent",
+        args_json,
+    ));
+    // 2. Child LLM turn 1: returns final text.
+    server.enqueue(ScriptedResponse::text_chunks(vec![
+        "Child workspace verified.",
+    ]));
+    // 3. Parent LLM turn 2: returns final text.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["Workspace test done."]));
+
+    let daemon = start_daemon_with_env(&server.url(), &[("AMAEBI_SPAWN_SANDBOX", "noop")])
+        .await
+        .expect("start_daemon");
+    let client = connect_client(&daemon.socket);
+
+    let responses = send_message(&client, "check workspace passthrough")
+        .await
+        .expect("send_message");
+
+    let text = collect_text(&responses);
+    assert!(
+        text.contains("Workspace test done."),
+        "expected final text in response: {text:?}"
+    );
+
+    // 3 requests: parent turn 1, child turn 1, parent turn 2.
+    let reqs = server.take_requests();
+    assert_eq!(reqs.len(), 3, "expected 3 LLM requests, got {}", reqs.len());
+
+    // The child's request (index 1) must contain the workspace path in its
+    // messages — spawn_agent embeds it in the "[Sandbox Context]" preamble.
+    let child_req = &reqs[1];
+    let messages = child_req.messages().expect("messages in child request");
+    let all_content: String = messages
+        .iter()
+        .filter_map(|m| m.get("content").and_then(|c| c.as_str()))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        all_content.contains(&workspace_path),
+        "child LLM request should contain workspace path {workspace_path:?}, got:\n{all_content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 14. Two spawn_agent calls in one batch run concurrently
+// ---------------------------------------------------------------------------
+
+/// When the LLM returns two spawn_agent tool calls in a single response, the
+/// daemon must execute them concurrently rather than sequentially.
+///
+/// Each child runs `shell_command("sleep 1")` before returning its final text.
+/// If the children ran sequentially the wall-clock time would be ≥ 2 s; the
+/// assert of elapsed < 1.8 s proves they ran concurrently.
+///
+/// Mock LLM sequence (6 requests total):
+///   1. Parent turn 1  → multi_tool_calls: two spawn_agent with parallel=true
+///   2. Child 1 turn 1 → tool_call shell_command("sleep 1")
+///   3. Child 2 turn 1 → tool_call shell_command("sleep 1")
+///   4. Child 1 turn 2 → text "child1 done"
+///   5. Child 2 turn 2 → text "child2 done"
+///   6. Parent turn 2  → text "all done"
+///
+/// Uses `AMAEBI_SPAWN_SANDBOX=noop` so no Docker is required.
+#[tokio::test]
+async fn spawn_agent_parallel_calls() {
+    let server = MockLlmServer::start().await;
+
+    // 1. Parent turn 1: LLM returns two spawn_agent calls in one response.
+    server.enqueue(ScriptedResponse::multi_tool_calls([
+        (
+            "call-spawn-parallel-A",
+            "spawn_agent",
+            r#"{"task":"task A","workspace":"/tmp","parallel":true}"#,
+        ),
+        (
+            "call-spawn-parallel-B",
+            "spawn_agent",
+            r#"{"task":"task B","workspace":"/tmp","parallel":true}"#,
+        ),
+    ]));
+    // 2 & 3. First two child requests each get a shell_command that sleeps 1 s.
+    //        Order is non-deterministic; the mock queue serves them FIFO.
+    server.enqueue(ScriptedResponse::tool_call(
+        "sc-parallel-1",
+        "shell_command",
+        r#"{"command":"sleep 1"}"#,
+    ));
+    server.enqueue(ScriptedResponse::tool_call(
+        "sc-parallel-2",
+        "shell_command",
+        r#"{"command":"sleep 1"}"#,
+    ));
+    // 4 & 5. Final text for each child (order is non-deterministic).
+    server.enqueue(ScriptedResponse::text_chunks(vec!["child1 done"]));
+    server.enqueue(ScriptedResponse::text_chunks(vec!["child2 done"]));
+    // 6. Parent turn 2: receives both tool results, returns final text.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["all done"]));
+
+    let daemon = start_daemon_with_env(&server.url(), &[("AMAEBI_SPAWN_SANDBOX", "noop")])
+        .await
+        .expect("start_daemon");
+    let client = connect_client(&daemon.socket);
+
+    let start = std::time::Instant::now();
+    let responses = send_message(&client, "run two child tasks in parallel")
+        .await
+        .expect("send_message");
+    let elapsed = start.elapsed();
+
+    let text = collect_text(&responses);
+    assert!(
+        text.contains("all done"),
+        "expected parent final text 'all done' in response: {text:?}"
+    );
+
+    // Parallel execution: ~1 s wall-clock + overhead.  Sequential would be
+    // ≥ 2 s of sleep alone, so < 2.5 s proves concurrency.
+    assert!(
+        elapsed.as_millis() < 2500,
+        "expected parallel execution to finish in < 2.5 s, took {elapsed:?}"
+    );
+
+    // 6 LLM requests: 1 parent + 2×(shell_command + text) + 1 parent final.
+    let reqs = server.take_requests();
+    assert_eq!(reqs.len(), 6, "expected 6 LLM requests, got {}", reqs.len());
+
+    // The parent's final request must contain results from both children.
+    let parent_final_req = &reqs[5];
+    let last_messages = parent_final_req
+        .messages()
+        .expect("messages in parent final request");
+    let all_content: String = last_messages
+        .iter()
+        .filter_map(|m| m.get("content").and_then(|c| c.as_str()))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        all_content.contains("child1 done") || all_content.contains("child2 done"),
+        "parent final request should contain child tool results, got:\n{all_content}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 15. parallel=true batch completes in ~5s not ~10s
+// ---------------------------------------------------------------------------
+
+/// When the LLM returns two spawn_agent calls both with `parallel=true`, the
+/// daemon must run them concurrently.  Each child sleeps for 5 real seconds;
+/// the combined wall-clock time must be < 8 s (sequential would be 10 s+).
+///
+/// Mock LLM sequence (6 requests total):
+///   1. Parent turn 1  → multi_tool_calls: two spawn_agent with parallel=true
+///   2. Child X turn 1 → tool_call shell_command("sleep 5")
+///   3. Child Y turn 1 → tool_call shell_command("sleep 5")
+///   4. Child X turn 2 → text "child1 done"
+///   5. Child Y turn 2 → text "child2 done"
+///   6. Parent turn 2  → text "both done"
+///
+/// Uses `AMAEBI_SPAWN_SANDBOX=noop` so no Docker is required.
+#[tokio::test]
+#[ignore] // takes ~5 real seconds
+async fn spawn_agent_parallel_timing() {
+    let server = MockLlmServer::start().await;
+
+    // 1. Parent turn 1: two spawn_agent calls, both opt-in to parallel.
+    server.enqueue(ScriptedResponse::multi_tool_calls([
+        (
+            "call-timing-A",
+            "spawn_agent",
+            r#"{"task":"sleep task A","workspace":"/tmp","parallel":true}"#,
+        ),
+        (
+            "call-timing-B",
+            "spawn_agent",
+            r#"{"task":"sleep task B","workspace":"/tmp","parallel":true}"#,
+        ),
+    ]));
+    // 2 & 3. First two child requests (whichever child arrives first): each
+    //        gets a shell_command that sleeps 5 seconds.
+    server.enqueue(ScriptedResponse::tool_call(
+        "sc-timing-1",
+        "shell_command",
+        r#"{"command":"sleep 5"}"#,
+    ));
+    server.enqueue(ScriptedResponse::tool_call(
+        "sc-timing-2",
+        "shell_command",
+        r#"{"command":"sleep 5"}"#,
+    ));
+    // 4 & 5. Final text for each child (order is non-deterministic).
+    server.enqueue(ScriptedResponse::text_chunks(vec!["child1 done"]));
+    server.enqueue(ScriptedResponse::text_chunks(vec!["child2 done"]));
+    // 6. Parent turn 2: both results received.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["both done"]));
+
+    let daemon = start_daemon_with_env(&server.url(), &[("AMAEBI_SPAWN_SANDBOX", "noop")])
+        .await
+        .expect("start_daemon");
+    let client = connect_client(&daemon.socket);
+
+    let start = std::time::Instant::now();
+    let responses = send_message(&client, "run two sleep tasks in parallel")
+        .await
+        .expect("send_message");
+    let elapsed = start.elapsed();
+
+    // Both children must have returned results visible in the parent's reply.
+    let text = collect_text(&responses);
+    assert!(
+        text.contains("both done"),
+        "expected parent final text 'both done', got: {text:?}"
+    );
+
+    // Parallel execution: ~5 s wall-clock.  Sequential would be ~10 s.
+    assert!(
+        elapsed.as_secs() < 8,
+        "expected parallel execution to finish in < 8 s, took {elapsed:?}"
+    );
+
+    // 6 LLM requests: 1 parent + 2×(shell_command + text) + 1 parent final.
+    let reqs = server.take_requests();
+    assert_eq!(reqs.len(), 6, "expected 6 LLM requests, got {}", reqs.len());
+}
+
+// ---------------------------------------------------------------------------
+// 16. Cron: job fires and calls the LLM
+// ---------------------------------------------------------------------------
+
+/// A scheduled cron job with schedule "* * * * *" must fire on the daemon's
+/// first scheduler tick (which is immediate — tokio intervals fire at t=0) and
+/// call the LLM with the job's description as the user prompt.
+///
+/// Strategy:
+/// 1. Create a temp home dir with `.amaebi/hosts.json`.
+/// 2. Seed a cron job via `amaebi cron add` before starting the daemon.
+/// 3. Start the daemon at that home directory.
+/// 4. The cron scheduler fires immediately; wait up to 5 s for the LLM call.
+/// 5. Assert the LLM received a request containing the cron task description.
+#[tokio::test]
+async fn cron_job_triggers_llm_call() {
+    let server = MockLlmServer::start().await;
+    server.enqueue(ScriptedResponse::text_chunks(vec!["cron-task-response"]));
+
+    // Set up a home dir and seed a cron job that always fires ("* * * * *").
+    let home_dir = setup_home().expect("setup_home");
+    seed_cron_job(home_dir.path(), "cron-unique-task-description", "* * * * *")
+        .await
+        .expect("seed_cron_job");
+
+    let (socket, mut child, _socket_dir) =
+        start_daemon_at_home_with_env(home_dir.path(), &server.url(), &[])
+            .await
+            .expect("start daemon");
+
+    // The cron scheduler fires its first tick immediately (tokio interval
+    // behaviour).  Wait up to 5 s for the LLM request to arrive.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        if server.peek_request_count() >= 1 || std::time::Instant::now() > deadline {
+            break;
+        }
+    }
+
+    let reqs = server.take_requests();
+    assert!(
+        !reqs.is_empty(),
+        "cron scheduler did not call the LLM within 5 s"
+    );
+
+    // The request's messages must contain the cron job description.
+    let messages = reqs[0].messages().expect("messages in cron LLM request");
+    let all_content: String = messages
+        .iter()
+        .filter_map(|m| m.get("content").and_then(|c| c.as_str()))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        all_content.contains("cron-unique-task-description"),
+        "expected cron task description in LLM request messages, got:\n{all_content}"
+    );
+
+    // Keep socket alive until assertions are done.
+    drop(socket);
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
+
+// ---------------------------------------------------------------------------
+// 17. Cron: output does NOT appear in the chat stream
+// ---------------------------------------------------------------------------
+
+/// Cron jobs run with a sink writer — their output is deposited into the inbox
+/// and must NOT appear when a user sends a normal chat message on the same
+/// daemon.
+///
+/// Strategy:
+/// 1. Seed a cron job; start the daemon.
+/// 2. Wait for the cron scheduler to fire and complete.
+/// 3. Send a chat message.
+/// 4. Assert the chat response does NOT contain the cron's unique output.
+///
+/// Note: when the chat session starts with empty history, the Chat handler
+/// spawns a background cross-session compaction for the cron's just-completed
+/// session.  That task also calls the LLM, so we over-provision the mock queue
+/// (3 extra "ok" responses beyond the cron response) to prevent 500 errors.
+#[tokio::test]
+async fn cron_job_result_not_sent_to_chat() {
+    const CRON_OUTPUT: &str = "super-unique-cron-only-output-xyz987";
+
+    let server = MockLlmServer::start().await;
+    // Response 1: for the cron job's LLM call.
+    server.enqueue(ScriptedResponse::text_chunks(vec![CRON_OUTPUT]));
+    // Responses 2-4: for the cross-session compaction background task and the
+    // chat's own LLM call.  All say "ok" — we only care that they are NOT
+    // CRON_OUTPUT.  Over-provisioning by 1 prevents any accidental 500 errors.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["ok"]));
+    server.enqueue(ScriptedResponse::text_chunks(vec!["ok"]));
+    server.enqueue(ScriptedResponse::text_chunks(vec!["ok"]));
+
+    let home_dir = setup_home().expect("setup_home");
+    seed_cron_job(home_dir.path(), "background cron task", "* * * * *")
+        .await
+        .expect("seed_cron_job");
+
+    let (socket, mut child, _socket_dir) =
+        start_daemon_at_home_with_env(home_dir.path(), &server.url(), &[])
+            .await
+            .expect("start daemon");
+
+    // Wait for the cron job to call the LLM (up to 5 s).
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        if server.peek_request_count() >= 1 || std::time::Instant::now() > deadline {
+            break;
+        }
+    }
+    assert!(
+        server.peek_request_count() >= 1,
+        "cron job did not fire within 5 s"
+    );
+    // Give the cron job a moment to finish (store_conversation, InboxStore, etc.).
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    // Send a chat message; the cron output went to a sink, never to this stream.
+    let client = connect_client(&socket);
+    let responses = send_message(&client, "hello from chat")
+        .await
+        .expect("chat message");
+
+    let text = collect_text(&responses);
+    // The cron-specific output must NOT appear in the chat stream.
+    assert!(
+        !text.contains(CRON_OUTPUT),
+        "cron output must NOT appear in chat stream, got: {text:?}"
+    );
+    // The chat must have completed successfully (no Error frame).
+    assert!(
+        !responses
+            .iter()
+            .any(|r| matches!(r, support::helpers::Response::Error { .. })),
+        "chat request must not fail: {responses:?}"
+    );
+
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
+
+// ---------------------------------------------------------------------------
+// 18. Cron: job can call spawn_agent
+// ---------------------------------------------------------------------------
+
+/// A cron job runs inside the full agentic loop with `include_spawn_agent=true`,
+/// so it can call `spawn_agent`.  This test verifies the end-to-end flow:
+///   cron turn 1 → spawn_agent tool call
+///   child turn 1 → final text
+///   cron turn 2 → final text (after receiving child result)
+///
+/// Uses `AMAEBI_SPAWN_SANDBOX=noop` so no Docker is required.
+#[tokio::test]
+async fn cron_job_with_spawn_agent() {
+    let server = MockLlmServer::start().await;
+
+    // Cron LLM turn 1: calls spawn_agent.
+    server.enqueue(ScriptedResponse::tool_call(
+        "cron-spawn-call-001",
+        "spawn_agent",
+        r#"{"task":"child task from cron","workspace":"/tmp"}"#,
+    ));
+    // Child agent LLM turn 1: returns final text.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["child-cron-result"]));
+    // Cron LLM turn 2 (after spawn_agent tool result): final cron text.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["cron-spawn-done"]));
+
+    let home_dir = setup_home().expect("setup_home");
+    seed_cron_job(
+        home_dir.path(),
+        "cron task that spawns a child agent",
+        "* * * * *",
+    )
+    .await
+    .expect("seed_cron_job");
+
+    let (_socket, mut child, _socket_dir) = start_daemon_at_home_with_env(
+        home_dir.path(),
+        &server.url(),
+        &[("AMAEBI_SPAWN_SANDBOX", "noop")],
+    )
+    .await
+    .expect("start daemon");
+
+    // Wait for all 3 LLM requests: cron turn 1 + child turn 1 + cron turn 2.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        if server.peek_request_count() >= 3 || std::time::Instant::now() > deadline {
+            break;
+        }
+    }
+
+    let reqs = server.take_requests();
+    assert_eq!(
+        reqs.len(),
+        3,
+        "expected 3 LLM requests (cron + child + cron final), got {}:\n{:#?}",
+        reqs.len(),
+        reqs.iter().map(|r| &r.body).collect::<Vec<_>>()
+    );
+
+    let _ = child.kill().await;
+    let _ = child.wait().await;
 }

--- a/tests/support/helpers.rs
+++ b/tests/support/helpers.rs
@@ -278,6 +278,51 @@ fn find_amaebi_binary() -> Result<PathBuf> {
 }
 
 // ---------------------------------------------------------------------------
+// Cron helpers
+// ---------------------------------------------------------------------------
+
+/// Create a fresh home directory with `.amaebi/hosts.json` pre-populated.
+///
+/// Use this when you need to pre-seed a cron job (or other amaebi state)
+/// before starting the daemon.
+pub fn setup_home() -> Result<TempDir> {
+    let home_dir = TempDir::new().context("creating temp HOME")?;
+    let amaebi_dir = home_dir.path().join(".amaebi");
+    std::fs::create_dir_all(&amaebi_dir).context("creating .amaebi dir")?;
+    std::fs::write(
+        amaebi_dir.join("hosts.json"),
+        r#"{"github.com": {"oauth_token": "test-oauth-token", "user": "test-user"}}"#,
+    )
+    .context("writing dummy hosts.json")?;
+    Ok(home_dir)
+}
+
+/// Seed a cron job into `<home_path>/.amaebi/cron.db` using the amaebi CLI.
+///
+/// `HOME` is set to `home_path` so the cron.db lands in the right place.
+/// No auth tokens are needed — `cron add` is a pure SQLite write.
+pub async fn seed_cron_job(home_path: &Path, description: &str, schedule: &str) -> Result<()> {
+    let exe = find_amaebi_binary()?;
+    let output = Command::new(&exe)
+        .arg("cron")
+        .arg("add")
+        .arg(description)
+        .arg("--cron")
+        .arg(schedule)
+        .env("HOME", home_path)
+        .output()
+        .await
+        .context("running amaebi cron add")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "amaebi cron add failed (exit {}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Client helpers
 // ---------------------------------------------------------------------------
 

--- a/tests/support/mock_llm.rs
+++ b/tests/support/mock_llm.rs
@@ -115,6 +115,41 @@ impl ScriptedResponse {
             ],
         }
     }
+
+    /// Create a response that returns multiple tool calls then stops.
+    ///
+    /// Each item in `calls` is `(id, name, arguments_json)`.
+    pub fn multi_tool_calls<I, S1, S2, S3>(calls: I) -> Self
+    where
+        I: IntoIterator<Item = (S1, S2, S3)>,
+        S1: Into<String>,
+        S2: Into<String>,
+        S3: Into<String>,
+    {
+        let mut chunks: Vec<(Chunk, Option<Duration>)> = Vec::new();
+        for (index, (id, name, args)) in calls.into_iter().enumerate() {
+            chunks.push((
+                Chunk::ToolCallDelta {
+                    index,
+                    id: Some(id.into()),
+                    function_name: Some(name.into()),
+                    arguments_fragment: String::new(),
+                },
+                None,
+            ));
+            chunks.push((
+                Chunk::ToolCallDelta {
+                    index,
+                    id: None,
+                    function_name: None,
+                    arguments_fragment: args.into(),
+                },
+                None,
+            ));
+        }
+        chunks.push((Chunk::Finish(FinishReason::ToolCalls), None));
+        Self { chunks }
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements Issue #20 (Phase 2): add `spawn_agent` so a parent agent can spawn child agents safely.

## What’s included
- New `spawn_agent` tool (`task`, `workspace`, optional `model`, `extra_mounts`, `env`, `parallel`)
- Child agents run in sandboxed execution context
- Recursion prevention (`spawn_agent` not advertised/allowed in child)
- Opt-in parallel spawning (`parallel: true`)
- Cron regression tests + spawn-agent regression coverage
- Parallel timing test (`#[ignore]`) to validate true concurrency behavior
- `scripts/dev.sh` helper for worktree + coder workflow
- `scripts/test.sh` logging improvements

## Key behavior
- `workspace` must be absolute, exist, and be a directory
- `extra_mounts` paths must be absolute + exist
- `env` values must be strings
- Model fallback is explicit/documented
- Token cache is shared from parent context

## Validation
- `scripts/test.sh` passes locally
- CI passes on PR branch

Closes #20
