### PR TITLE
fix: surface on-demand doc paths from AGENTS.md

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1733,6 +1733,7 @@ pub(crate) async fn inject_skill_files(messages: &mut Vec<Message>) {
 
 /// Internal helper used by [`inject_skill_files`] and tests.
 async fn inject_skill_files_from(messages: &mut Vec<Message>, amaebi_home: &std::path::Path) {
+    // Always-injected files: loaded unconditionally at the start of every turn.
     const FIXED_FILES: &[(&str, &str)] =
         &[("AGENTS.md", "## Agent Guidelines"), ("SOUL.md", "## Soul")];
     for (filename, header) in FIXED_FILES {
@@ -1749,6 +1750,42 @@ async fn inject_skill_files_from(messages: &mut Vec<Message>, amaebi_home: &std:
                 tracing::debug!(file = %path.display(), error = %e, "could not read config file");
             }
         }
+    }
+
+    // On-demand operations docs: not preloaded, but the agent needs absolute paths
+    // to use the read_file tool.  Inject a single pointer message listing whichever
+    // files are present so the agent can load them when the task requires it.
+    const ONDEMAND_FILES: &[&str] = &[
+        "OPERATIONS_INDEX.md",
+        "DEPLOYMENT.md",
+        "CONFIG_REFERENCE.md",
+        "RUNBOOK.md",
+    ];
+    let mut available: Vec<String> = Vec::new();
+    for filename in ONDEMAND_FILES {
+        let path = amaebi_home.join(filename);
+        match tokio::fs::metadata(&path).await {
+            Ok(meta) if meta.is_file() => available.push(path.display().to_string()),
+            Ok(_) => {
+                tracing::debug!(file = %path.display(), "on-demand path exists but is not a regular file; skipping");
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                tracing::debug!(file = %path.display(), error = %e, "could not stat on-demand file");
+            }
+        }
+    }
+    if !available.is_empty() {
+        let list = available
+            .iter()
+            .map(|p| format!("- {p}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        messages.push(Message::system(format!(
+            "## On-demand Operations Docs\n\n\
+             The following files can be loaded with read_file when the task involves \
+             deployment, configuration, or troubleshooting:\n\n{list}"
+        )));
     }
 }
 
@@ -2185,6 +2222,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn skill_files_dev_workflow_not_a_fixed_file() {
+        // DEV_WORKFLOW.md is intentionally NOT a fixed file — only AGENTS.md
+        // and SOUL.md are auto-injected.  A lone DEV_WORKFLOW.md must not
+        // produce any messages.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("DEV_WORKFLOW.md"), "workflow rules").unwrap();
+        let mut messages: Vec<Message> = vec![];
+        inject_skill_files_from(&mut messages, dir.path()).await;
+        assert!(
+            messages.is_empty(),
+            "DEV_WORKFLOW.md must not be auto-injected as a fixed file"
+        );
+    }
+
+    #[tokio::test]
     async fn skill_files_absent_produces_no_messages() {
         let dir = tempfile::TempDir::new().unwrap();
         let mut messages: Vec<Message> = vec![];
@@ -2216,6 +2268,40 @@ mod tests {
             .as_deref()
             .unwrap_or("")
             .contains("soul only"));
+    }
+
+    #[tokio::test]
+    async fn skill_files_ondemand_paths_injected_when_present() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("OPERATIONS_INDEX.md"), "ops index").unwrap();
+        std::fs::write(dir.path().join("DEPLOYMENT.md"), "deploy steps").unwrap();
+        let mut messages: Vec<Message> = vec![];
+        inject_skill_files_from(&mut messages, dir.path()).await;
+        assert_eq!(messages.len(), 1, "one on-demand pointer message expected");
+        let body = messages[0].content.as_deref().unwrap_or("");
+        assert!(body.contains("## On-demand Operations Docs"));
+        assert!(body.contains("OPERATIONS_INDEX.md"));
+        assert!(body.contains("DEPLOYMENT.md"));
+        assert!(body.contains("read_file"));
+    }
+
+    #[tokio::test]
+    async fn skill_files_ondemand_absent_produces_no_pointer_message() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Only a non-on-demand file present — no pointer message expected.
+        std::fs::write(dir.path().join("AGENTS.md"), "guidelines").unwrap();
+        let mut messages: Vec<Message> = vec![];
+        inject_skill_files_from(&mut messages, dir.path()).await;
+        let has_ondemand = messages.iter().any(|m| {
+            m.content
+                .as_deref()
+                .unwrap_or("")
+                .contains("On-demand Operations Docs")
+        });
+        assert!(
+            !has_ondemand,
+            "no on-demand pointer message when files absent"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **On-demand operations docs** (`OPERATIONS_INDEX.md`, `DEPLOYMENT.md`, `CONFIG_REFERENCE.md`, `RUNBOOK.md`) are now surfaced by absolute path in a single `## On-demand Operations Docs` system message when present in `~/.amaebi/`, so the agent can issue a targeted `read_file` call instead of guessing bare filenames.
- Fixed files remain **`AGENTS.md`** and **`SOUL.md`** only — `DEV_WORKFLOW.md` is not auto-injected.

## Regression tests added

Three new `#[tokio::test]` unit tests in `daemon::tests`:

| Test | What it covers |
|------|---------------|
| `skill_files_dev_workflow_not_a_fixed_file` | `DEV_WORKFLOW.md` alone produces no injected messages (not a fixed file) |
| `skill_files_ondemand_paths_injected_when_present` | On-demand docs get absolute-path pointer message with `read_file` hint |
| `skill_files_ondemand_absent_produces_no_pointer_message` | No spurious message when no on-demand files exist |

These tests were originally written in the `chore/portable-dev-image` work session but the commit was never pushed to a branch; this PR brings them to master.

## Test plan

- [x] `cargo test -- --include-ignored` on host — 24/24 pass (all including Docker sandbox tests)
- [x] `cargo test` in `amaebi-dev` container — 23/23 pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)