### PR TITLE
fix(cron): replace panic! with unreachable! in test assertions

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -435,11 +435,11 @@ mod tests {
     fn parse_specific_values_single_field() {
         let s = parse_schedule("30 9 15 3 1").unwrap();
         let FieldSpec::Values(ref mins) = s.minute else {
-            panic!("expected Values for minute")
+            unreachable!("expected Values for minute")
         };
         assert_eq!(mins, &[30]);
         let FieldSpec::Values(ref hours) = s.hour else {
-            panic!("expected Values for hour")
+            unreachable!("expected Values for hour")
         };
         assert_eq!(hours, &[9]);
     }
@@ -448,7 +448,7 @@ mod tests {
     fn parse_step_every_15_minutes() {
         let s = parse_schedule("*/15 * * * *").unwrap();
         let FieldSpec::Values(ref mins) = s.minute else {
-            panic!("expected Values")
+            unreachable!("expected Values")
         };
         assert_eq!(mins, &[0, 15, 30, 45]);
     }
@@ -457,7 +457,7 @@ mod tests {
     fn parse_range_9_to_17() {
         let s = parse_schedule("0 9-17 * * *").unwrap();
         let FieldSpec::Values(ref hours) = s.hour else {
-            panic!("expected Values")
+            unreachable!("expected Values")
         };
         assert_eq!(hours, &(9u32..=17).collect::<Vec<_>>());
     }
@@ -466,7 +466,7 @@ mod tests {
     fn parse_comma_list_dom() {
         let s = parse_schedule("0 0 1,15 * *").unwrap();
         let FieldSpec::Values(ref doms) = s.dom else {
-            panic!("expected Values")
+            unreachable!("expected Values")
         };
         assert_eq!(doms, &[1, 15]);
     }


### PR DESCRIPTION
## Summary
- Replace 5 `panic!()` calls in `cron.rs` test functions with `unreachable!()`
- These are all in `let-else` arms that verify a parsed `FieldSpec` is the expected `Values` variant
- `unreachable!()` is semantically correct here: it asserts "this path cannot be reached given the test input", whereas `panic!()` implies a recoverable runtime error

## Test plan
- [x] `cargo test` — 33 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)