### PR TITLE
fix(daemon): skip Copilot token check for Bedrock models

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -270,6 +270,16 @@ fn compaction_threshold_tokens(model: &str) -> usize {
 }
 
 // ---------------------------------------------------------------------------
+// Provider auth helpers
+// ---------------------------------------------------------------------------
+
+/// Returns true when the resolved provider for `model` is Copilot, meaning a
+/// token pre-flight check is required before dispatching the request.
+fn needs_copilot_auth(model: &str) -> bool {
+    crate::provider::resolve(model).provider == crate::provider::ProviderKind::Copilot
+}
+
+// ---------------------------------------------------------------------------
 // Listener loop
 // ---------------------------------------------------------------------------
 
@@ -504,9 +514,7 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                 session_id,
             } => {
                 tracing::info!(model = %model, prompt_len = prompt.len(), "received detach request");
-                if crate::provider::resolve(&model).provider
-                    == crate::provider::ProviderKind::Copilot
-                {
+                if needs_copilot_auth(&model) {
                     if let Err(e) = state.tokens.get(&state.http).await {
                         let mut w = writer.lock().await;
                         write_frame(
@@ -821,7 +829,7 @@ async fn handle_resume_request(
             return Ok(ConnAction::Continue);
         }
     };
-    if crate::provider::resolve(&model).provider == crate::provider::ProviderKind::Copilot {
+    if needs_copilot_auth(&model) {
         if let Err(e) = state.tokens.get(&state.http).await {
             let mut w = writer.lock().await;
             write_frame(
@@ -923,7 +931,7 @@ async fn handle_chat_request(
         }
     }
 
-    if crate::provider::resolve(&model).provider == crate::provider::ProviderKind::Copilot {
+    if needs_copilot_auth(&model) {
         if let Err(e) = state.tokens.get(&state.http).await {
             let mut w = writer.lock().await;
             write_frame(
@@ -3055,5 +3063,31 @@ mod tests {
             "user",
             "without steer text there must be no trailing user message"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // needs_copilot_auth tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn bedrock_models_do_not_require_copilot_auth() {
+        // Bedrock inference profiles must NOT trigger Copilot token pre-flight.
+        assert!(!needs_copilot_auth(
+            "us.anthropic.claude-opus-4-6-20251101-v1:0"
+        ));
+        assert!(!needs_copilot_auth(
+            "us.anthropic.claude-sonnet-4-6-20251101-v1:0"
+        ));
+        assert!(!needs_copilot_auth(
+            "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        ));
+    }
+
+    #[test]
+    fn copilot_models_require_copilot_auth() {
+        // Models explicitly routed through the Copilot provider must trigger auth.
+        assert!(needs_copilot_auth("copilot/claude-opus-4-6-20251101"));
+        assert!(needs_copilot_auth("copilot/claude-sonnet-4-5"));
+        assert!(needs_copilot_auth("copilot/gpt-4o"));
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -504,16 +504,20 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                 session_id,
             } => {
                 tracing::info!(model = %model, prompt_len = prompt.len(), "received detach request");
-                if let Err(e) = state.tokens.get(&state.http).await {
-                    let mut w = writer.lock().await;
-                    write_frame(
-                        &mut *w,
-                        &Response::Error {
-                            message: format!("authentication error: {e:#}"),
-                        },
-                    )
-                    .await?;
-                    break 'connection;
+                if crate::provider::resolve(&model).provider
+                    == crate::provider::ProviderKind::Copilot
+                {
+                    if let Err(e) = state.tokens.get(&state.http).await {
+                        let mut w = writer.lock().await;
+                        write_frame(
+                            &mut *w,
+                            &Response::Error {
+                                message: format!("authentication error: {e:#}"),
+                            },
+                        )
+                        .await?;
+                        break 'connection;
+                    }
                 }
                 let sid = session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
                 {
@@ -817,16 +821,18 @@ async fn handle_resume_request(
             return Ok(ConnAction::Continue);
         }
     };
-    if let Err(e) = state.tokens.get(&state.http).await {
-        let mut w = writer.lock().await;
-        write_frame(
-            &mut *w,
-            &Response::Error {
-                message: format!("authentication error: {e:#}"),
-            },
-        )
-        .await?;
-        return Ok(ConnAction::Break);
+    if crate::provider::resolve(&model).provider == crate::provider::ProviderKind::Copilot {
+        if let Err(e) = state.tokens.get(&state.http).await {
+            let mut w = writer.lock().await;
+            write_frame(
+                &mut *w,
+                &Response::Error {
+                    message: format!("authentication error: {e:#}"),
+                },
+            )
+            .await?;
+            return Ok(ConnAction::Break);
+        }
     }
     let (history, summaries, own_summary) = load_session_state(state, &session_id).await;
     let (messages, _) = build_and_trim_messages(
@@ -917,16 +923,18 @@ async fn handle_chat_request(
         }
     }
 
-    if let Err(e) = state.tokens.get(&state.http).await {
-        let mut w = writer.lock().await;
-        write_frame(
-            &mut *w,
-            &Response::Error {
-                message: format!("authentication error: {e:#}"),
-            },
-        )
-        .await?;
-        return Ok(ConnAction::Break);
+    if crate::provider::resolve(&model).provider == crate::provider::ProviderKind::Copilot {
+        if let Err(e) = state.tokens.get(&state.http).await {
+            let mut w = writer.lock().await;
+            write_frame(
+                &mut *w,
+                &Response::Error {
+                    message: format!("authentication error: {e:#}"),
+                },
+            )
+            .await?;
+            return Ok(ConnAction::Break);
+        }
     }
 
     // First turn: load history from DB.  Subsequent turns: extend carried messages.


### PR DESCRIPTION
## Problem

On machines with only Bedrock credentials (no GitHub Copilot), any `amaebi chat/ask/resume` command failed immediately with:

```
Error: authentication error: GitHub Copilot OAuth token not found.
Expected ~/.amaebi/hosts.json or ~/.config/github-copilot/hosts.json / apps.json
```

## Root cause

`handle_chat_request`, `handle_resume_request`, and `SubmitDetach` all called `state.tokens.get()` **unconditionally** before routing to the provider. `tokens.get()` always reads the Copilot OAuth token from disk, even when the selected model is Bedrock.

## Fix

Wrap the `tokens.get()` call in a provider check — only run it when `resolve(model).provider == Copilot`.

## Test plan

- [x] All 33 tests pass (`cargo test`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] Manual: run `amaebi chat` with `AMAEBI_MODEL=claude-sonnet-4.6` (Bedrock) on a machine without Copilot credentials — should connect without auth error

🤖 Generated with [Claude Code](https://claude.com/claude-code)