### PR TITLE
feat: amaebi chat — persistent interactive REPL

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,25 @@ pub enum Command {
         #[arg(long, conflicts_with = "detach")]
         resume: Option<String>,
     },
+    /// Start an interactive multi-turn chat session.
+    ///
+    /// Sends the optional initial prompt, streams the reply, then keeps the
+    /// session alive: after each response a `>` prompt is shown so you can
+    /// type the next message without re-invoking `amaebi ask`.  Full turn
+    /// history is preserved across turns (consistent chat).
+    ///
+    /// Type an empty line or press Ctrl-D to exit.
+    Chat {
+        /// Optional opening message.  If omitted, the session starts empty
+        /// and you are immediately shown the `>` prompt.
+        prompt: Option<String>,
+        /// Path to the Unix socket.
+        #[arg(long, default_value = DEFAULT_SOCKET)]
+        socket: PathBuf,
+        /// Model to use (overrides AMAEBI_MODEL env var; default: gpt-4o).
+        #[arg(long)]
+        model: Option<String>,
+    },
     /// Authenticate with GitHub Copilot via the device flow.
     Auth {
         /// GitHub OAuth App client ID (defaults to the public neovim copilot.vim ID).

--- a/src/client.rs
+++ b/src/client.rs
@@ -299,6 +299,153 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
 }
 
 // ---------------------------------------------------------------------------
+// Interactive chat REPL
+// ---------------------------------------------------------------------------
+
+/// Run a persistent multi-turn chat session.
+///
+/// Sends `initial_prompt` (if provided), streams the response, then keeps
+/// the session alive: after each `Done` frame a `> ` cursor is shown so the
+/// user can type the next message.  The session ends on Ctrl-D (EOF) or a
+/// blank line.
+///
+/// Every turn reuses the same `session_id` so the daemon's `session_turns`
+/// table accumulates the full conversation; the model always receives the
+/// complete history.
+pub async fn run_chat_loop(
+    socket: PathBuf,
+    initial_prompt: Option<String>,
+    model: Option<String>,
+) -> Result<()> {
+    let model = model
+        .or_else(|| std::env::var("AMAEBI_MODEL").ok())
+        .unwrap_or_else(|| "gpt-4o".to_string());
+
+    let cwd = std::env::current_dir().context("getting current directory")?;
+    let session_id = tokio::task::spawn_blocking(move || session::get_or_create(&cwd))
+        .await
+        .context("session::get_or_create panicked")?
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to resolve session id; using \"global\"");
+            "global".to_string()
+        });
+
+    let mut stdout = tokio::io::stdout();
+    let mut stderr = tokio::io::stderr();
+
+    if std::io::stderr().is_terminal() {
+        let _ = stderr
+            .write_all(
+                format!(
+                    "Chat session started. ID: {session_id}\nCtrl-D or empty line to exit.\n\n"
+                )
+                .as_bytes(),
+            )
+            .await;
+        let _ = stderr.flush().await;
+    }
+
+    // The first prompt comes from the CLI argument; subsequent ones from stdin.
+    let mut next_prompt: Option<String> = initial_prompt;
+
+    loop {
+        // If no prompt queued, read one from stdin.
+        let prompt = match next_prompt.take() {
+            Some(p) => p,
+            None => {
+                if std::io::stderr().is_terminal() {
+                    let _ = stderr.write_all(b"> ").await;
+                    let _ = stderr.flush().await;
+                }
+                let mut line = String::new();
+                let n = tokio::io::AsyncBufReadExt::read_line(
+                    &mut BufReader::new(tokio::io::stdin()),
+                    &mut line,
+                )
+                .await
+                .unwrap_or(0);
+                if n == 0 {
+                    // EOF (Ctrl-D)
+                    break;
+                }
+                let trimmed = line
+                    .trim_end_matches('\n')
+                    .trim_end_matches('\r')
+                    .to_owned();
+                if trimmed.is_empty() {
+                    break;
+                }
+                trimmed
+            }
+        };
+
+        // Send a single Chat turn and stream the response.
+        let stream = connect_or_start_daemon(&socket).await?;
+        let (reader, mut writer) = tokio::io::split(stream);
+        let req = Request::Chat {
+            prompt,
+            tmux_pane: std::env::var("TMUX_PANE").ok(),
+            session_id: Some(session_id.clone()),
+            model: model.clone(),
+        };
+        let mut req_line = serde_json::to_string(&req).context("serializing request")?;
+        req_line.push('\n');
+        writer
+            .write_all(req_line.as_bytes())
+            .await
+            .context("sending request")?;
+
+        let mut lines = BufReader::new(reader).lines();
+        loop {
+            let line = match lines.next_line().await.context("reading response")? {
+                Some(l) => l,
+                None => break,
+            };
+            let resp: Response = serde_json::from_str(&line).context("parsing response")?;
+            match resp {
+                Response::Text { chunk } => {
+                    stdout.write_all(chunk.as_bytes()).await?;
+                    stdout.flush().await?;
+                }
+                Response::Done => {
+                    stdout.write_all(b"\n").await?;
+                    break;
+                }
+                Response::Error { message } => {
+                    anyhow::bail!("{message}");
+                }
+                Response::ToolUse { name, detail } => {
+                    if std::io::stderr().is_terminal() {
+                        match name.as_str() {
+                            "shell_command" => eprintln!("```bash\n$ {detail}\n```"),
+                            "read_file" => eprintln!("📄 {detail}"),
+                            "edit_file" => eprintln!("✏️  {detail}"),
+                            _ => eprintln!("🔧 {name}: {detail}"),
+                        }
+                    }
+                }
+                Response::WaitingForInput { .. } => {
+                    // The model asked a question; the next REPL iteration will read the reply.
+                    stdout.write_all(b"\n").await?;
+                    break;
+                }
+                Response::Compacting => {
+                    if std::io::stderr().is_terminal() {
+                        eprintln!("\n[compacting…]");
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if std::io::stderr().is_terminal() {
+        eprintln!("\nSession ended. ID: {session_id}");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Detach mode
 // ---------------------------------------------------------------------------
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ async fn main() -> Result<()> {
     if matches!(
         &cli.command,
         cli::Command::Ask { .. }
+            | cli::Command::Chat { .. }
             | cli::Command::Session { .. }
             | cli::Command::Memory { .. }
             | cli::Command::Cache { .. }
@@ -79,6 +80,11 @@ async fn main() -> Result<()> {
             let http = reqwest::Client::new();
             auth_flow::ensure_authenticated(&http, &client_id, skip_validate).await
         }
+        cli::Command::Chat {
+            prompt,
+            socket,
+            model,
+        } => client::run_chat_loop(socket, prompt, model).await,
         cli::Command::Acp { model, socket } => agent_server::run(model, socket).await,
         cli::Command::Models => models::run().await,
         cli::Command::Memory { action, socket } => run_memory(action, socket).await,


### PR DESCRIPTION
## Problem

\`amaebi ask\` exits after every response. The consistent-chat feature (#34) persists history across invocations, but the user still has to re-invoke \`amaebi ask \"...\"\` for each turn — the UX doesn't feel like a continuous conversation.

## Solution

New \`amaebi chat\` subcommand: a persistent REPL that stays open after each response and prompts for the next message.

\`\`\`
$ amaebi chat "what is the capital of France?"
The capital is Paris.

> tell me more
Paris is known for the Eiffel Tower...

> [empty line or Ctrl-D to exit]
Session ended. ID: abc-123
\`\`\`

## Design

- Reuses the same \`session_id\` for all turns, so every exchange accumulates in \`session_turns\` and the model receives the full history
- Optional opening prompt: \`amaebi chat "hello"\` or just \`amaebi chat\`
- \`--model\` flag supported
- Empty line or Ctrl-D exits
- Tool use, compaction notices shown on stderr as usual

## Test plan

- [x] \`cargo test -- --include-ignored\` — 36/36 pass
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy -- -D warnings\` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)