### PR TITLE
fix: bypass HTTP proxy for mock server in integration tests

### DIFF
--- a/tests/support/helpers.rs
+++ b/tests/support/helpers.rs
@@ -117,6 +117,10 @@ pub async fn start_daemon_with_env(
         .env("AMAEBI_COPILOT_URL", mock_url)
         .env("AMAEBI_COPILOT_TOKEN", "test-api-token")
         .env("RUST_LOG", "error")
+        // Bypass any corporate/system HTTP proxy for localhost so that the
+        // daemon's reqwest client connects directly to the mock server.
+        .env("no_proxy", "127.0.0.1,localhost")
+        .env("NO_PROXY", "127.0.0.1,localhost")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped());
@@ -194,6 +198,9 @@ pub async fn start_daemon(mock_url: &str) -> Result<DaemonHandle> {
         .env("AMAEBI_COPILOT_URL", mock_url)
         .env("AMAEBI_COPILOT_TOKEN", "test-api-token")
         .env("RUST_LOG", "error")
+        // Bypass any corporate/system HTTP proxy for localhost.
+        .env("no_proxy", "127.0.0.1,localhost")
+        .env("NO_PROXY", "127.0.0.1,localhost")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -243,6 +250,9 @@ pub async fn start_daemon_at_home_with_env(
         .env("AMAEBI_COPILOT_URL", mock_url)
         .env("AMAEBI_COPILOT_TOKEN", "test-api-token")
         .env("RUST_LOG", "error")
+        // Bypass any corporate/system HTTP proxy for localhost.
+        .env("no_proxy", "127.0.0.1,localhost")
+        .env("NO_PROXY", "127.0.0.1,localhost")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());

--- a/tests/support/mock_llm.rs
+++ b/tests/support/mock_llm.rs
@@ -505,7 +505,9 @@ mod tests {
         let server = MockLlmServer::start().await;
         server.enqueue(ScriptedResponse::text_chunks(vec!["hello"]));
 
-        let client = reqwest::Client::new();
+        // Use no_proxy() so the client connects directly to the local mock
+        // server even when an HTTP proxy is configured in the environment.
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
         let resp = client
             .post(server.url())
             .json(&json!({
@@ -530,7 +532,7 @@ mod tests {
         let server = MockLlmServer::start().await;
         server.enqueue(ScriptedResponse::text_chunks(vec!["ok"]));
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
         client
             .post(server.url())
             .json(&json!({


### PR DESCRIPTION
## Summary

- All 19 non-ignored integration tests and `spawn_agent_parallel_timing` were silently failing because `http_proxy` is set in the build environment and `reqwest::Client::new()` routes **all** HTTP requests (including `127.0.0.1`) through it.
- The corporate proxy either blocked the request or forwarded it to the real Copilot API, which returned 403. The mock server received zero requests.

**Two-line fix:**

1. `tests/support/helpers.rs` — all three `start_daemon*` helpers set `no_proxy=127.0.0.1,localhost` in the daemon process env so its reqwest client bypasses the proxy.
2. `tests/support/mock_llm.rs` — self-tests use `reqwest::Client::builder().no_proxy().build()` for the same reason.

## Test plan

- [x] 19/19 non-ignored integration tests: pass
- [x] `spawn_agent_parallel_timing` (`--ignored`, ~5.5 s): pass
- [x] 232 unit tests: pass
- [x] `cargo fmt --check`: clean
- [x] `cargo clippy -- -D warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)