### PR TITLE
fix: remove --rm from docker run to fix race in test.sh

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -75,7 +75,11 @@ fi
 # for a local dev-test runner.
 echo "    image:   $DEV_IMAGE"
 echo "    workdir: $WORKDIR"
-CONTAINER_ID=$(docker run --rm -d \
+# Omit --rm so the container is not auto-deleted before `docker wait` reads
+# its exit code.  With --rm, the container is removed the instant it exits,
+# creating a race where `docker wait` (and sometimes `docker logs -f`) can
+# no longer find it.  The explicit `docker rm` below does the cleanup.
+CONTAINER_ID=$(docker run -d \
     -w "$WORKDIR" \
     --user 0:0 \
     -v "$REPO_ROOT:$REPO_ROOT:rw" \


### PR DESCRIPTION
## Problem

`scripts/test.sh` runs the test container with `--rm -d`. The `--rm` flag tells Docker to delete the container the instant it exits. On fast machines with a warm cargo cache the container can finish and be deleted before `docker logs -f` or `docker wait` can connect to it, producing:

```
Error response from daemon: can not get logs from container which is dead or marked for removal
```

This made `test.sh` appear to fail even when all tests actually passed.

## Fix

Remove `--rm` from `docker run`. The container now persists until the explicit `docker rm "$CONTAINER_ID"` on the next line cleans it up — after `docker wait` has already read the exit code.

```diff
-CONTAINER_ID=$(docker run --rm -d \
+CONTAINER_ID=$(docker run -d \
```

## Verification

Running `./scripts/test.sh` no longer produces the "dead or marked for removal" error. `docker logs -f` streams all cargo output correctly and `docker wait` always finds a valid container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)