### PR TITLE
feat: 1M context window for Bedrock claude-sonnet-4 and opus-4-6

### DIFF
--- a/src/bedrock.rs
+++ b/src/bedrock.rs
@@ -662,6 +662,16 @@ fn supports_adaptive_thinking(model_id: &str) -> bool {
         || model_id.starts_with("us.anthropic.claude-sonnet-4-6")
 }
 
+/// Returns true for Bedrock Claude models that support the 1M context window
+/// via the `context-1m-2025-08-07` beta header.
+///
+/// Matches the reference implementation: claude-sonnet-4 family and opus-4-6.
+/// The model_id must be a bare resolved Bedrock ID (no `[1m]` suffix).
+pub(crate) fn supports_1m_context(model_id: &str) -> bool {
+    model_id.contains("claude-sonnet-4") || model_id.contains("claude-opus-4-6")
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn send_with_retry(
     http: &reqwest::Client,
     token: &str,
@@ -670,6 +680,7 @@ async fn send_with_retry(
     messages: &[Message],
     tools: &[serde_json::Value],
     max_tokens: usize,
+    use_1m: bool,
 ) -> Result<reqwest::Response> {
     let parts = to_bedrock_request(messages);
     let bedrock_tools = to_bedrock_tools(tools);
@@ -685,9 +696,24 @@ async fn send_with_retry(
     if !bedrock_tools.is_empty() {
         body["toolConfig"] = serde_json::json!({ "tools": bedrock_tools });
     }
+
+    // Build additionalModelRequestFields by merging all per-model flags so
+    // that adding a second flag never silently drops the first.
+    let mut amrf = serde_json::Map::new();
     if supports_adaptive_thinking(model_id) {
-        body["additionalModelRequestFields"] =
-            serde_json::json!({ "thinking": { "type": "adaptive" } });
+        amrf.insert(
+            "thinking".to_owned(),
+            serde_json::json!({ "type": "adaptive" }),
+        );
+    }
+    if use_1m && supports_1m_context(model_id) {
+        amrf.insert(
+            "anthropic_beta".to_owned(),
+            serde_json::json!(["context-1m-2025-08-07"]),
+        );
+    }
+    if !amrf.is_empty() {
+        body["additionalModelRequestFields"] = serde_json::Value::Object(amrf);
     }
 
     let url = converse_stream_endpoint(region, model_id);
@@ -1040,10 +1066,9 @@ where
 /// Reads `AWS_BEARER_TOKEN_BEDROCK` and `AWS_REGION` from the environment.
 /// Text chunks are forwarded to `writer` as `Response::Text` frames as they
 /// arrive.  Returns a [`CopilotResponse`] describing the full turn result.
-#[allow(clippy::too_many_arguments)]
 pub async fn stream_chat<W>(
     http: &reqwest::Client,
-    model_id: &str,
+    spec: &crate::provider::ModelSpec,
     messages: &[Message],
     tools: &[serde_json::Value],
     max_tokens: usize,
@@ -1057,13 +1082,24 @@ where
 
     tracing::debug!(
         messages = messages.len(),
-        model = model_id,
+        model = %spec.display_name,
+        model_id = %spec.model_id,
+        use_1m = spec.use_1m,
         region = %region,
         "sending Bedrock ConverseStream request"
     );
 
-    let resp =
-        send_with_retry(http, &token, &region, model_id, messages, tools, max_tokens).await?;
+    let resp = send_with_retry(
+        http,
+        &token,
+        &region,
+        &spec.model_id,
+        messages,
+        tools,
+        max_tokens,
+        spec.use_1m,
+    )
+    .await?;
     parse_converse_stream(resp, writer).await
 }
 
@@ -1110,6 +1146,100 @@ mod tests {
         ));
         assert!(!supports_adaptive_thinking("gpt-4o"));
         assert!(!supports_adaptive_thinking(""));
+    }
+
+    // ---- supports_1m_context ------------------------------------------------
+
+    #[test]
+    fn supports_1m_context_sonnet_family() {
+        assert!(supports_1m_context("us.anthropic.claude-sonnet-4-6"));
+        assert!(supports_1m_context("us.anthropic.claude-sonnet-4-6-v1:0"));
+        assert!(supports_1m_context(
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        ));
+        assert!(supports_1m_context(
+            "us.anthropic.claude-sonnet-4-20250514-v1:0"
+        ));
+    }
+
+    #[test]
+    fn supports_1m_context_opus_4_6() {
+        assert!(supports_1m_context("us.anthropic.claude-opus-4-6-v1"));
+        assert!(supports_1m_context("us.anthropic.claude-opus-4-6"));
+    }
+
+    #[test]
+    fn supports_1m_context_rejects_haiku_and_older_opus() {
+        assert!(!supports_1m_context(
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        ));
+        assert!(!supports_1m_context(
+            "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+        ));
+        assert!(!supports_1m_context(
+            "us.anthropic.claude-opus-4-5-20251101-v1:0"
+        ));
+        assert!(!supports_1m_context(
+            "us.anthropic.claude-opus-4-1-20250805-v1:0"
+        ));
+        assert!(!supports_1m_context("gpt-4o"));
+        assert!(!supports_1m_context(""));
+    }
+
+    #[test]
+    fn send_with_retry_body_injects_1m_beta_for_supported_model() {
+        // Verify that the additionalModelRequestFields contains anthropic_beta
+        // when use_1m=true and the model supports 1M context.
+        let model_id = "us.anthropic.claude-sonnet-4-6";
+        let mut amrf = serde_json::Map::new();
+        if supports_adaptive_thinking(model_id) {
+            amrf.insert(
+                "thinking".to_owned(),
+                serde_json::json!({ "type": "adaptive" }),
+            );
+        }
+        if supports_1m_context(model_id) {
+            amrf.insert(
+                "anthropic_beta".to_owned(),
+                serde_json::json!(["context-1m-2025-08-07"]),
+            );
+        }
+        assert!(
+            amrf.contains_key("thinking"),
+            "adaptive thinking must be present"
+        );
+        assert!(
+            amrf.contains_key("anthropic_beta"),
+            "1M beta must be present"
+        );
+        assert_eq!(
+            amrf["anthropic_beta"],
+            serde_json::json!(["context-1m-2025-08-07"])
+        );
+    }
+
+    #[test]
+    fn send_with_retry_body_no_1m_beta_when_use_1m_false() {
+        let model_id = "us.anthropic.claude-sonnet-4-6";
+        let use_1m = false;
+        let mut amrf = serde_json::Map::new();
+        if supports_adaptive_thinking(model_id) {
+            amrf.insert(
+                "thinking".to_owned(),
+                serde_json::json!({ "type": "adaptive" }),
+            );
+        }
+        if use_1m && supports_1m_context(model_id) {
+            amrf.insert(
+                "anthropic_beta".to_owned(),
+                serde_json::json!(["context-1m-2025-08-07"]),
+            );
+        }
+        assert!(amrf.contains_key("thinking"));
+        assert!(
+            !amrf.contains_key("anthropic_beta"),
+            "1M beta must not be present"
+        );
     }
 
     // ---- to_bedrock_request: message conversion ---------------------------

--- a/src/bedrock.rs
+++ b/src/bedrock.rs
@@ -663,13 +663,39 @@ fn supports_adaptive_thinking(model_id: &str) -> bool {
 }
 
 /// Returns true for Bedrock Claude models that support the 1M context window
-/// via the `context-1m-2025-08-07` beta header.
+/// via the `context-1m-2025-08-07` Anthropic beta value passed in
+/// `additionalModelRequestFields.anthropic_beta` of the Bedrock request body.
 ///
 /// Matches the reference implementation: claude-sonnet-4 family and opus-4-6.
 /// The model_id must be a bare resolved Bedrock ID (no `[1m]` suffix).
 pub(crate) fn supports_1m_context(model_id: &str) -> bool {
     model_id.starts_with("us.anthropic.claude-sonnet-4")
         || model_id.starts_with("us.anthropic.claude-opus-4-6")
+}
+
+/// Build the `additionalModelRequestFields` map for a Bedrock request.
+///
+/// Merges all per-model feature flags (adaptive thinking, 1M context) into a
+/// single JSON object so that adding one flag never silently drops another.
+/// Returns an empty map when no flags apply so callers can skip the field.
+fn build_additional_model_request_fields(
+    model_id: &str,
+    use_1m: bool,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut amrf = serde_json::Map::new();
+    if supports_adaptive_thinking(model_id) {
+        amrf.insert(
+            "thinking".to_owned(),
+            serde_json::json!({ "type": "adaptive" }),
+        );
+    }
+    if use_1m && supports_1m_context(model_id) {
+        amrf.insert(
+            "anthropic_beta".to_owned(),
+            serde_json::json!(["context-1m-2025-08-07"]),
+        );
+    }
+    amrf
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -700,19 +726,7 @@ async fn send_with_retry(
 
     // Build additionalModelRequestFields by merging all per-model flags so
     // that adding a second flag never silently drops the first.
-    let mut amrf = serde_json::Map::new();
-    if supports_adaptive_thinking(model_id) {
-        amrf.insert(
-            "thinking".to_owned(),
-            serde_json::json!({ "type": "adaptive" }),
-        );
-    }
-    if use_1m && supports_1m_context(model_id) {
-        amrf.insert(
-            "anthropic_beta".to_owned(),
-            serde_json::json!(["context-1m-2025-08-07"]),
-        );
-    }
+    let amrf = build_additional_model_request_fields(model_id, use_1m);
     if !amrf.is_empty() {
         body["additionalModelRequestFields"] = serde_json::Value::Object(amrf);
     }
@@ -1187,24 +1201,12 @@ mod tests {
         assert!(!supports_1m_context(""));
     }
 
+    // ---- build_additional_model_request_fields ------------------------------
+
     #[test]
-    fn send_with_retry_body_injects_1m_beta_for_supported_model() {
-        // Verify that the additionalModelRequestFields contains anthropic_beta
-        // when use_1m=true and the model supports 1M context.
-        let model_id = "us.anthropic.claude-sonnet-4-6";
-        let mut amrf = serde_json::Map::new();
-        if supports_adaptive_thinking(model_id) {
-            amrf.insert(
-                "thinking".to_owned(),
-                serde_json::json!({ "type": "adaptive" }),
-            );
-        }
-        if supports_1m_context(model_id) {
-            amrf.insert(
-                "anthropic_beta".to_owned(),
-                serde_json::json!(["context-1m-2025-08-07"]),
-            );
-        }
+    fn amrf_injects_both_thinking_and_1m_for_supported_model() {
+        // claude-sonnet-4-6 supports both adaptive thinking and 1M context.
+        let amrf = build_additional_model_request_fields("us.anthropic.claude-sonnet-4-6", true);
         assert!(
             amrf.contains_key("thinking"),
             "adaptive thinking must be present"
@@ -1217,30 +1219,44 @@ mod tests {
             amrf["anthropic_beta"],
             serde_json::json!(["context-1m-2025-08-07"])
         );
+        assert_eq!(amrf["thinking"], serde_json::json!({ "type": "adaptive" }));
     }
 
     #[test]
-    fn send_with_retry_body_no_1m_beta_when_use_1m_false() {
-        let model_id = "us.anthropic.claude-sonnet-4-6";
-        let use_1m = false;
-        let mut amrf = serde_json::Map::new();
-        if supports_adaptive_thinking(model_id) {
-            amrf.insert(
-                "thinking".to_owned(),
-                serde_json::json!({ "type": "adaptive" }),
-            );
-        }
-        if use_1m && supports_1m_context(model_id) {
-            amrf.insert(
-                "anthropic_beta".to_owned(),
-                serde_json::json!(["context-1m-2025-08-07"]),
-            );
-        }
-        assert!(amrf.contains_key("thinking"));
+    fn amrf_no_1m_beta_when_use_1m_false() {
+        let amrf = build_additional_model_request_fields("us.anthropic.claude-sonnet-4-6", false);
+        assert!(
+            amrf.contains_key("thinking"),
+            "adaptive thinking still present"
+        );
         assert!(
             !amrf.contains_key("anthropic_beta"),
             "1M beta must not be present"
         );
+    }
+
+    #[test]
+    fn amrf_empty_for_unsupported_model() {
+        // Haiku supports neither adaptive thinking nor 1M context.
+        let amrf = build_additional_model_request_fields(
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            true,
+        );
+        assert!(amrf.is_empty(), "no fields expected for haiku");
+    }
+
+    #[test]
+    fn amrf_1m_only_for_model_without_adaptive_thinking() {
+        // claude-opus-4-1 does not support adaptive thinking but does support 1M.
+        let amrf = build_additional_model_request_fields(
+            "us.anthropic.claude-sonnet-4-20250514-v1:0",
+            true,
+        );
+        assert!(
+            !amrf.contains_key("thinking"),
+            "no adaptive thinking for sonnet-4"
+        );
+        assert!(amrf.contains_key("anthropic_beta"), "1M beta present");
     }
 
     // ---- to_bedrock_request: message conversion ---------------------------

--- a/src/bedrock.rs
+++ b/src/bedrock.rs
@@ -668,7 +668,8 @@ fn supports_adaptive_thinking(model_id: &str) -> bool {
 /// Matches the reference implementation: claude-sonnet-4 family and opus-4-6.
 /// The model_id must be a bare resolved Bedrock ID (no `[1m]` suffix).
 pub(crate) fn supports_1m_context(model_id: &str) -> bool {
-    model_id.contains("claude-sonnet-4") || model_id.contains("claude-opus-4-6")
+    model_id.starts_with("us.anthropic.claude-sonnet-4")
+        || model_id.starts_with("us.anthropic.claude-opus-4-6")
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/bedrock.rs
+++ b/src/bedrock.rs
@@ -1247,7 +1247,7 @@ mod tests {
 
     #[test]
     fn amrf_1m_only_for_model_without_adaptive_thinking() {
-        // claude-opus-4-1 does not support adaptive thinking but does support 1M.
+        // claude-sonnet-4 does not support adaptive thinking but does support 1M.
         let amrf = build_additional_model_request_fields(
             "us.anthropic.claude-sonnet-4-20250514-v1:0",
             true,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -61,7 +61,9 @@ fn max_output_tokens_for_model(model: &str) -> usize {
 fn response_max_tokens(model: &str) -> usize {
     let model_id = &resolved_model_id(model);
     let model_max = max_output_tokens_for_model(model_id);
-    let context_budget = context_limit_for_model(model_id) / 2;
+    // Pass the raw model string (preserving [1m]) so context_limit_for_model
+    // can return 1_000_000 when the suffix is present.
+    let context_budget = context_limit_for_model(model) / 2;
     let result = model_max.min(context_budget);
     tracing::debug!(
         model,
@@ -218,6 +220,15 @@ fn count_message_tokens(messages: &[Message]) -> usize {
 /// Falls back to a conservative 32 k for unknown models so we never send
 /// more tokens than the server can handle.
 fn context_limit_for_model(model: &str) -> usize {
+    // Check for the [1m] opt-in suffix before resolving the model ID.
+    // We must operate on the raw string here so the flag survives alias resolution.
+    if model.ends_with("[1m]") {
+        let bare = resolved_model_id(model); // strips [1m] via provider::resolve
+        if crate::bedrock::supports_1m_context(&bare) {
+            return 1_000_000;
+        }
+    }
+
     let model = resolved_model_id(model);
     // Ordered longest-prefix-first so that e.g. "gpt-4-turbo" beats "gpt-4".
     const TABLE: &[(&str, usize)] = &[
@@ -1404,6 +1415,7 @@ where
         provider = %spec.provider,
         model_id = %spec.model_id,
         display = %spec.display_name,
+        use_1m = spec.use_1m,
         "invoke_model: resolved provider"
     );
 
@@ -1411,7 +1423,7 @@ where
         crate::provider::ProviderKind::Bedrock => {
             crate::bedrock::stream_chat(
                 &state.http,
-                &spec.model_id,
+                &spec,
                 messages,
                 tools,
                 max_completion_tokens,
@@ -1421,6 +1433,21 @@ where
         }
 
         crate::provider::ProviderKind::Copilot => {
+            if spec.use_1m {
+                tracing::warn!(
+                    display = %spec.display_name,
+                    "1M context is not supported via Copilot; proceeding with standard context window"
+                );
+                write_frame(
+                    writer,
+                    &crate::ipc::Response::Text {
+                        chunk: "[warning] 1M context ([1m]) is not supported via Copilot; \
+                                proceeding with standard context window.\n"
+                            .into(),
+                    },
+                )
+                .await?;
+            }
             invoke_copilot(
                 state,
                 &spec.model_id,
@@ -2645,6 +2672,37 @@ mod tests {
         assert_eq!(context_limit_for_model("o1-preview"), 200_000);
         assert_eq!(context_limit_for_model("o3-mini"), 200_000);
         assert_eq!(context_limit_for_model("claude-3-5-sonnet"), 200_000);
+    }
+
+    #[test]
+    fn context_limit_1m_suffix_supported_models() {
+        // Supported models with [1m] suffix return 1_000_000.
+        assert_eq!(context_limit_for_model("claude-sonnet-4.6[1m]"), 1_000_000);
+        assert_eq!(context_limit_for_model("claude-opus-4.6[1m]"), 1_000_000);
+        assert_eq!(
+            context_limit_for_model("us.anthropic.claude-sonnet-4-6[1m]"),
+            1_000_000
+        );
+        assert_eq!(
+            context_limit_for_model("bedrock/us.anthropic.claude-sonnet-4-6[1m]"),
+            1_000_000
+        );
+    }
+
+    #[test]
+    fn context_limit_1m_suffix_unsupported_model_falls_back() {
+        // Haiku does not support 1M — suffix is ignored, returns standard limit.
+        assert_eq!(context_limit_for_model("claude-haiku-3.5[1m]"), 200_000);
+    }
+
+    #[test]
+    fn context_limit_no_1m_suffix_unchanged() {
+        // Without suffix, supported models still return standard 200k.
+        assert_eq!(context_limit_for_model("claude-sonnet-4.6"), 200_000);
+        assert_eq!(
+            context_limit_for_model("us.anthropic.claude-sonnet-4-6"),
+            200_000
+        );
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -220,16 +220,19 @@ fn count_message_tokens(messages: &[Message]) -> usize {
 /// Falls back to a conservative 32 k for unknown models so we never send
 /// more tokens than the server can handle.
 fn context_limit_for_model(model: &str) -> usize {
-    // Check for the [1m] opt-in suffix before resolving the model ID.
-    // We must operate on the raw string here so the flag survives alias resolution.
-    if model.ends_with("[1m]") {
-        let bare = resolved_model_id(model); // strips [1m] via provider::resolve
-        if crate::bedrock::supports_1m_context(&bare) {
-            return 1_000_000;
-        }
+    // Resolve once to get the provider, model ID, and use_1m flag together.
+    // Gating on provider == Bedrock prevents Copilot model IDs that contain
+    // "claude-sonnet-4" / "claude-opus-4-6" (e.g. copilot/claude-sonnet-4[1m])
+    // from incorrectly receiving a 1M token budget.
+    let spec = crate::provider::resolve(model);
+    if spec.provider == crate::provider::ProviderKind::Bedrock
+        && spec.use_1m
+        && crate::bedrock::supports_1m_context(&spec.model_id)
+    {
+        return 1_000_000;
     }
 
-    let model = resolved_model_id(model);
+    let model = spec.model_id;
     // Ordered longest-prefix-first so that e.g. "gpt-4-turbo" beats "gpt-4".
     const TABLE: &[(&str, usize)] = &[
         // Bedrock model IDs (cross-region us.anthropic.* format): 200k context.
@@ -2693,6 +2696,20 @@ mod tests {
     fn context_limit_1m_suffix_unsupported_model_falls_back() {
         // Haiku does not support 1M — suffix is ignored, returns standard limit.
         assert_eq!(context_limit_for_model("claude-haiku-3.5[1m]"), 200_000);
+    }
+
+    #[test]
+    fn context_limit_1m_suffix_copilot_does_not_get_1m_budget() {
+        // Copilot provider does not support 1M — even a Claude model ID with
+        // [1m] must not receive a 1M token budget.
+        assert_eq!(
+            context_limit_for_model("copilot/claude-sonnet-4-5[1m]"),
+            200_000
+        );
+        assert_eq!(
+            context_limit_for_model("copilot/claude-opus-4.6[1m]"),
+            200_000
+        );
     }
 
     #[test]

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -128,8 +128,10 @@ pub fn resolve(raw: &str) -> ModelSpec {
                     provider: ProviderKind::Copilot,
                     model_id: model.to_owned(),
                     display_name,
-                    // Copilot does not support 1M context — ignore the suffix.
-                    use_1m: false,
+                    // Preserve the user's opt-in so the daemon can warn and log
+                    // accurately; the Copilot execution path ignores it at
+                    // runtime because Copilot does not support 1M context.
+                    use_1m,
                 };
             }
             "bedrock" => {
@@ -295,13 +297,14 @@ mod tests {
     }
 
     #[test]
-    fn resolve_1m_suffix_copilot_ignored() {
-        // Copilot does not support 1M — use_1m must be false regardless of suffix.
+    fn resolve_1m_suffix_copilot_preserves_flag() {
+        // Copilot does not support 1M at runtime, but use_1m is preserved so
+        // the daemon can warn and log accurately.
         let spec = resolve("copilot/claude-opus-4.6[1m]");
         assert_eq!(spec.provider, ProviderKind::Copilot);
         assert_eq!(spec.model_id, "claude-opus-4.6");
         assert_eq!(spec.display_name, "copilot/claude-opus-4.6[1m]");
-        assert!(!spec.use_1m);
+        assert!(spec.use_1m);
     }
 
     #[test]

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -36,6 +36,10 @@ pub struct ModelSpec {
     pub model_id: String,
     /// The raw string the user typed — used for logging and display.
     pub display_name: String,
+    /// Whether the user requested 1M context via the `[1m]` suffix.
+    ///
+    /// Only meaningful for Bedrock — Copilot does not support 1M context.
+    pub use_1m: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -108,13 +112,24 @@ pub const DEFAULT_MODEL: &str = "claude-sonnet-4.6";
 pub fn resolve(raw: &str) -> ModelSpec {
     let display_name = raw.to_owned();
 
-    if let Some((prefix, model)) = raw.split_once('/') {
+    // Strip the `[1m]` opt-in suffix before routing and alias resolution.
+    // The flag is preserved in `display_name` and `use_1m`.
+    let use_1m = raw.ends_with("[1m]");
+    let bare: &str = if use_1m {
+        &raw[..raw.len() - "[1m]".len()]
+    } else {
+        raw
+    };
+
+    if let Some((prefix, model)) = bare.split_once('/') {
         match prefix {
             "copilot" => {
                 return ModelSpec {
                     provider: ProviderKind::Copilot,
                     model_id: model.to_owned(),
                     display_name,
+                    // Copilot does not support 1M context — ignore the suffix.
+                    use_1m: false,
                 };
             }
             "bedrock" => {
@@ -122,6 +137,7 @@ pub fn resolve(raw: &str) -> ModelSpec {
                     provider: ProviderKind::Bedrock,
                     model_id: resolve_bedrock_alias(model),
                     display_name,
+                    use_1m,
                 };
             }
             _ => {
@@ -134,8 +150,9 @@ pub fn resolve(raw: &str) -> ModelSpec {
     // No recognised prefix → default provider (Bedrock) with alias resolution.
     ModelSpec {
         provider: ProviderKind::Bedrock,
-        model_id: resolve_bedrock_alias(raw),
+        model_id: resolve_bedrock_alias(bare),
         display_name,
+        use_1m,
     }
 }
 
@@ -252,6 +269,45 @@ mod tests {
     fn alias_full_id_passthrough() {
         let full = "us.anthropic.claude-sonnet-4-6-v1:0";
         assert_eq!(resolve_bedrock_alias(full), full);
+    }
+
+    // ---- 1M suffix --------------------------------------------------------
+
+    #[test]
+    fn resolve_1m_suffix_bedrock_alias() {
+        let spec = resolve("claude-sonnet-4.6[1m]");
+        assert_eq!(spec.provider, ProviderKind::Bedrock);
+        assert_eq!(spec.model_id, "us.anthropic.claude-sonnet-4-6");
+        assert_eq!(spec.display_name, "claude-sonnet-4.6[1m]");
+        assert!(spec.use_1m);
+    }
+
+    #[test]
+    fn resolve_1m_suffix_bedrock_prefix() {
+        let spec = resolve("bedrock/us.anthropic.claude-sonnet-4-6[1m]");
+        assert_eq!(spec.provider, ProviderKind::Bedrock);
+        assert_eq!(spec.model_id, "us.anthropic.claude-sonnet-4-6");
+        assert_eq!(
+            spec.display_name,
+            "bedrock/us.anthropic.claude-sonnet-4-6[1m]"
+        );
+        assert!(spec.use_1m);
+    }
+
+    #[test]
+    fn resolve_1m_suffix_copilot_ignored() {
+        // Copilot does not support 1M — use_1m must be false regardless of suffix.
+        let spec = resolve("copilot/claude-opus-4.6[1m]");
+        assert_eq!(spec.provider, ProviderKind::Copilot);
+        assert_eq!(spec.model_id, "claude-opus-4.6");
+        assert_eq!(spec.display_name, "copilot/claude-opus-4.6[1m]");
+        assert!(!spec.use_1m);
+    }
+
+    #[test]
+    fn resolve_no_1m_suffix_use_1m_false() {
+        let spec = resolve("claude-sonnet-4.6");
+        assert!(!spec.use_1m);
     }
 
     // ---- Display ----------------------------------------------------------

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -227,6 +227,15 @@ async fn test_compaction_triggered_at_threshold() {
         )
         .await
         .unwrap_or_else(|e| panic!("seed turn {i} failed: {e}"));
+        // Verify the mock LLM was actually called and returned the expected text.
+        // This catches the case where the daemon returns an Error frame without
+        // calling the LLM (which would leave the queued response unconsumed and
+        // cause the Phase 2 drain assertion to fail).
+        let seed_text = collect_text(&r);
+        assert!(
+            seed_text.contains(&format!("Seed {i}.")),
+            "seed turn {i}: expected 'Seed {i}.' in response, got: {seed_text:?}\nframes: {r:?}"
+        );
         assert!(
             !r.iter()
                 .any(|f| matches!(f, support::helpers::Response::Compacting)),
@@ -234,11 +243,10 @@ async fn test_compaction_triggered_at_threshold() {
         );
     }
 
-    // Wait until every seed response has been consumed from the mock queue
-    // before killing the seed daemon.  On slow CI runners there is a window
-    // between the client receiving Done and the daemon's HTTP response being
-    // fully read; if we kill the daemon inside that window the mock server may
-    // not have drained the response, leaving it in the queue for Phase 2.
+    // All 4 seed turns verified correct content — the mock was called for each
+    // turn, so all queued responses have been consumed.  A short drain wait
+    // still guards the rare window where the daemon's HTTP response stream
+    // hasn't been fully closed yet on a slow CI runner.
     let drain_deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     loop {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;


### PR DESCRIPTION
## Summary

Adds an opt-in `[1m]` suffix to model strings to enable the 1M context window for supported Bedrock Claude models.

**Usage:**
```bash
export AMAEBI_MODEL=claude-sonnet-4.6[1m]
# or
amaebi ask --model bedrock/claude-opus-4.6[1m] "..."
```

**Supported models:** `claude-sonnet-4` family and `claude-opus-4-6` (matched by `us.anthropic.` prefix).

## Changes

- **`src/provider.rs`**: `resolve()` strips `[1m]` before routing/alias resolution; `display_name` preserves the original string; `use_1m` flag is preserved for all providers including Copilot (so the daemon can warn accurately).
- **`src/bedrock.rs`**:
  - `supports_1m_context(model_id)` — detects supported models via `starts_with("us.anthropic.claude-sonnet-4")` / `starts_with("us.anthropic.claude-opus-4-6")`.
  - `build_additional_model_request_fields(model_id, use_1m)` — pure helper that merges adaptive-thinking and 1M beta flags into `additionalModelRequestFields`; `send_with_retry` delegates to it.
  - Injects `anthropic_beta: ["context-1m-2025-08-07"]` in the request body's `additionalModelRequestFields` (not an HTTP header).
  - `stream_chat` now accepts `&ModelSpec` for richer logging (`display_name`, `use_1m`).
- **`src/daemon.rs`**:
  - `context_limit_for_model` resolves to `ModelSpec` and gates the 1M budget on `provider == Bedrock && use_1m && supports_1m_context`.
  - Copilot + `[1m]`: emits a user-visible warning frame then continues with the standard context window.
- **`tests/integration_tests.rs`**: adds content assertions to each seed turn in `test_compaction_triggered_at_threshold` to catch daemon errors that would leave a mock response unconsumed.

## Test plan

- [x] `cargo test` — 33 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] Unit tests cover: `[1m]` suffix parsing, `supports_1m_context`, `build_additional_model_request_fields` (both flags, no 1m, unsupported model, 1m-only), context limit gating, Copilot not receiving 1M budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)