### PR TITLE
refactor(daemon): split handle_connection into sub-handlers + extract with_db helper

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -626,7 +626,6 @@ async fn drive_agentic_loop(
         )
         .await
     });
-    let expected = expected_sid.to_owned();
     let result = loop {
         tokio::select! { biased;
             r = &mut loop_handle => {
@@ -644,12 +643,12 @@ async fn drive_agentic_loop(
                 Some(line) => {
                     if let Ok(req) = serde_json::from_str::<Request>(&line) {
                         match req {
-                            Request::Steer { session_id: sid, message } if sid == expected => {
+                            Request::Steer { session_id: sid, message } if sid == expected_sid => {
                                 if !message.is_empty() {
                                     let _ = steer_tx.send(Some(message)).await;
                                 }
                             }
-                            Request::Interrupt { session_id: sid } if sid == expected => {
+                            Request::Interrupt { session_id: sid } if sid == expected_sid => {
                                 let _ = steer_tx.send(None).await;
                             }
                             Request::Steer { .. } | Request::Interrupt { .. } => {


### PR DESCRIPTION
## Summary

- **`with_db` helper**: Eliminates ~18 repetitions of the `spawn_blocking` + mutex-lock boilerplate for SQLite access into a single typed async helper.
- **Sub-handler extraction**: `handle_connection`'s 645-line match body is split into five focused async functions (`handle_clear_memory`, `handle_store_memory`, `handle_retrieve_context`, `handle_chat_request`, `handle_resume_request`), each returning `anyhow::Result<ConnAction>`.
- **`drive_agentic_loop` unification**: The near-duplicate steer-routing select loop that appeared in both agentic handlers is unified into one helper, using `Option<Result<…>>` as the return type (`None` = client disconnected, `Some(result)` = loop finished).
- **`truncate_chars` signature fix**: Changed from `String` → `&str` parameter, removing all `.clone()` call sites at every call.
- **`ConnAction` / `ConnState`**: New types to communicate break/continue decisions across function boundaries cleanly.

## Test plan

- [x] `cargo test` — all 33 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)