### PR TITLE
feat: amaebi chat — long-connection REPL with steer and in-memory context

### DIFF
--- a/src/agent_server.rs
+++ b/src/agent_server.rs
@@ -258,7 +258,8 @@ impl acp::Agent for AmaebiAgent {
         let model = Arc::clone(&self.model);
 
         // Oneshot to receive the loop's final text.
-        let (result_tx, result_rx) = oneshot::channel::<Result<(String, usize), String>>();
+        let (result_tx, result_rx) =
+            oneshot::channel::<Result<(String, usize, Vec<crate::copilot::Message>), String>>();
 
         // Run the agentic loop in a background local task.
         // ACP mode has no steering channel — create a channel and immediately
@@ -332,7 +333,7 @@ impl acp::Agent for AmaebiAgent {
 
         // Await the loop outcome; propagate any error to the ACP client.
         let final_text = match result_rx.await {
-            Ok(Ok((text, _))) => text,
+            Ok(Ok((text, _, _))) => text,
             Ok(Err(e)) => return Err(acp::Error::internal_error().data(e)),
             Err(_) => return Err(acp::Error::internal_error()),
         };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,21 @@ pub enum Command {
         #[arg(long, conflicts_with = "detach")]
         resume: Option<String>,
     },
+    /// Start an interactive multi-turn chat session.
+    ///
+    /// Stays open after each response: type the next message at the `>` prompt.
+    /// Uses the same per-directory session UUID as `amaebi ask`, so history is
+    /// shared and the existing compaction mechanism applies.
+    /// Empty line or Ctrl-D exits.
+    Chat {
+        /// Optional opening message.
+        prompt: Option<String>,
+        #[arg(long, default_value = DEFAULT_SOCKET)]
+        socket: PathBuf,
+        /// Model to use (overrides AMAEBI_MODEL env var; default: gpt-4o).
+        #[arg(long)]
+        model: Option<String>,
+    },
     /// Authenticate with GitHub Copilot via the device flow.
     Auth {
         /// GitHub OAuth App client ID (defaults to the public neovim copilot.vim ID).

--- a/src/client.rs
+++ b/src/client.rs
@@ -299,6 +299,244 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
 }
 
 // ---------------------------------------------------------------------------
+// Interactive chat REPL
+// ---------------------------------------------------------------------------
+
+/// Run a persistent multi-turn chat session on a single long-lived socket
+/// connection.
+///
+/// Each turn sends a `Chat` request on the same connection; the daemon keeps
+/// the `messages` array in memory so every tool-call/result exchange from
+/// prior turns is visible to the model — no extra DB tables needed.
+///
+/// Ctrl-C during generation → interrupt + enter correction (steer).
+/// Second Ctrl-C within 2 s → exit.
+/// Empty line or Ctrl-D → exit.
+#[allow(unused_assignments)] // steer_pending reads inside select! async blocks
+pub async fn run_chat_loop(
+    socket: PathBuf,
+    initial_prompt: Option<String>,
+    model: Option<String>,
+) -> Result<()> {
+    let mut sigint = signal(SignalKind::interrupt()).context("setting up SIGINT handler")?;
+
+    let model = model
+        .or_else(|| std::env::var("AMAEBI_MODEL").ok())
+        .unwrap_or_else(|| "gpt-4o".to_string());
+
+    let cwd = std::env::current_dir().context("getting current directory")?;
+    let session_id = tokio::task::spawn_blocking(move || session::get_or_create(&cwd))
+        .await
+        .context("session::get_or_create panicked")?
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to resolve session id; using \"global\"");
+            "global".to_string()
+        });
+
+    if std::io::stderr().is_terminal() {
+        eprintln!("Chat session started (ID: {session_id}). Empty line or Ctrl-D to exit.\n");
+    }
+
+    // Open one persistent socket connection for the whole session.
+    let stream = connect_or_start_daemon(&socket).await?;
+    let (read_half, mut write_half) = stream.into_split();
+    let mut lines = BufReader::new(read_half).lines();
+
+    let mut stdout = tokio::io::stdout();
+    let mut next_prompt = initial_prompt;
+    let mut last_ctrl_c: Option<Instant> = None;
+    let mut steer_pending = false;
+
+    'session: loop {
+        // ── Prompt the user and read the next message ──────────────────────
+        let prompt = match next_prompt.take() {
+            Some(p) => p,
+            None => {
+                if std::io::stderr().is_terminal() {
+                    eprint!("> ");
+                    let _ = tokio::io::stderr().flush().await;
+                }
+                let mut line = String::new();
+                let n = tokio::io::AsyncBufReadExt::read_line(
+                    &mut BufReader::new(tokio::io::stdin()),
+                    &mut line,
+                )
+                .await
+                .unwrap_or(0);
+                if n == 0 {
+                    break 'session; // Ctrl-D / EOF
+                }
+                let trimmed = line
+                    .trim_end_matches('\n')
+                    .trim_end_matches('\r')
+                    .to_owned();
+                if trimmed.is_empty() {
+                    break 'session;
+                }
+                trimmed
+            }
+        };
+
+        // ── Send Chat request on the existing connection ────────────────────
+        let req = Request::Chat {
+            prompt: prompt.clone(),
+            tmux_pane: std::env::var("TMUX_PANE").ok(),
+            session_id: Some(session_id.clone()),
+            model: model.clone(),
+        };
+        let mut req_line = serde_json::to_string(&req).context("serializing request")?;
+        req_line.push('\n');
+        write_half
+            .write_all(req_line.as_bytes())
+            .await
+            .context("sending request")?;
+
+        steer_pending = false;
+
+        // ── Stream the response ─────────────────────────────────────────────
+        loop {
+            tokio::select! {
+                biased;
+
+                // Handle Ctrl-C.
+                result = sigint.recv() => {
+                    let Some(_) = result else { break 'session; };
+                    let now = Instant::now();
+                    if is_within_window(last_ctrl_c, now, DOUBLE_CTRLC_WINDOW) {
+                        eprintln!();
+                        let _ = stdout.flush().await;
+                        return Err(anyhow::Error::new(Interrupted));
+                    }
+                    steer_pending = true;
+                    if std::io::stderr().is_terminal() {
+                        eprintln!("\n^C interrupted. Enter correction (empty line to cancel): ");
+                        eprint!(">");
+                        let _ = tokio::io::stderr().flush().await;
+                    } else {
+                        eprintln!("\n[interrupted — press Ctrl-C again quickly to exit]");
+                    }
+                    let interrupt_req = Request::Interrupt { session_id: session_id.clone() };
+                    if let Ok(mut frame) = serde_json::to_string(&interrupt_req) {
+                        frame.push('\n');
+                        let _ = write_half.write_all(frame.as_bytes()).await;
+                    }
+                    last_ctrl_c = Some(now);
+                }
+
+                // Handle daemon response frame.
+                result = lines.next_line() => {
+                    let line = result.context("reading response")?;
+                    let line = match line {
+                        Some(l) => l,
+                        None => break 'session, // daemon closed connection
+                    };
+                    let resp: Response = serde_json::from_str(&line).context("parsing response")?;
+                    match resp {
+                        Response::Text { chunk } => {
+                            stdout.write_all(chunk.as_bytes()).await?;
+                            stdout.flush().await?;
+                        }
+                        Response::Done => {
+                            stdout.write_all(b"\n").await?;
+                            break; // inner loop — ready for next prompt
+                        }
+                        Response::Error { message } => {
+                            anyhow::bail!("{message}");
+                        }
+                        Response::ToolUse { name, detail } => {
+                            if std::io::stderr().is_terminal() {
+                                match name.as_str() {
+                                    "shell_command" => eprintln!("```bash\n$ {detail}\n```"),
+                                    "read_file"     => eprintln!("📄 {detail}"),
+                                    "edit_file"     => eprintln!("✏️  {detail}"),
+                                    _ => eprintln!("🔧 {name}: {detail}"),
+                                }
+                            }
+                        }
+                        Response::WaitingForInput { prompt: extra } => {
+                            if !extra.is_empty() {
+                                eprintln!("\n{extra}");
+                            }
+                            eprint!(">");
+                            let _ = tokio::io::stderr().flush().await;
+                            // Read user reply and send as Steer.
+                            let mut reply = String::new();
+                            let n = tokio::io::AsyncBufReadExt::read_line(
+                                &mut BufReader::new(tokio::io::stdin()),
+                                &mut reply,
+                            )
+                            .await
+                            .unwrap_or(0);
+                            if n == 0 { break 'session; }
+                            let trimmed = reply.trim_end_matches('\n').trim_end_matches('\r').to_owned();
+                            if trimmed.is_empty() { break; }
+                            let steer_req = Request::Steer {
+                                session_id: session_id.clone(),
+                                message: trimmed,
+                            };
+                            if let Ok(mut frame) = serde_json::to_string(&steer_req) {
+                                frame.push('\n');
+                                let _ = write_half.write_all(frame.as_bytes()).await;
+                            }
+                        }
+                        Response::SteerAck => {
+                            steer_pending = false;
+                            tracing::debug!("steer acknowledged");
+                        }
+                        Response::Compacting => {
+                            if std::io::stderr().is_terminal() {
+                                eprintln!("\n[compacting…]");
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                // Read steer correction from stdin when Ctrl-C was pressed.
+                line = async {
+                    if steer_pending {
+                        let mut buf = String::new();
+                        let n = tokio::io::AsyncBufReadExt::read_line(
+                            &mut BufReader::new(tokio::io::stdin()),
+                            &mut buf,
+                        ).await.unwrap_or(0);
+                        if n > 0 { Some(buf) } else { None }
+                    } else {
+                        std::future::pending::<Option<String>>().await
+                    }
+                } => {
+                    match line {
+                        Some(text) => {
+                            let trimmed = text.trim_end_matches('\n').trim_end_matches('\r');
+                            if trimmed.is_empty() {
+                                steer_pending = false;
+                            } else {
+                                let steer_req = Request::Steer {
+                                    session_id: session_id.clone(),
+                                    message: trimmed.to_owned(),
+                                };
+                                if let Ok(mut frame) = serde_json::to_string(&steer_req) {
+                                    frame.push('\n');
+                                    let _ = write_half.write_all(frame.as_bytes()).await;
+                                }
+                                steer_pending = false;
+                                last_ctrl_c = None;
+                            }
+                        }
+                        None => break 'session,
+                    }
+                }
+            }
+        }
+    }
+
+    if std::io::stderr().is_terminal() {
+        eprintln!("\nSession ended. ID: {session_id}");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Detach mode
 // ---------------------------------------------------------------------------
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -286,146 +286,278 @@ pub async fn run(socket: PathBuf) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Result<()> {
-    let (reader, mut writer) = tokio::io::split(stream);
-    let mut lines = BufReader::new(reader).lines();
+    // OwnedRead/WriteHalf are Send, enabling cross-task sharing.
+    let (owned_reader, owned_writer) = stream.into_split();
 
-    let line = lines
-        .next_line()
-        .await
-        .context("reading request")?
-        .context("client disconnected before sending a request")?;
+    // Shared writer: the spawned agentic-loop task holds the lock while generating;
+    // the main task acquires it to write Done/Error and for single-turn requests.
+    let writer: Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>> =
+        Arc::new(tokio::sync::Mutex::new(owned_writer));
 
-    let req: Request = serde_json::from_str(&line).context("parsing request JSON")?;
-
-    match req {
-        Request::ClearMemory => {
-            tracing::info!("received memory clear request");
-            let db = Arc::clone(&state.db);
-            let result = tokio::task::spawn_blocking(move || {
-                let conn = db.lock().unwrap_or_else(|p| p.into_inner());
-                memory_db::clear(&conn)
-            })
-            .await
-            .unwrap_or_else(|e| Err(anyhow::anyhow!("DB clear panicked: {e}")));
-            if let Err(e) = result {
-                tracing::warn!(error = %e, "failed to clear memory DB");
+    // Forwarding task: reads every raw line from the socket and sends it to
+    // a channel so the main task can use select! to route frames.
+    let (frame_tx, mut frame_rx) = tokio::sync::mpsc::channel::<String>(64);
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(owned_reader).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if frame_tx.send(line).await.is_err() {
+                break;
             }
-            write_frame(&mut writer, &Response::Done).await?;
+        }
+    });
+
+    // For long-connection Chat sessions the messages array carries over between
+    // turns so the model sees the complete tool-call history in memory.
+    // None = first turn (load from DB).  Some = subsequent turns (extend).
+    let mut carried_messages: Option<Vec<Message>> = None;
+
+    'connection: loop {
+        let line = match frame_rx.recv().await {
+            Some(l) => l,
+            None => break 'connection, // forwarding task exited (EOF)
+        };
+        if line.trim().is_empty() {
+            continue;
         }
 
-        Request::StoreMemory { user, assistant } => {
-            // Use a stable session id for ACP-sourced memory so it lands in
-            // the same logical bucket as other global (non-directory) writes.
-            store_conversation(&state, "global", &user, &assistant).await;
-            write_frame(&mut writer, &Response::Done).await?;
-        }
-
-        Request::RetrieveContext { prompt } => {
-            let db = Arc::clone(&state.db);
-            let entries = tokio::task::spawn_blocking(move || {
-                let conn = db.lock().unwrap_or_else(|p| p.into_inner());
-                memory_db::retrieve_context(&conn, &prompt, 4, 10)
-            })
-            .await
-            .unwrap_or_else(|e| Err(anyhow::anyhow!("memory read panicked: {e}")))
-            .unwrap_or_else(|e| {
-                tracing::warn!(error = %e, "failed to retrieve memory context via IPC");
-                vec![]
-            });
-            for entry in entries {
-                write_frame(
-                    &mut writer,
-                    &Response::MemoryEntry {
-                        role: entry.role,
-                        content: truncate_chars(entry.content, MAX_HISTORY_CHARS),
-                    },
-                )
-                .await?;
+        let req: Request = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "ignoring unparseable request frame");
+                continue;
             }
-            write_frame(&mut writer, &Response::Done).await?;
-        }
+        };
 
-        Request::Steer { .. } => {
-            // A Steer frame arriving on a fresh connection (not mid-Chat) is
-            // an error — there is no running agentic loop to steer.
-            write_frame(
-                &mut writer,
-                &Response::Error {
-                    message: "no active agentic loop to steer on this connection".into(),
-                },
-            )
-            .await?;
-        }
-
-        Request::Interrupt { .. } => {
-            // An Interrupt arriving on a fresh connection is silently ignored —
-            // there is no active loop to interrupt.
-            tracing::debug!("ignoring Interrupt on fresh connection (no active loop)");
-        }
-
-        Request::SubmitDetach {
-            prompt,
-            tmux_pane,
-            model,
-            session_id,
-        } => {
-            tracing::info!(
-                model = %model,
-                prompt_len = prompt.len(),
-                "received detach request"
-            );
-
-            // Verify auth eagerly so we can return an error before detaching.
-            if let Err(e) = state.tokens.get(&state.http).await {
-                write_frame(
-                    &mut writer,
-                    &Response::Error {
-                        message: format!("authentication error: {e:#}"),
-                    },
-                )
-                .await?;
-                return Ok(());
-            }
-
-            // Generate a fresh UUID for detached tasks when the client does
-            // not provide one, so every background task has a stable identifier
-            // that appears in inbox reports and can be resumed later.
-            let sid = session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-
-            // Acknowledge immediately — client can exit after this.
-            write_frame(
-                &mut writer,
-                &Response::DetachAccepted {
-                    session_id: sid.clone(),
-                },
-            )
-            .await?;
-
-            // Spawn the agentic loop as a fully detached background task.
-            let state = Arc::clone(&state);
-            tokio::spawn(async move {
-                // Load full session history from SQLite; token budget trims it below.
+        match req {
+            Request::ClearMemory => {
+                tracing::info!("received memory clear request");
                 let db = Arc::clone(&state.db);
-                let sid_clone = sid.clone();
-                let history = tokio::task::spawn_blocking(move || {
+                let result = tokio::task::spawn_blocking(move || {
                     let conn = db.lock().unwrap_or_else(|p| p.into_inner());
-                    memory_db::get_session_history(&conn, &sid_clone)
+                    memory_db::clear(&conn)
                 })
                 .await
-                .unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "detach history load panicked");
-                    Ok(vec![])
+                .unwrap_or_else(|e| Err(anyhow::anyhow!("DB clear panicked: {e}")));
+                if let Err(e) = result {
+                    tracing::warn!(error = %e, "failed to clear memory DB");
+                }
+                let mut w = writer.lock().await;
+                write_frame(&mut *w, &Response::Done).await?;
+            }
+
+            Request::StoreMemory { user, assistant } => {
+                store_conversation(&state, "global", &user, &assistant).await;
+                let mut w = writer.lock().await;
+                write_frame(&mut *w, &Response::Done).await?;
+            }
+
+            Request::RetrieveContext { prompt } => {
+                let db = Arc::clone(&state.db);
+                let entries = tokio::task::spawn_blocking(move || {
+                    let conn = db.lock().unwrap_or_else(|p| p.into_inner());
+                    memory_db::retrieve_context(&conn, &prompt, 4, 10)
                 })
+                .await
+                .unwrap_or_else(|e| Err(anyhow::anyhow!("memory read panicked: {e}")))
                 .unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "failed to load detach history");
+                    tracing::warn!(error = %e, "failed to retrieve memory context via IPC");
                     vec![]
                 });
+                let mut w = writer.lock().await;
+                for entry in entries {
+                    write_frame(
+                        &mut *w,
+                        &Response::MemoryEntry {
+                            role: entry.role,
+                            content: truncate_chars(entry.content, MAX_HISTORY_CHARS),
+                        },
+                    )
+                    .await?;
+                }
+                write_frame(&mut *w, &Response::Done).await?;
+            }
 
-                let mut messages =
-                    build_messages(&prompt, tmux_pane.as_deref(), &history, &[], None);
+            Request::Steer { .. } => {
+                let mut w = writer.lock().await;
+                write_frame(
+                    &mut *w,
+                    &Response::Error {
+                        message: "no active agentic loop to steer on this connection".into(),
+                    },
+                )
+                .await?;
+            }
+
+            Request::Interrupt { .. } => {
+                tracing::debug!("ignoring Interrupt on fresh connection (no active loop)");
+            }
+
+            Request::SubmitDetach {
+                prompt,
+                tmux_pane,
+                model,
+                session_id,
+            } => {
+                tracing::info!(
+                    model = %model,
+                    prompt_len = prompt.len(),
+                    "received detach request"
+                );
+
+                if let Err(e) = state.tokens.get(&state.http).await {
+                    let mut w = writer.lock().await;
+                    write_frame(
+                        &mut *w,
+                        &Response::Error {
+                            message: format!("authentication error: {e:#}"),
+                        },
+                    )
+                    .await?;
+                    break 'connection;
+                }
+
+                let sid = session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+                {
+                    let mut w = writer.lock().await;
+                    write_frame(
+                        &mut *w,
+                        &Response::DetachAccepted {
+                            session_id: sid.clone(),
+                        },
+                    )
+                    .await?;
+                }
+
+                let state = Arc::clone(&state);
+                tokio::spawn(async move {
+                    let db = Arc::clone(&state.db);
+                    let sid_clone = sid.clone();
+                    let history = tokio::task::spawn_blocking(move || {
+                        let conn = db.lock().unwrap_or_else(|p| p.into_inner());
+                        memory_db::get_session_history(&conn, &sid_clone)
+                    })
+                    .await
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(error = %e, "detach history load panicked");
+                        Ok(vec![])
+                    })
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(error = %e, "failed to load detach history");
+                        vec![]
+                    });
+
+                    let mut messages =
+                        build_messages(&prompt, tmux_pane.as_deref(), &history, &[], None);
+                    inject_skill_files(&mut messages).await;
+
+                    let threshold = compaction_threshold_tokens(&model);
+                    if count_message_tokens(&messages) > threshold {
+                        let hot = HOT_TAIL_PAIRS * 2;
+                        let trimmed = if history.len() > hot {
+                            &history[history.len() - hot..]
+                        } else {
+                            &history[..]
+                        };
+                        messages =
+                            build_messages(&prompt, tmux_pane.as_deref(), trimmed, &[], None);
+                        inject_skill_files(&mut messages).await;
+                    }
+
+                    let mut sink = tokio::io::sink();
+                    let (_, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(1);
+
+                    match run_agentic_loop(&state, &model, messages, &mut sink, &mut steer_rx, true)
+                        .await
+                    {
+                        Ok((final_text, _, _)) => {
+                            let user_text = truncate_chars(prompt.clone(), MAX_PROMPT_CHARS);
+                            let assistant_text =
+                                truncate_chars(final_text.clone(), MAX_RESPONSE_CHARS);
+                            store_conversation(&state, &sid, &user_text, &assistant_text).await;
+                            let task_desc = truncate_chars(prompt, 200);
+                            match InboxStore::open() {
+                                Ok(inbox) => {
+                                    if let Err(e) = inbox.save_report(&sid, &task_desc, &final_text)
+                                    {
+                                        tracing::warn!(error = %e, "detach: failed to save inbox report");
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "detach: failed to open inbox");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "detach agentic loop error");
+                            let task_desc = truncate_chars(prompt, 200);
+                            if let Ok(inbox) = InboxStore::open() {
+                                let _ =
+                                    inbox.save_report(&sid, &task_desc, &format!("[error] {e:#}"));
+                            }
+                        }
+                    }
+                });
+            }
+
+            Request::Resume {
+                prompt,
+                tmux_pane,
+                model,
+                session_id,
+            } => {
+                tracing::info!(
+                    model = %model,
+                    session_id = %session_id,
+                    prompt_len = prompt.len(),
+                    "received resume request"
+                );
+
+                if let Err(e) = state.tokens.get(&state.http).await {
+                    let mut w = writer.lock().await;
+                    write_frame(
+                        &mut *w,
+                        &Response::Error {
+                            message: format!("authentication error: {e:#}"),
+                        },
+                    )
+                    .await?;
+                    break 'connection;
+                }
+
+                let (steer_tx, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(16);
+                let expected_resume_sid = session_id.clone();
+
+                let db = Arc::clone(&state.db);
+                let sid_clone = session_id.clone();
+                let (history, summaries, own_summary) =
+                    tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+                        let conn = db.lock().unwrap_or_else(|p| p.into_inner());
+                        let history = memory_db::get_session_history(&conn, &sid_clone)?;
+                        let summaries =
+                            memory_db::get_recent_summaries(&conn, &sid_clone, MAX_SUMMARIES)?;
+                        let own_summary = memory_db::get_session_own_summary(&conn, &sid_clone)?;
+                        Ok((history, summaries, own_summary))
+                    })
+                    .await
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(error = %e, "resume history load panicked");
+                        Ok((vec![], vec![], None))
+                    })
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(error = %e, "failed to load resume history");
+                        (vec![], vec![], None)
+                    });
+
+                let mut messages = build_messages(
+                    &prompt,
+                    tmux_pane.as_deref(),
+                    &history,
+                    &summaries,
+                    own_summary.as_deref(),
+                );
                 inject_skill_files(&mut messages).await;
 
-                // Pre-flight token check: trim to hot tail if over budget.
                 let threshold = compaction_threshold_tokens(&model);
                 if count_message_tokens(&messages) > threshold {
                     let hot = HOT_TAIL_PAIRS * 2;
@@ -434,447 +566,305 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                     } else {
                         &history[..]
                     };
-                    messages = build_messages(&prompt, tmux_pane.as_deref(), trimmed, &[], None);
+                    messages = build_messages(
+                        &prompt,
+                        tmux_pane.as_deref(),
+                        trimmed,
+                        &summaries,
+                        own_summary.as_deref(),
+                    );
                     inject_skill_files(&mut messages).await;
                 }
 
-                // Use a sink writer — output frames are discarded; we only
-                // need the return value (final_text) for the inbox.
-                // Drop the sender immediately (`_`) so steer_rx.recv() in the
-                // agentic loop returns None at once instead of timing out if
-                // the model ends with '?'.
-                let mut sink = tokio::io::sink();
-                let (_, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(1);
-
-                match run_agentic_loop(&state, &model, messages, &mut sink, &mut steer_rx, true)
+                let writer_for_loop = Arc::clone(&writer);
+                let state_for_loop = Arc::clone(&state);
+                let model_for_loop = model.clone();
+                let mut loop_handle = tokio::spawn(async move {
+                    let mut w = writer_for_loop.lock().await;
+                    run_agentic_loop(
+                        &state_for_loop,
+                        &model_for_loop,
+                        messages,
+                        &mut *w,
+                        &mut steer_rx,
+                        true,
+                    )
                     .await
-                {
-                    Ok((final_text, _)) => {
-                        let user_text = truncate_chars(prompt.clone(), MAX_PROMPT_CHARS);
-                        let assistant_text = truncate_chars(final_text.clone(), MAX_RESPONSE_CHARS);
+                });
 
-                        // Persist to SQLite memory store.
-                        store_conversation(&state, &sid, &user_text, &assistant_text).await;
-
-                        // Save result to inbox so the user gets a notification.
-                        let task_desc = truncate_chars(prompt, 200);
-                        match InboxStore::open() {
-                            Ok(inbox) => {
-                                if let Err(e) = inbox.save_report(&sid, &task_desc, &final_text) {
-                                    tracing::warn!(
-                                        error = %e,
-                                        "detach: failed to save inbox report"
-                                    );
+                let loop_result = loop {
+                    tokio::select! {
+                        biased;
+                        result = &mut loop_handle => {
+                            break result.unwrap_or_else(|e| Err(anyhow::anyhow!("loop panicked: {e}")));
+                        }
+                        maybe_frame = frame_rx.recv() => {
+                            match maybe_frame {
+                                None => { loop_handle.abort(); break 'connection; }
+                                Some(line) => {
+                                    if let Ok(Request::Steer { session_id: sid, message }) = serde_json::from_str::<Request>(&line) {
+                                        if sid == expected_resume_sid {
+                                            let _ = steer_tx.send(Some(message)).await;
+                                        }
+                                    } else if let Ok(Request::Interrupt { session_id: sid }) = serde_json::from_str::<Request>(&line) {
+                                        if sid == expected_resume_sid {
+                                            let _ = steer_tx.send(None).await;
+                                        }
+                                    }
                                 }
                             }
-                            Err(e) => {
-                                tracing::warn!(
-                                    error = %e,
-                                    "detach: failed to open inbox"
-                                );
-                            }
                         }
+                    }
+                };
+
+                match loop_result {
+                    Ok((response_text, _, _)) => {
+                        let user_text = truncate_chars(prompt.clone(), MAX_PROMPT_CHARS);
+                        let assistant_text =
+                            truncate_chars(response_text.clone(), MAX_RESPONSE_CHARS);
+                        store_conversation(&state, &session_id, &user_text, &assistant_text).await;
+                        let mut w = writer.lock().await;
+                        write_frame(&mut *w, &Response::Done).await?;
                     }
                     Err(e) => {
-                        tracing::error!(error = %e, "detach agentic loop error");
-                        // Save the error itself to inbox so user is informed.
-                        let task_desc = truncate_chars(prompt, 200);
-                        if let Ok(inbox) = InboxStore::open() {
-                            let _ = inbox.save_report(&sid, &task_desc, &format!("[error] {e:#}"));
-                        }
+                        tracing::error!(error = %e, "resume agentic loop error");
+                        let mut w = writer.lock().await;
+                        let _ = write_frame(
+                            &mut *w,
+                            &Response::Error {
+                                message: format!("agent error: {e:#}"),
+                            },
+                        )
+                        .await;
                     }
                 }
-            });
-        }
-
-        Request::Resume {
-            prompt,
-            tmux_pane,
-            model,
-            session_id,
-        } => {
-            tracing::info!(
-                model = %model,
-                session_id = %session_id,
-                prompt_len = prompt.len(),
-                "received resume request"
-            );
-
-            if let Err(e) = state.tokens.get(&state.http).await {
-                write_frame(
-                    &mut writer,
-                    &Response::Error {
-                        message: format!("authentication error: {e:#}"),
-                    },
-                )
-                .await?;
-                return Ok(());
             }
 
-            let (steer_tx, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(16);
-            let expected_resume_sid = session_id.clone();
-            tokio::spawn(async move {
-                while let Ok(Some(frame)) = lines.next_line().await {
-                    match serde_json::from_str::<Request>(&frame) {
-                        Ok(Request::Steer {
-                            session_id: steer_sid,
-                            message,
-                        }) => {
-                            if steer_sid != expected_resume_sid {
-                                tracing::debug!(
-                                    expected = %expected_resume_sid,
-                                    got = %steer_sid,
-                                    "ignoring steer frame with mismatched session_id on resume"
-                                );
-                                continue;
-                            }
-                            if steer_tx.send(Some(message)).await.is_err() {
-                                break;
-                            }
-                        }
-                        Ok(Request::Interrupt {
-                            session_id: steer_sid,
-                        }) => {
-                            if steer_sid != expected_resume_sid {
-                                tracing::debug!(
-                                    expected = %expected_resume_sid,
-                                    got = %steer_sid,
-                                    "ignoring interrupt frame with mismatched session_id on resume"
-                                );
-                                continue;
-                            }
-                            if steer_tx.send(None).await.is_err() {
-                                break;
-                            }
-                        }
-                        Ok(_) | Err(_) => {
-                            tracing::debug!("unexpected frame on established resume connection");
-                        }
-                    }
-                }
-            });
-
-            // Resume: load the FULL history from SQLite without a sliding-window cap,
-            // plus summaries from other sessions for cross-session context,
-            // and the session's own running summary if one was already compacted.
-            let db = Arc::clone(&state.db);
-            let sid_clone = session_id.clone();
-            let (history, summaries, own_summary) =
-                tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
-                    let conn = db.lock().unwrap_or_else(|p| p.into_inner());
-                    let history = memory_db::get_session_history(&conn, &sid_clone)?;
-                    let summaries =
-                        memory_db::get_recent_summaries(&conn, &sid_clone, MAX_SUMMARIES)?;
-                    let own_summary = memory_db::get_session_own_summary(&conn, &sid_clone)?;
-                    Ok((history, summaries, own_summary))
-                })
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "resume history load panicked");
-                    Ok((vec![], vec![], None))
-                })
-                .unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "failed to load resume history");
-                    (vec![], vec![], None)
-                });
-
-            // Resume: full history for re-hydration; token budget trims if needed.
-            let mut messages = build_messages(
-                &prompt,
-                tmux_pane.as_deref(),
-                &history,
-                &summaries,
-                own_summary.as_deref(),
-            );
-            inject_skill_files(&mut messages).await;
-
-            // Pre-flight token check.
-            let threshold = compaction_threshold_tokens(&model);
-            if count_message_tokens(&messages) > threshold {
-                let hot = HOT_TAIL_PAIRS * 2;
-                let trimmed = if history.len() > hot {
-                    &history[history.len() - hot..]
-                } else {
-                    &history[..]
-                };
-                messages = build_messages(
-                    &prompt,
-                    tmux_pane.as_deref(),
-                    trimmed,
-                    &summaries,
-                    own_summary.as_deref(),
+            Request::Chat {
+                prompt,
+                tmux_pane,
+                model,
+                session_id,
+            } => {
+                tracing::info!(
+                    pane = ?tmux_pane,
+                    model = %model,
+                    prompt_len = prompt.len(),
+                    "received chat request"
                 );
-                inject_skill_files(&mut messages).await;
-            }
 
-            match run_agentic_loop(&state, &model, messages, &mut writer, &mut steer_rx, true).await
-            {
-                Ok((response_text, _)) => {
-                    let user_text = truncate_chars(prompt.clone(), MAX_PROMPT_CHARS);
-                    let assistant_text = truncate_chars(response_text.clone(), MAX_RESPONSE_CHARS);
-
-                    store_conversation(&state, &session_id, &user_text, &assistant_text).await;
-                    write_frame(&mut writer, &Response::Done).await?;
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, "resume agentic loop error");
-                    let _ = write_frame(
-                        &mut writer,
+                if let Err(e) = state.tokens.get(&state.http).await {
+                    tracing::error!(error = %e, "failed to get Copilot API token");
+                    let mut w = writer.lock().await;
+                    write_frame(
+                        &mut *w,
                         &Response::Error {
-                            message: format!("agent error: {e:#}"),
+                            message: format!("authentication error: {e:#}"),
                         },
                     )
-                    .await;
+                    .await?;
+                    break 'connection;
                 }
-            }
-        }
 
-        Request::Chat {
-            prompt,
-            tmux_pane,
-            model,
-            session_id,
-        } => {
-            tracing::info!(
-                pane = ?tmux_pane,
-                model = %model,
-                prompt_len = prompt.len(),
-                "received chat request"
-            );
+                let sid = session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-            // Verify authentication before entering the loop so we can return
-            // a clear error to the user instead of failing mid-conversation.
-            if let Err(e) = state.tokens.get(&state.http).await {
-                tracing::error!(error = %e, "failed to get Copilot API token");
-                write_frame(
-                    &mut writer,
-                    &Response::Error {
-                        message: format!("authentication error: {e:#}"),
-                    },
-                )
-                .await?;
-                return Ok(());
-            }
-
-            // Resolve session first so the steer reader can validate the
-            // session_id on incoming Steer frames.
-            // Older clients that omit session_id get a fresh UUID so their
-            // history and steer lookups are isolated (not all lumped under "").
-            let sid = session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-
-            // Steering channel: the spawned reader task sends user corrections
-            // here; the agentic loop drains them between model turns.
-            let (steer_tx, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(16);
-
-            // Spawn a task that reads subsequent frames from the client on
-            // this connection.  Any Steer frames are forwarded to steer_tx so
-            // the running agentic loop can inject them between tool turns.
-            // The task exits when the client closes the connection (EOF) or
-            // when steer_tx is dropped (agentic loop finished).
-            let expected_chat_sid = sid.clone();
-            tokio::spawn(async move {
-                while let Ok(Some(frame)) = lines.next_line().await {
-                    match serde_json::from_str::<Request>(&frame) {
-                        Ok(Request::Steer {
-                            session_id: steer_sid,
-                            message,
-                        }) => {
-                            if steer_sid != expected_chat_sid {
-                                tracing::debug!(
-                                    expected = %expected_chat_sid,
-                                    got = %steer_sid,
-                                    "ignoring steer frame with mismatched session_id on chat"
-                                );
-                                continue;
-                            }
-                            if steer_tx.send(Some(message)).await.is_err() {
-                                break; // agentic loop has finished; channel closed
-                            }
-                        }
-                        Ok(Request::Interrupt {
-                            session_id: steer_sid,
-                        }) => {
-                            if steer_sid != expected_chat_sid {
-                                tracing::debug!(
-                                    expected = %expected_chat_sid,
-                                    got = %steer_sid,
-                                    "ignoring interrupt frame with mismatched session_id on chat"
-                                );
-                                continue;
-                            }
-                            // None = interrupt-only; no steer text to inject.
-                            if steer_tx.send(None).await.is_err() {
-                                break;
-                            }
-                        }
-                        Ok(_) | Err(_) => {
-                            // Unexpected frame type mid-stream; ignore.
-                            tracing::debug!("unexpected frame type on established chat connection");
-                        }
-                    }
-                }
-            });
-
-            // Load full session history, past-session summaries, and the session's own
-            // running summary (if any) for token-budget-driven compaction decisions.
-            let db = Arc::clone(&state.db);
-            let sid_clone = sid.clone();
-            let (history, past_summaries, own_summary) =
-                tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
-                    let conn = db.lock().unwrap_or_else(|p| p.into_inner());
-                    let history = memory_db::get_session_history(&conn, &sid_clone)?;
-                    let past_summaries =
-                        memory_db::get_recent_summaries(&conn, &sid_clone, MAX_SUMMARIES)?;
-                    let own_summary = memory_db::get_session_own_summary(&conn, &sid_clone)?;
-                    Ok((history, past_summaries, own_summary))
-                })
-                .await
-                .unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "session history load panicked");
-                    Ok((vec![], vec![], None))
-                })
-                .unwrap_or_else(|e| {
-                    tracing::warn!(error = %e, "failed to load session history");
-                    (vec![], vec![], None)
-                });
-
-            // Cross-session: if this is the first turn of a new session, compact any
-            // old sessions that have never been summarised.
-            if history.is_empty() {
-                let db = Arc::clone(&state.db);
-                let sid_clone = sid.clone();
-                let old_sessions = tokio::task::spawn_blocking(move || {
-                    let conn = db.lock().unwrap_or_else(|p| p.into_inner());
-                    memory_db::get_sessions_without_summary(&conn, &sid_clone, MAX_SUMMARIES)
-                })
-                .await
-                .unwrap_or_else(|_| Ok(vec![]))
-                .unwrap_or_default();
-
-                for old_sid in old_sessions {
-                    // Cross-session: summarise the full closed session (keep_recent = 0).
-                    tokio::spawn(compact_session(
-                        Arc::clone(&state),
-                        old_sid,
-                        model.clone(),
-                        0,
-                    ));
-                }
-            }
-
-            let mut messages = build_messages(
-                &prompt,
-                tmux_pane.as_deref(),
-                &history,
-                &past_summaries,
-                own_summary.as_deref(),
-            );
-            inject_skill_files(&mut messages).await;
-
-            // Pre-flight token check: if over the compaction threshold, trim to hot tail.
-            // Also record whether we had to trim — that alone is enough to schedule
-            // compaction even if the API does not return usage data.
-            let threshold = compaction_threshold_tokens(&model);
-            let pre_flight_trimmed = if count_message_tokens(&messages) > threshold {
-                let hot = HOT_TAIL_PAIRS * 2;
-                let trimmed = if history.len() > hot {
-                    &history[history.len() - hot..]
+                // Build messages: first turn loads from DB; subsequent turns on the same
+                // long connection extend the in-memory array with the new user prompt so
+                // the model sees the full tool-call history without re-serialising to DB.
+                let messages = if let Some(mut prev) = carried_messages.take() {
+                    prev.push(Message::user(prompt.clone()));
+                    prev
                 } else {
-                    &history[..]
-                };
-                messages = build_messages(
-                    &prompt,
-                    tmux_pane.as_deref(),
-                    trimmed,
-                    &past_summaries,
-                    own_summary.as_deref(),
-                );
-                inject_skill_files(&mut messages).await;
-                tracing::debug!(
-                    hot_tail = trimmed.len(),
-                    "pre-flight token trim: history reduced to hot tail"
-                );
-                true
-            } else {
-                false
-            };
+                    // First turn: load history, apply compaction policy.
+                    let db = Arc::clone(&state.db);
+                    let sid_clone = sid.clone();
+                    let (history, past_summaries, own_summary) =
+                        tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+                            let conn = db.lock().unwrap_or_else(|p| p.into_inner());
+                            let history = memory_db::get_session_history(&conn, &sid_clone)?;
+                            let past_summaries =
+                                memory_db::get_recent_summaries(&conn, &sid_clone, MAX_SUMMARIES)?;
+                            let own_summary =
+                                memory_db::get_session_own_summary(&conn, &sid_clone)?;
+                            Ok((history, past_summaries, own_summary))
+                        })
+                        .await
+                        .unwrap_or_else(|e| {
+                            tracing::warn!(error = %e, "session history load panicked");
+                            Ok((vec![], vec![], None))
+                        })
+                        .unwrap_or_else(|e| {
+                            tracing::warn!(error = %e, "failed to load session history");
+                            (vec![], vec![], None)
+                        });
 
-            // Snapshot the token count before messages is moved into the loop.
-            // Used as a fallback when the API returns prompt_tokens = 0.
-            let pre_send_tokens = count_message_tokens(&messages);
+                    // Cross-session compaction for new sessions.
+                    if history.is_empty() {
+                        let db = Arc::clone(&state.db);
+                        let sid_clone = sid.clone();
+                        let old_sessions = tokio::task::spawn_blocking(move || {
+                            let conn = db.lock().unwrap_or_else(|p| p.into_inner());
+                            memory_db::get_sessions_without_summary(
+                                &conn,
+                                &sid_clone,
+                                MAX_SUMMARIES,
+                            )
+                        })
+                        .await
+                        .unwrap_or_else(|_| Ok(vec![]))
+                        .unwrap_or_default();
 
-            match run_agentic_loop(&state, &model, messages, &mut writer, &mut steer_rx, true).await
-            {
-                Ok((response_text, prompt_tokens)) => {
-                    let user_text = truncate_chars(prompt.clone(), MAX_PROMPT_CHARS);
-                    let assistant_text = truncate_chars(response_text.clone(), MAX_RESPONSE_CHARS);
-
-                    // Persist to SQLite memory store.
-                    store_conversation(&state, &sid, &user_text, &assistant_text).await;
-
-                    // Within-session compaction: trigger when the context is large enough.
-                    // Two signals both warrant compaction:
-                    //   1. pre_flight_trimmed — the full history already exceeded the
-                    //      threshold before we sent the request; the API's prompt_tokens
-                    //      reflects only the trimmed slice and would never cross the
-                    //      threshold on its own.
-                    //   2. effective_tokens > threshold — the API confirmed the request
-                    //      consumed more than the compaction threshold.  Fall back to the
-                    //      pre-send tiktoken estimate when the server returns 0.
-                    let effective_tokens = if prompt_tokens > 0 {
-                        prompt_tokens
-                    } else {
-                        pre_send_tokens
-                    };
-                    tracing::debug!(
-                        effective_tokens,
-                        threshold,
-                        pre_flight_trimmed,
-                        prompt_tokens,
-                        pre_send_tokens,
-                        "compaction check"
-                    );
-                    // Compact whenever the context is over budget.  After compaction,
-                    // the archived turns are excluded from future history loads, so
-                    // the loaded window shrinks and this condition naturally goes false
-                    // until enough new turns accumulate to push past the threshold again.
-                    if pre_flight_trimmed || effective_tokens > threshold {
-                        tracing::info!(
-                            session = %sid,
-                            effective_tokens,
-                            threshold,
-                            pre_flight_trimmed,
-                            "compacting conversation history"
-                        );
-                        let _ = write_frame(&mut writer, &Response::Compacting).await;
-                        // Guard against overlapping compactions for the same session.
-                        let already_compacting = {
-                            let mut guard = state
-                                .compacting_sessions
-                                .lock()
-                                .unwrap_or_else(|p| p.into_inner());
-                            !guard.insert(sid.clone())
-                        };
-                        if !already_compacting {
+                        for old_sid in old_sessions {
                             tokio::spawn(compact_session(
                                 Arc::clone(&state),
-                                sid.clone(),
+                                old_sid,
                                 model.clone(),
-                                HOT_TAIL_PAIRS * 2, // keep hot tail out of the summary
+                                0,
                             ));
                         }
                     }
-                    write_frame(&mut writer, &Response::Done).await?;
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, "agentic loop error");
-                    let _ = write_frame(
-                        &mut writer,
-                        &Response::Error {
-                            message: format!("agent error: {e:#}"),
-                        },
+
+                    let mut msgs = build_messages(
+                        &prompt,
+                        tmux_pane.as_deref(),
+                        &history,
+                        &past_summaries,
+                        own_summary.as_deref(),
+                    );
+                    inject_skill_files(&mut msgs).await;
+
+                    let threshold = compaction_threshold_tokens(&model);
+                    if count_message_tokens(&msgs) > threshold {
+                        let hot = HOT_TAIL_PAIRS * 2;
+                        let trimmed = if history.len() > hot {
+                            &history[history.len() - hot..]
+                        } else {
+                            &history[..]
+                        };
+                        msgs = build_messages(
+                            &prompt,
+                            tmux_pane.as_deref(),
+                            trimmed,
+                            &past_summaries,
+                            own_summary.as_deref(),
+                        );
+                        inject_skill_files(&mut msgs).await;
+                    }
+
+                    msgs
+                };
+
+                let pre_send_tokens = count_message_tokens(&messages);
+                let threshold = compaction_threshold_tokens(&model);
+
+                // Steer channel for this turn.
+                let (steer_tx, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(16);
+                let expected_chat_sid = sid.clone();
+
+                // Spawn the agentic loop — it holds the writer lock for its duration.
+                let writer_for_loop = Arc::clone(&writer);
+                let state_for_loop = Arc::clone(&state);
+                let model_for_loop = model.clone();
+                let mut loop_handle = tokio::spawn(async move {
+                    let mut w = writer_for_loop.lock().await;
+                    run_agentic_loop(
+                        &state_for_loop,
+                        &model_for_loop,
+                        messages,
+                        &mut *w,
+                        &mut steer_rx,
+                        true,
                     )
-                    .await;
+                    .await
+                });
+
+                // Route Steer/Interrupt frames to the loop while it runs; break when done.
+                let loop_result = loop {
+                    tokio::select! {
+                        biased;
+                        result = &mut loop_handle => {
+                            break result.unwrap_or_else(|e| Err(anyhow::anyhow!("loop panicked: {e}")));
+                        }
+                        maybe_frame = frame_rx.recv() => {
+                            match maybe_frame {
+                                None => { loop_handle.abort(); break 'connection; }
+                                Some(line) => {
+                                    if let Ok(req) = serde_json::from_str::<Request>(&line) {
+                                        match req {
+                                            Request::Steer { session_id: sid, message } if sid == expected_chat_sid => {
+                                                let _ = steer_tx.send(Some(message)).await;
+                                            }
+                                            Request::Interrupt { session_id: sid } if sid == expected_chat_sid => {
+                                                let _ = steer_tx.send(None).await;
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                match loop_result {
+                    Ok((response_text, prompt_tokens, final_messages)) => {
+                        let user_text = truncate_chars(prompt.clone(), MAX_PROMPT_CHARS);
+                        let assistant_text =
+                            truncate_chars(response_text.clone(), MAX_RESPONSE_CHARS);
+
+                        store_conversation(&state, &sid, &user_text, &assistant_text).await;
+
+                        let effective_tokens = if prompt_tokens > 0 {
+                            prompt_tokens
+                        } else {
+                            pre_send_tokens
+                        };
+                        tracing::debug!(effective_tokens, threshold, "compaction check");
+
+                        let mut w = writer.lock().await;
+                        if effective_tokens > threshold {
+                            tracing::info!(
+                                session = %sid,
+                                effective_tokens,
+                                threshold,
+                                "compacting conversation history"
+                            );
+                            let _ = write_frame(&mut *w, &Response::Compacting).await;
+                            let already_compacting = {
+                                let mut guard = state
+                                    .compacting_sessions
+                                    .lock()
+                                    .unwrap_or_else(|p| p.into_inner());
+                                !guard.insert(sid.clone())
+                            };
+                            if !already_compacting {
+                                tokio::spawn(compact_session(
+                                    Arc::clone(&state),
+                                    sid.clone(),
+                                    model.clone(),
+                                    HOT_TAIL_PAIRS * 2,
+                                ));
+                            }
+                        }
+                        write_frame(&mut *w, &Response::Done).await?;
+                        drop(w);
+
+                        // Carry messages for the next turn on this long connection.
+                        carried_messages = Some(final_messages);
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "agentic loop error");
+                        let mut w = writer.lock().await;
+                        let _ = write_frame(
+                            &mut *w,
+                            &Response::Error {
+                                message: format!("agent error: {e:#}"),
+                            },
+                        )
+                        .await;
+                        // After an error, clear carried state to avoid corrupt context.
+                        carried_messages = None;
+                    }
                 }
             }
         }
@@ -1312,7 +1302,7 @@ pub(crate) async fn run_agentic_loop<W>(
     writer: &mut W,
     steer_rx: &mut tokio::sync::mpsc::Receiver<Option<String>>,
     include_spawn_agent: bool,
-) -> Result<(String, usize)>
+) -> Result<(String, usize, Vec<Message>)>
 where
     W: AsyncWriteExt + Unpin,
 {
@@ -1581,6 +1571,11 @@ where
                 }
 
                 final_text = resp.text;
+                // Push the final assistant turn into messages so the
+                // long-connection carry-over includes the full exchange.
+                if !final_text.is_empty() {
+                    messages.push(Message::assistant(Some(final_text.clone()), vec![]));
+                }
                 break;
             }
 
@@ -1829,12 +1824,15 @@ where
                 let warning = format!("\n[stopped: unexpected finish reason '{reason}']");
                 write_frame(writer, &Response::Text { chunk: warning }).await?;
                 final_text = resp.text;
+                if !final_text.is_empty() {
+                    messages.push(Message::assistant(Some(final_text.clone()), vec![]));
+                }
                 break;
             }
         }
     }
 
-    Ok((final_text, last_prompt_tokens))
+    Ok((final_text, last_prompt_tokens, messages))
 }
 
 // ---------------------------------------------------------------------------
@@ -2080,7 +2078,7 @@ async fn run_cron_job(state: Arc<DaemonState>, job: &cron::CronJob) {
     let result = run_agentic_loop(&state, &model, messages, &mut sink, &mut steer_rx, true).await;
 
     let (output, run_ok) = match result {
-        Ok((final_text, _)) => {
+        Ok((final_text, _, _)) => {
             store_conversation(&state, &session_id, &job.description, &final_text).await;
             (final_text, true)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ async fn main() -> Result<()> {
     if matches!(
         &cli.command,
         cli::Command::Ask { .. }
+            | cli::Command::Chat { .. }
             | cli::Command::Session { .. }
             | cli::Command::Memory { .. }
             | cli::Command::Cache { .. }
@@ -79,6 +80,11 @@ async fn main() -> Result<()> {
             let http = reqwest::Client::new();
             auth_flow::ensure_authenticated(&http, &client_id, skip_validate).await
         }
+        cli::Command::Chat {
+            prompt,
+            socket,
+            model,
+        } => client::run_chat_loop(socket, prompt, model).await,
         cli::Command::Acp { model, socket } => agent_server::run(model, socket).await,
         cli::Command::Models => models::run().await,
         cli::Command::Memory { action, socket } => run_memory(action, socket).await,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -431,7 +431,7 @@ async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<Stri
 
     // Fix 5: child agents do not get spawn_agent in their tool schema to
     // prevent unbounded recursion at the schema level.
-    let (final_text, _) = crate::daemon::run_agentic_loop(
+    let (final_text, _, _) = crate::daemon::run_agentic_loop(
         &child_state,
         &model,
         messages,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -27,7 +27,7 @@ use support::{
     helpers::{
         collect_text, connect_client, seed_cron_job, send_message, send_message_with_session,
         send_resume, setup_home, start_daemon, start_daemon_at_home_with_env,
-        start_daemon_with_env, Request, Response,
+        start_daemon_with_env, LongChatConnection, Request, Response,
     },
     mock_llm::{MockLlmServer, ScriptedResponse},
 };
@@ -2042,3 +2042,329 @@ async fn gemini_models_route_via_copilot_and_succeed() {
 // Verifies that when /chat/completions returns 400 unsupported_api_for_model
 // the daemon automatically retries via /v1/responses and delivers the
 // response to the client.
+
+// ===========================================================================
+// amaebi chat long-connection regression tests
+// ===========================================================================
+//
+// These tests use a single persistent socket connection (LongChatConnection)
+// to send multiple Chat requests, mirroring what `amaebi chat` does.
+
+// ---------------------------------------------------------------------------
+// LC-1. Multi-turn plain text context on one connection
+// ---------------------------------------------------------------------------
+
+/// Two Chat turns on the same socket: Turn 2's LLM request must include the
+/// user message and assistant reply from Turn 1.
+#[tokio::test]
+async fn chat_long_connection_multi_turn_context() {
+    let server = MockLlmServer::start().await;
+    server.enqueue(ScriptedResponse::text_chunks(vec!["The answer is 42."]));
+    server.enqueue(ScriptedResponse::text_chunks(vec!["That is 84."]));
+
+    let daemon = start_daemon(&server.url()).await.expect("start_daemon");
+    let session_id = "lc-plain-001";
+
+    let mut conn = LongChatConnection::connect(&daemon.socket)
+        .await
+        .expect("connect");
+
+    // Turn 1.
+    let r1 = conn
+        .chat("what is 6 times 7?", session_id, "gpt-4o")
+        .await
+        .expect("turn 1");
+    assert!(
+        collect_text(&r1).contains("42"),
+        "turn 1: {:?}",
+        collect_text(&r1)
+    );
+
+    // Turn 2 — same connection.
+    let r2 = conn
+        .chat("double that", session_id, "gpt-4o")
+        .await
+        .expect("turn 2");
+    assert!(
+        collect_text(&r2).contains("84"),
+        "turn 2: {:?}",
+        collect_text(&r2)
+    );
+
+    let reqs = server.take_requests();
+    assert_eq!(reqs.len(), 2, "expected 2 LLM requests, got {}", reqs.len());
+
+    let msgs2 = reqs[1]
+        .body
+        .get("messages")
+        .and_then(|m| m.as_array())
+        .expect("messages");
+
+    let has_user1 = msgs2.iter().any(|m| {
+        m.get("role").and_then(|r| r.as_str()) == Some("user")
+            && m.get("content")
+                .and_then(|c| c.as_str())
+                .map(|s| s.contains("6 times 7"))
+                .unwrap_or(false)
+    });
+    assert!(
+        has_user1,
+        "turn 2 must include turn 1 user; messages: {msgs2:#?}"
+    );
+
+    let has_asst1 = msgs2.iter().any(|m| {
+        m.get("role").and_then(|r| r.as_str()) == Some("assistant")
+            && m.get("content")
+                .and_then(|c| c.as_str())
+                .map(|s| s.contains("42"))
+                .unwrap_or(false)
+    });
+    assert!(
+        has_asst1,
+        "turn 2 must include turn 1 assistant; messages: {msgs2:#?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LC-2. Tool context preserved across turns (key difference from short-conn)
+// ---------------------------------------------------------------------------
+
+/// Turn 1 executes a tool. Turn 2's LLM request must contain the raw
+/// tool_call and tool_result messages from Turn 1 — not just the text summary.
+/// This is the critical regression that proves the messages array stays alive
+/// in memory across turns (no need for session_turns table).
+#[tokio::test]
+async fn chat_long_connection_tool_context_preserved() {
+    let server = MockLlmServer::start().await;
+    // Turn 1: tool call then final text.
+    server.enqueue(ScriptedResponse::tool_call(
+        "t1",
+        "shell_command",
+        r#"{"command":"echo hello"}"#,
+    ));
+    server.enqueue(ScriptedResponse::text_chunks(vec!["The tool said hello."]));
+    // Turn 2.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["Got it."]));
+
+    let daemon = start_daemon(&server.url()).await.expect("start_daemon");
+    let session_id = "lc-tool-001";
+
+    let mut conn = LongChatConnection::connect(&daemon.socket)
+        .await
+        .expect("connect");
+
+    let r1 = conn
+        .chat("run echo hello", session_id, "gpt-4o")
+        .await
+        .expect("turn 1");
+    assert!(
+        collect_text(&r1).contains("hello"),
+        "turn 1: {:?}",
+        collect_text(&r1)
+    );
+
+    let _r2 = conn
+        .chat("what did the tool return?", session_id, "gpt-4o")
+        .await
+        .expect("turn 2");
+
+    let reqs = server.take_requests();
+    // 3 requests: turn1-step1 (tool call), turn1-step2 (final text), turn2
+    assert_eq!(reqs.len(), 3, "expected 3 LLM requests, got {}", reqs.len());
+
+    let msgs2 = reqs[2]
+        .body
+        .get("messages")
+        .and_then(|m| m.as_array())
+        .expect("messages in turn 2");
+
+    // Must contain the assistant tool-call message from Turn 1.
+    let has_tool_call = msgs2.iter().any(|m| {
+        m.get("role").and_then(|r| r.as_str()) == Some("assistant")
+            && m.get("tool_calls")
+                .and_then(|tc| tc.as_array())
+                .map(|a| !a.is_empty())
+                .unwrap_or(false)
+    });
+    assert!(
+        has_tool_call,
+        "turn 2 must include turn 1 tool_call message; messages: {msgs2:#?}"
+    );
+
+    // Must contain the tool result message from Turn 1.
+    let has_tool_result = msgs2
+        .iter()
+        .any(|m| m.get("role").and_then(|r| r.as_str()) == Some("tool"));
+    assert!(
+        has_tool_result,
+        "turn 2 must include turn 1 tool_result message; messages: {msgs2:#?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LC-3. Steer injected mid-turn on the same connection
+// ---------------------------------------------------------------------------
+
+/// While Turn 1 is executing a tool (giving time for steer to arrive), send a
+/// Steer on the same connection. The daemon must return SteerAck and the final
+/// LLM request must include the steer text.
+#[tokio::test]
+async fn chat_long_connection_steer_mid_turn() {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::UnixStream;
+
+    let server = MockLlmServer::start().await;
+    // Turn 1: slow tool call (sleep 0.3s) so steer can arrive during execution.
+    server.enqueue(ScriptedResponse::tool_call(
+        "t1",
+        "shell_command",
+        r#"{"command":"sleep 0.3"}"#,
+    ));
+    server.enqueue(ScriptedResponse::text_chunks(vec!["steer-acknowledged"]));
+
+    let daemon = start_daemon(&server.url()).await.expect("start_daemon");
+    let session_id = "lc-steer-001";
+
+    // Open the raw socket so we can interleave reads and writes.
+    let stream = UnixStream::connect(&daemon.socket).await.expect("connect");
+    let (reader, mut writer) = stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+
+    // Send Chat request.
+    let chat_req = Request::Chat {
+        prompt: "run sleep 0.3".to_string(),
+        tmux_pane: None,
+        session_id: Some(session_id.to_string()),
+        model: "gpt-4o".to_string(),
+    };
+    let mut line = serde_json::to_string(&chat_req).unwrap();
+    line.push('\n');
+    writer.write_all(line.as_bytes()).await.unwrap();
+
+    // Wait a bit then send Steer on the same socket while tool is running.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let steer_req = Request::Steer {
+        session_id: session_id.to_string(),
+        message: "actually just return hi".to_string(),
+    };
+    let mut steer_line = serde_json::to_string(&steer_req).unwrap();
+    steer_line.push('\n');
+    writer.write_all(steer_line.as_bytes()).await.unwrap();
+
+    // Collect all response frames until Done.
+    let mut responses = Vec::new();
+    while let Some(l) = tokio::time::timeout(std::time::Duration::from_secs(10), lines.next_line())
+        .await
+        .expect("timeout")
+        .expect("read error")
+    {
+        if l.is_empty() {
+            continue;
+        }
+        let frame: Response = serde_json::from_str(&l).expect("parse frame");
+        let done = matches!(frame, Response::Done | Response::Error { .. });
+        responses.push(frame);
+        if done {
+            break;
+        }
+    }
+
+    // SteerAck must have been received.
+    assert!(
+        responses.iter().any(|r| matches!(r, Response::SteerAck)),
+        "expected SteerAck in responses: {responses:?}"
+    );
+
+    // The final LLM request must include the steer text.
+    let reqs = server.take_requests();
+    let last_req = reqs.last().expect("at least one LLM request");
+    let msgs = last_req
+        .body
+        .get("messages")
+        .and_then(|m| m.as_array())
+        .expect("messages");
+    let has_steer = msgs.iter().any(|m| {
+        m.get("content")
+            .and_then(|c| c.as_str())
+            .map(|s| s.contains("actually just return hi"))
+            .unwrap_or(false)
+    });
+    assert!(
+        has_steer,
+        "steer text must appear in LLM request; messages: {msgs:#?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LC-4. EOF on long connection exits cleanly, daemon stays alive
+// ---------------------------------------------------------------------------
+
+/// Drop the long connection (EOF) then open a new one — daemon must still work.
+#[tokio::test]
+async fn chat_long_connection_eof_exits_cleanly() {
+    let server = MockLlmServer::start().await;
+    server.enqueue(ScriptedResponse::text_chunks(vec!["hello"]));
+    server.enqueue(ScriptedResponse::text_chunks(vec!["world"]));
+
+    let daemon = start_daemon(&server.url()).await.expect("start_daemon");
+
+    // Use the same session_id for both connections so cross-session compaction
+    // doesn't fire (which would consume mock responses unexpectedly).
+    let session_id = "lc-eof-session";
+
+    // Connection 1: one turn then drop (EOF).
+    {
+        let mut conn = LongChatConnection::connect(&daemon.socket)
+            .await
+            .expect("conn1");
+        let r = conn
+            .chat("hello", session_id, "gpt-4o")
+            .await
+            .expect("turn on conn1");
+        assert!(collect_text(&r).contains("hello"));
+        // conn dropped here → EOF
+    }
+
+    // Connection 2: daemon must still respond normally.
+    let mut conn2 = LongChatConnection::connect(&daemon.socket)
+        .await
+        .expect("conn2");
+    let r2 = conn2
+        .chat("world", session_id, "gpt-4o")
+        .await
+        .expect("turn on conn2");
+    assert!(
+        collect_text(&r2).contains("world"),
+        "daemon must survive EOF: {:?}",
+        collect_text(&r2)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LC-5. amaebi ask (single-turn) still works unchanged
+// ---------------------------------------------------------------------------
+
+/// `amaebi ask` uses a short connection (connect, send Chat, receive Done,
+/// disconnect). This must be unaffected by the long-connection changes.
+#[tokio::test]
+async fn chat_long_connection_ask_still_single_turn() {
+    let server = MockLlmServer::start().await;
+    server.enqueue(ScriptedResponse::text_chunks(vec!["single turn ok"]));
+
+    let daemon = start_daemon(&server.url()).await.expect("start_daemon");
+    let client = connect_client(&daemon.socket);
+
+    let responses = send_message(&client, "hello").await.expect("send_message");
+    assert!(
+        collect_text(&responses).contains("single turn ok"),
+        "amaebi ask must work unchanged: {:?}",
+        collect_text(&responses)
+    );
+    assert!(
+        responses.iter().any(|r| matches!(r, Response::Done)),
+        "must get Done: {responses:?}"
+    );
+
+    let reqs = server.take_requests();
+    assert_eq!(reqs.len(), 1, "exactly 1 LLM request for single turn");
+}

--- a/tests/support/helpers.rs
+++ b/tests/support/helpers.rs
@@ -478,6 +478,97 @@ pub async fn send_request(client: &ClientHandle, req: &Request) -> Result<Vec<Re
     Ok(responses)
 }
 
+// ---------------------------------------------------------------------------
+// Long-connection helper for amaebi chat tests
+// ---------------------------------------------------------------------------
+
+/// A persistent daemon connection that can send multiple Chat requests on the
+/// same socket, simulating what `amaebi chat` does (long connection).
+pub struct LongChatConnection {
+    writer: tokio::io::WriteHalf<UnixStream>,
+    reader: BufReader<tokio::io::ReadHalf<UnixStream>>,
+}
+
+impl LongChatConnection {
+    /// Open a persistent connection to the daemon.
+    pub async fn connect(socket: &Path) -> Result<Self> {
+        let stream = UnixStream::connect(socket)
+            .await
+            .context("connecting to daemon")?;
+        let (reader, writer) = tokio::io::split(stream);
+        Ok(Self {
+            writer,
+            reader: BufReader::new(reader),
+        })
+    }
+
+    /// Read one newline-delimited response frame from the connection.
+    async fn read_frame(&mut self) -> Result<Option<Response>> {
+        let mut line = String::new();
+        let n = self.reader.read_line(&mut line).await?;
+        if n == 0 {
+            return Ok(None); // EOF
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+        let frame: Response = serde_json::from_str(trimmed)
+            .with_context(|| format!("parsing response: {trimmed:?}"))?;
+        Ok(Some(frame))
+    }
+
+    /// Send a Chat request and collect all response frames until Done/Error.
+    pub async fn chat(
+        &mut self,
+        prompt: &str,
+        session_id: &str,
+        model: &str,
+    ) -> Result<Vec<Response>> {
+        let req = Request::Chat {
+            prompt: prompt.to_string(),
+            tmux_pane: None,
+            session_id: Some(session_id.to_string()),
+            model: model.to_string(),
+        };
+        let mut line = serde_json::to_string(&req)?;
+        line.push('\n');
+        self.writer.write_all(line.as_bytes()).await?;
+
+        let mut responses = Vec::new();
+        tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                match self.read_frame().await? {
+                    None => break,
+                    Some(frame) => {
+                        let done = matches!(frame, Response::Done | Response::Error { .. });
+                        responses.push(frame);
+                        if done {
+                            break;
+                        }
+                    }
+                }
+            }
+            Ok::<(), anyhow::Error>(())
+        })
+        .await
+        .context("chat turn timed out after 30 s")??;
+        Ok(responses)
+    }
+
+    /// Send a Steer request on this connection (same socket as the Chat).
+    pub async fn steer(&mut self, session_id: &str, message: &str) -> Result<()> {
+        let req = Request::Steer {
+            session_id: session_id.to_string(),
+            message: message.to_string(),
+        };
+        let mut line = serde_json::to_string(&req)?;
+        line.push('\n');
+        self.writer.write_all(line.as_bytes()).await?;
+        Ok(())
+    }
+}
+
 /// Collect all text chunks from a list of responses into a single string.
 pub fn collect_text(responses: &[Response]) -> String {
     responses


### PR DESCRIPTION
## What

Adds \`amaebi chat\` — a persistent interactive REPL backed by a single long-lived socket connection per session.

\`\`\`
$ amaebi chat "what files are here?"
[model calls ls, replies]

> what's in main.rs?
[model calls read_file — sees the actual file content, not just a summary]

> what does line 42 do?
[model answers correctly because read_file output is still in context]

> [Ctrl-D to exit]
Session ended. ID: abc-123
\`\`\`

## Why long connection

The short-connection approach (one socket per turn) discards all tool-call context between turns — the daemon only persists \`(user_text, assistant_text)\` in \`memories\`. On the next turn the model sees a plain-text summary, not the raw tool output.

With a long connection the daemon keeps \`messages: Vec<Message>\` alive in memory. Every tool call, tool result, and assistant reply from prior turns stays in context automatically — **no extra DB tables needed**.

## Architecture

\`\`\`
client                         daemon handle_connection (loop)
──────                         ──────────────────────────────
connect ──────────────────────→ forwarding task reads all frames → channel
Chat("q1") ──────────────────→ first turn: load history from DB
                                spawn agentic loop (holds Arc<Mutex<writer>>)
                                main task routes Steer/Interrupt via select!
← Text… Done ─────────────────
Chat("q2") ──────────────────→ subsequent turn: push q2 onto carried messages
                                spawn agentic loop (full q1 context in memory)
← Text… Done ─────────────────
[EOF / Ctrl-D] ───────────────→ forwarding task sees EOF → break
\`\`\`

**Ctrl-C mid-generation** sends \`Interrupt\` + shows correction prompt, identical to \`amaebi ask\`.

## Files changed

| File | Change |
|------|--------|
| \`src/daemon.rs\` | \`handle_connection\` loop; forwarding task; \`Arc<Mutex<OwnedWriteHalf>>\`; \`run_agentic_loop\` returns \`Vec<Message>\`; final assistant reply pushed before return |
| \`src/client.rs\` | \`run_chat_loop\`: single socket, Ctrl-C/steer/WaitingForInput handling |
| \`src/cli.rs\` | \`Chat\` subcommand |
| \`src/main.rs\` | dispatch + inbox notification |
| \`src/tools.rs\` / \`src/agent_server.rs\` | updated for 3-tuple return |
| \`tests/support/helpers.rs\` | \`LongChatConnection\` test helper |
| \`tests/integration_tests.rs\` | 5 regression tests |

## Regression tests

| Test | Verifies |
|------|---------|
| \`chat_long_connection_multi_turn_context\` | Turn 2 sees turn 1 user + assistant |
| \`chat_long_connection_tool_context_preserved\` | **Key**: turn 2 sees raw \`tool_call\` + \`tool\` messages from turn 1 |
| \`chat_long_connection_steer_mid_turn\` | Steer on same connection → SteerAck + steer text in LLM request |
| \`chat_long_connection_eof_exits_cleanly\` | EOF → daemon stays alive, next connection works |
| \`chat_long_connection_ask_still_single_turn\` | \`amaebi ask\` behaviour unchanged |

## Test plan

- [x] 35/35 pass including all ignored (Docker sandbox, parallel timing)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy -- -D warnings\` zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)