### PR TITLE
refactor: extract shared retry utilities into retry.rs

### DIFF
--- a/src/bedrock.rs
+++ b/src/bedrock.rs
@@ -12,8 +12,9 @@ use anyhow::{Context, Result};
 use futures_util::StreamExt;
 use tokio::io::AsyncWriteExt;
 
-use crate::copilot::{backoff_delay, CopilotResponse, FinishReason, Message, ToolCall};
+use crate::copilot::{CopilotResponse, FinishReason, Message, ToolCall};
 use crate::ipc::{write_frame, Response};
+use crate::retry::{backoff_delay, parse_retry_after_header};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -21,9 +22,6 @@ use crate::ipc::{write_frame, Response};
 
 /// Maximum retries for transient errors (same policy as copilot.rs).
 const MAX_RETRIES: u32 = 3;
-
-/// Cap on `Retry-After` header values.
-const MAX_RETRY_AFTER_SECS: u64 = 30;
 
 /// Default AWS region when `AWS_REGION` is not set.
 const DEFAULT_REGION: &str = "us-east-1";
@@ -703,13 +701,7 @@ async fn send_with_retry(
                         body: body_text,
                     }));
                 }
-                let delay = resp
-                    .headers()
-                    .get(reqwest::header::RETRY_AFTER)
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|s| s.parse::<u64>().ok())
-                    .filter(|&s| s > 0)
-                    .map(|s| std::time::Duration::from_secs(s.min(MAX_RETRY_AFTER_SECS)))
+                let delay = parse_retry_after_header(resp.headers())
                     .unwrap_or_else(|| backoff_delay(attempt));
                 tracing::warn!(
                     attempt,

--- a/src/copilot.rs
+++ b/src/copilot.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 
 use crate::ipc::{write_frame, Response};
@@ -35,13 +34,6 @@ pub(crate) fn chat_endpoint(base_url: &str) -> String {
 /// How many times to retry transient failures (5xx, 429, network errors)
 /// before surfacing the error to the caller.
 const MAX_RETRIES: u32 = 3;
-
-/// Base delay for exponential backoff: attempt 0 → 1 s, 1 → 2 s, 2 → 4 s.
-const BACKOFF_BASE_MS: u64 = 1_000;
-
-/// Hard ceiling on a Retry-After value.  Prevents hanging for unreasonably
-/// long server-imposed back-off windows.
-const MAX_RETRY_AFTER_SECS: u64 = 30;
 
 // ---------------------------------------------------------------------------
 // Typed HTTP error — lets callers inspect the status and body
@@ -342,38 +334,11 @@ impl SseAccumulator {
 }
 
 // ---------------------------------------------------------------------------
-// Retry helpers
+// Retry helpers (shared utilities re-exported from retry module)
 // ---------------------------------------------------------------------------
 
-/// Exponential back-off delay for `attempt` (0-indexed).
-///
-/// Returns 1 s, 2 s, 4 s for attempts 0, 1, 2.  The exponent is capped at
-/// 10, so the delay saturates at `BACKOFF_BASE_MS << 10` (about 17 minutes),
-/// but in practice `MAX_RETRIES` is 3 so the maximum used delay is 4 s.
-pub(crate) fn backoff_delay(attempt: u32) -> Duration {
-    Duration::from_millis(BACKOFF_BASE_MS << attempt.min(10))
-}
-
-/// Parse the `Retry-After` response header into a `Duration`.
-///
-/// Accepts an integer number of seconds only (date-form is not handled).
-/// Caps the returned delay at [`MAX_RETRY_AFTER_SECS`] to prevent the daemon
-/// from sleeping for unreasonably long periods.
-pub(crate) fn parse_retry_after(resp: &reqwest::Response) -> Option<Duration> {
-    parse_retry_after_header(resp.headers())
-}
-
-/// Parse the `Retry-After` header from a [`HeaderMap`] into a [`Duration`].
-///
-/// Factored out of [`parse_retry_after`] so it can be tested without
-/// constructing a full `reqwest::Response`.
-pub(crate) fn parse_retry_after_header(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
-    headers
-        .get(reqwest::header::RETRY_AFTER)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<u64>().ok())
-        .map(|secs| Duration::from_secs(secs.min(MAX_RETRY_AFTER_SECS)))
-}
+/// Exponential back-off: 1 s, 2 s, 4 s for attempts 0, 1, 2 (capped at 10).
+pub(crate) use crate::retry::backoff_delay;
 
 /// Send a single chat-completions POST to Copilot with a transparent retry
 /// policy for transient failures.
@@ -443,7 +408,8 @@ async fn send_with_retry(
                         body: body_text,
                     }));
                 }
-                let delay = parse_retry_after(&resp).unwrap_or_else(|| backoff_delay(attempt));
+                let delay = crate::retry::parse_retry_after_header(resp.headers())
+                    .unwrap_or_else(|| backoff_delay(attempt));
                 tracing::warn!(
                     attempt,
                     delay_ms = delay.as_millis(),
@@ -631,7 +597,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::retry::{parse_retry_after_header, MAX_RETRY_AFTER_SECS};
     use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
+    use std::time::Duration;
 
     // ---- chat_endpoint -----------------------------------------------------
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod memory_db;
 mod models;
 mod provider;
 mod responses;
+mod retry;
 mod sandbox;
 mod session;
 #[cfg(test)]

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -13,10 +13,9 @@ use anyhow::{Context, Result};
 use futures_util::StreamExt;
 use tokio::io::AsyncWriteExt;
 
-use crate::copilot::{
-    backoff_delay, CopilotHttpError, CopilotResponse, FinishReason, Message, ToolCall,
-};
+use crate::copilot::{CopilotHttpError, CopilotResponse, FinishReason, Message, ToolCall};
 use crate::ipc::{write_frame, Response};
+use crate::retry::{backoff_delay, parse_retry_after_header};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -48,7 +47,6 @@ fn responses_endpoint(base_url: &str) -> String {
     format!("{}/v1/responses", base_url.trim_end_matches('/'))
 }
 const MAX_RETRIES: u32 = 3;
-const MAX_RETRY_AFTER_SECS: u64 = 30;
 
 // ---------------------------------------------------------------------------
 // Message format conversion: Chat Completions → Responses API
@@ -238,19 +236,8 @@ async fn send_with_retry(
                         body: body_text,
                     }));
                 }
-                let delay = {
-                    let secs = resp
-                        .headers()
-                        .get(reqwest::header::RETRY_AFTER)
-                        .and_then(|v| v.to_str().ok())
-                        .and_then(|s| s.parse::<u64>().ok())
-                        .unwrap_or(0);
-                    if secs > 0 {
-                        std::time::Duration::from_secs(secs.min(MAX_RETRY_AFTER_SECS))
-                    } else {
-                        backoff_delay(attempt)
-                    }
-                };
+                let delay = parse_retry_after_header(resp.headers())
+                    .unwrap_or_else(|| backoff_delay(attempt));
                 tracing::warn!(
                     attempt,
                     delay_ms = delay.as_millis(),

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,111 @@
+//! Shared HTTP retry utilities used by all provider backends.
+//!
+//! Extracted from `copilot.rs` so that `bedrock.rs` and `responses.rs` can
+//! share the same exponential back-off formula and `Retry-After` header
+//! parsing without going through `copilot`.
+
+use std::time::Duration;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Base delay for exponential backoff: attempt 0 → 1 s, 1 → 2 s, 2 → 4 s.
+pub const BACKOFF_BASE_MS: u64 = 1_000;
+
+/// Hard ceiling on a `Retry-After` header value.  Prevents hanging for
+/// unreasonably long server-imposed back-off windows.
+pub const MAX_RETRY_AFTER_SECS: u64 = 30;
+
+// ---------------------------------------------------------------------------
+// Retry helpers
+// ---------------------------------------------------------------------------
+
+/// Exponential back-off delay for `attempt` (0-indexed).
+///
+/// Returns 1 s, 2 s, 4 s for attempts 0, 1, 2.  The exponent is capped at
+/// 10, so the delay saturates at `BACKOFF_BASE_MS << 10` (about 17 minutes),
+/// but in practice `MAX_RETRIES` is 3 so the maximum used delay is 4 s.
+pub fn backoff_delay(attempt: u32) -> Duration {
+    Duration::from_millis(BACKOFF_BASE_MS << attempt.min(10))
+}
+
+/// Parse the `Retry-After` response header from a [`reqwest::header::HeaderMap`]
+/// into a [`Duration`].
+///
+/// Accepts an integer number of seconds only (date-form is not handled).
+/// Returns `None` when the header is absent, non-numeric, or zero.
+/// Caps the returned delay at [`MAX_RETRY_AFTER_SECS`] to prevent the daemon
+/// from sleeping for unreasonably long periods.
+pub fn parse_retry_after_header(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let secs = headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&s| s > 0)?;
+    Some(Duration::from_secs(secs.min(MAX_RETRY_AFTER_SECS)))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::{HeaderMap, HeaderValue, RETRY_AFTER};
+
+    #[test]
+    fn backoff_delay_increases_exponentially() {
+        assert_eq!(backoff_delay(0), Duration::from_millis(1_000));
+        assert_eq!(backoff_delay(1), Duration::from_millis(2_000));
+        assert_eq!(backoff_delay(2), Duration::from_millis(4_000));
+    }
+
+    #[test]
+    fn backoff_delay_saturates_at_high_attempt() {
+        // Must not panic on large attempt numbers.
+        let _ = backoff_delay(30);
+        let _ = backoff_delay(u32::MAX);
+    }
+
+    #[test]
+    fn parse_retry_after_header_missing() {
+        let headers = HeaderMap::new();
+        assert_eq!(parse_retry_after_header(&headers), None);
+    }
+
+    #[test]
+    fn parse_retry_after_header_invalid_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("not-a-number"));
+        assert_eq!(parse_retry_after_header(&headers), None);
+    }
+
+    #[test]
+    fn parse_retry_after_header_zero_returns_none() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("0"));
+        assert_eq!(parse_retry_after_header(&headers), None);
+    }
+
+    #[test]
+    fn parse_retry_after_header_valid_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, HeaderValue::from_static("10"));
+        let dur = parse_retry_after_header(&headers).expect("expected Some(Duration)");
+        assert_eq!(dur, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn parse_retry_after_header_caps_large_values() {
+        let mut headers = HeaderMap::new();
+        let large = (MAX_RETRY_AFTER_SECS.saturating_add(10)).to_string();
+        headers.insert(
+            RETRY_AFTER,
+            HeaderValue::from_str(&large).expect("valid header value"),
+        );
+        let dur = parse_retry_after_header(&headers).expect("expected Some(Duration)");
+        assert_eq!(dur, Duration::from_secs(MAX_RETRY_AFTER_SECS));
+    }
+}


### PR DESCRIPTION
## Summary
- New `src/retry.rs` with `backoff_delay()` and `parse_retry_after_header()` shared across all three provider backends (bedrock, copilot, responses)
- `bedrock.rs`: drop local `MAX_RETRY_AFTER_SECS` constant, import from `retry`
- `copilot.rs`: remove duplicated `backoff_delay`/`parse_retry_after_header` functions and `BACKOFF_BASE_MS`/`MAX_RETRY_AFTER_SECS` constants; remove the thin `parse_retry_after()` wrapper (one-line function used once, inlined)
- `responses.rs`: same cleanup, references `retry::` directly
- All three providers keep their own `MAX_RETRIES` since retry counts could reasonably diverge per provider

## Behavior note: `Retry-After: 0` now falls back to backoff

The old `copilot.rs` implementation returned `Some(Duration::from_secs(0))` for `Retry-After: 0`, causing an immediate retry (sleep 0 s). The new `parse_retry_after_header` filters out zero with `.filter(|&s| s > 0)` and returns `None`, falling back to `backoff_delay(attempt)` (minimum 1 s).

This is an intentional improvement: `Retry-After: 0` + `sleep(0)` is a no-op that could allow a tight retry loop if a misbehaving server keeps sending `0`. Falling back to exponential backoff is safer. No production API is expected to send `Retry-After: 0` with the intent of requesting an immediate retry — the RFC permits it but it is a pathological edge case.

## Test plan
- [x] `cargo test` — 33 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)