### PR TITLE
fix(daemon): route gpt-5.x directly to Responses API, skip chat/completions first-hop

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1471,6 +1471,67 @@ where
     }
 }
 
+/// Call the Responses API with `tok`, evicting the token cache and retrying
+/// once on a 401/403 auth error.  Centralises retry/telemetry logic so both
+/// the gpt-5.x direct path and the chat-completions fallback path stay in sync.
+async fn stream_via_responses_with_auth_retry<W>(
+    state: &DaemonState,
+    tok: &crate::auth::CopilotToken,
+    model: &str,
+    messages: &[Message],
+    tools: &[serde_json::Value],
+    max_completion_tokens: usize,
+    writer: &mut W,
+) -> Result<copilot::CopilotResponse>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    let r = crate::responses::stream_chat(
+        &state.http,
+        &tok.value,
+        &tok.base_url,
+        model,
+        messages,
+        tools,
+        max_completion_tokens,
+        writer,
+    )
+    .await;
+    match r {
+        Ok(r) => Ok(r),
+        Err(e) => {
+            let is_auth = e
+                .downcast_ref::<copilot::CopilotHttpError>()
+                .is_some_and(|he| matches!(he.status.as_u16(), 401 | 403));
+            if is_auth {
+                tracing::warn!(
+                    error = %e,
+                    "Responses API auth error; evicting token and retrying"
+                );
+                state.tokens.invalidate().await;
+                let fresh = state
+                    .tokens
+                    .get(&state.http)
+                    .await
+                    .context("fetching fresh token after Responses API auth error")?;
+                crate::responses::stream_chat(
+                    &state.http,
+                    &fresh.value,
+                    &fresh.base_url,
+                    model,
+                    messages,
+                    tools,
+                    max_completion_tokens,
+                    writer,
+                )
+                .await
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
 /// Copilot-specific model invocation.  gpt-5.x models are routed directly to
 /// the Responses API; all other models try Chat Completions first, falling
 /// back to Responses API on `unsupported_api_for_model`.  Auth errors evict
@@ -1496,10 +1557,9 @@ where
     // Skip the first-hop attempt and go directly to the Responses API.
     if requires_responses_api(model) {
         tracing::debug!(model, "routing directly to Responses API (gpt-5 family)");
-        let r = crate::responses::stream_chat(
-            &state.http,
-            &tok.value,
-            &tok.base_url,
+        return stream_via_responses_with_auth_retry(
+            state,
+            &tok,
             model,
             messages,
             tools,
@@ -1507,39 +1567,6 @@ where
             writer,
         )
         .await;
-        return match r {
-            Ok(r) => Ok(r),
-            Err(e) => {
-                let is_auth = e
-                    .downcast_ref::<copilot::CopilotHttpError>()
-                    .is_some_and(|he| matches!(he.status.as_u16(), 401 | 403));
-                if is_auth {
-                    tracing::warn!(
-                        error = %e,
-                        "Responses API auth error; evicting token and retrying"
-                    );
-                    state.tokens.invalidate().await;
-                    let fresh = state
-                        .tokens
-                        .get(&state.http)
-                        .await
-                        .context("fetching fresh token after Responses API auth error")?;
-                    crate::responses::stream_chat(
-                        &state.http,
-                        &fresh.value,
-                        &fresh.base_url,
-                        model,
-                        messages,
-                        tools,
-                        max_completion_tokens,
-                        writer,
-                    )
-                    .await
-                } else {
-                    Err(e)
-                }
-            }
-        };
     }
 
     let result = copilot::stream_chat(
@@ -1564,52 +1591,16 @@ where
                 model,
                 "model not accessible via /chat/completions; retrying via Responses API"
             );
-            let r = crate::responses::stream_chat(
-                &state.http,
-                &tok.value,
-                &tok.base_url,
+            stream_via_responses_with_auth_retry(
+                state,
+                &tok,
                 model,
                 messages,
                 tools,
                 max_completion_tokens,
                 writer,
             )
-            .await;
-            // The Responses API can also return 401/403 on token expiry.
-            // Evict the cache and retry once with a fresh token.
-            match r {
-                Ok(r) => Ok(r),
-                Err(e2) => {
-                    let is_auth = e2
-                        .downcast_ref::<copilot::CopilotHttpError>()
-                        .is_some_and(|he| matches!(he.status.as_u16(), 401 | 403));
-                    if is_auth {
-                        tracing::warn!(
-                            error = %e2,
-                            "Responses API auth error; evicting token and retrying"
-                        );
-                        state.tokens.invalidate().await;
-                        let fresh = state
-                            .tokens
-                            .get(&state.http)
-                            .await
-                            .context("fetching fresh token after Responses API auth error")?;
-                        crate::responses::stream_chat(
-                            &state.http,
-                            &fresh.value,
-                            &fresh.base_url,
-                            model,
-                            messages,
-                            tools,
-                            max_completion_tokens,
-                            writer,
-                        )
-                        .await
-                    } else {
-                        Err(e2)
-                    }
-                }
-            }
+            .await
         }
 
         // Auth error — evict the token cache and retry once with a fresh token.
@@ -1641,10 +1632,9 @@ where
                 match r2 {
                     Ok(r) => Ok(r),
                     Err(ref e2) if is_unsupported_via_chat_completions(e2) => {
-                        crate::responses::stream_chat(
-                            &state.http,
-                            &fresh.value,
-                            &fresh.base_url,
+                        stream_via_responses_with_auth_retry(
+                            state,
+                            &fresh,
                             model,
                             messages,
                             tools,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1388,15 +1388,22 @@ fn is_unsupported_via_chat_completions(e: &anyhow::Error) -> bool {
         })
 }
 
+/// Returns `true` for models that must be routed directly to the Responses API
+/// and do not support Chat Completions at all (e.g. the gpt-5 family).
+fn requires_responses_api(model: &str) -> bool {
+    model == "gpt-5" || model.starts_with("gpt-5.") || model.starts_with("gpt-5-")
+}
+
 /// Send one model turn, dispatching to the correct provider backend.
 ///
 /// The raw `model` string is resolved via [`crate::provider::resolve`] to
 /// determine the provider (Copilot or Bedrock) and the actual model ID.
 ///
-/// **Copilot** path (existing behaviour):
+/// **Copilot** path:
 /// 1. The base URL is derived from the `proxy-ep` field in the Copilot JWT.
-/// 2. Tries `/v1/chat/completions` first.
-/// 3. Falls back to `/v1/responses` on 400 `unsupported_api_for_model`.
+/// 2. gpt-5.x models go directly to `/v1/responses`.
+/// 3. All other models try `/v1/chat/completions` first, falling back to
+///    `/v1/responses` on 400 `unsupported_api_for_model`.
 /// 4. Auth errors (401/403) evict the token cache and retry once.
 ///
 /// **Bedrock** path:
@@ -1464,8 +1471,10 @@ where
     }
 }
 
-/// Copilot-specific model invocation with Chat Completions / Responses API
-/// fallback and auth-error retry.
+/// Copilot-specific model invocation.  gpt-5.x models are routed directly to
+/// the Responses API; all other models try Chat Completions first, falling
+/// back to Responses API on `unsupported_api_for_model`.  Auth errors evict
+/// the token cache and retry once.
 async fn invoke_copilot<W>(
     state: &DaemonState,
     model: &str,
@@ -1482,6 +1491,56 @@ where
         .get(&state.http)
         .await
         .context("refreshing Copilot API token")?;
+
+    // Models in the gpt-5 family do not support Chat Completions at all.
+    // Skip the first-hop attempt and go directly to the Responses API.
+    if requires_responses_api(model) {
+        tracing::debug!(model, "routing directly to Responses API (gpt-5 family)");
+        let r = crate::responses::stream_chat(
+            &state.http,
+            &tok.value,
+            &tok.base_url,
+            model,
+            messages,
+            tools,
+            max_completion_tokens,
+            writer,
+        )
+        .await;
+        return match r {
+            Ok(r) => Ok(r),
+            Err(e) => {
+                let is_auth = e
+                    .downcast_ref::<copilot::CopilotHttpError>()
+                    .is_some_and(|he| matches!(he.status.as_u16(), 401 | 403));
+                if is_auth {
+                    tracing::warn!(
+                        error = %e,
+                        "Responses API auth error; evicting token and retrying"
+                    );
+                    state.tokens.invalidate().await;
+                    let fresh = state
+                        .tokens
+                        .get(&state.http)
+                        .await
+                        .context("fetching fresh token after Responses API auth error")?;
+                    crate::responses::stream_chat(
+                        &state.http,
+                        &fresh.value,
+                        &fresh.base_url,
+                        model,
+                        messages,
+                        tools,
+                        max_completion_tokens,
+                        writer,
+                    )
+                    .await
+                } else {
+                    Err(e)
+                }
+            }
+        };
+    }
 
     let result = copilot::stream_chat(
         &state.http,
@@ -3164,5 +3223,24 @@ mod tests {
         assert!(needs_copilot_auth("copilot/claude-opus-4-6-20251101"));
         assert!(needs_copilot_auth("copilot/claude-sonnet-4-5"));
         assert!(needs_copilot_auth("copilot/gpt-4o"));
+    }
+
+    // ------------------------------------------------------------------
+    // requires_responses_api tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn gpt_5_4_requires_responses_api() {
+        assert!(requires_responses_api("gpt-5.4"));
+    }
+
+    #[test]
+    fn gpt_4o_does_not_require_responses_api() {
+        assert!(!requires_responses_api("gpt-4o"));
+    }
+
+    #[test]
+    fn gpt_5_mini_requires_responses_api() {
+        assert!(requires_responses_api("gpt-5-mini"));
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2241,6 +2241,61 @@ async fn gemini_models_route_via_copilot_and_succeed() {
 // Verifies that when /chat/completions returns 400 unsupported_api_for_model
 // the daemon automatically retries via /v1/responses and delivers the
 // response to the client.
+// ---------------------------------------------------------------------------
+
+/// When `/chat/completions` returns `400 unsupported_api_for_model` for a
+/// non-gpt-5 model the daemon must transparently retry via `/v1/responses`
+/// and deliver the response to the client.
+///
+/// gpt-4o is used here because it goes through the chat-first path; gpt-5.x
+/// skips chat/completions entirely so it cannot exercise this fallback.
+#[tokio::test]
+async fn chat_completions_400_falls_back_to_responses_api() {
+    let server = MockLlmServer::start().await;
+
+    // First request: /chat/completions returns 400 unsupported_api_for_model.
+    server.enqueue_error(
+        400,
+        r#"{"error":{"code":"unsupported_api_for_model","message":"model not supported via chat completions"}}"#,
+    );
+    // Second request: /v1/responses succeeds.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["fallback-ok"]));
+
+    let daemon = start_daemon(&server.url()).await.expect("start_daemon");
+    let client = connect_client(&daemon.socket);
+
+    let responses = send_message_with_session(&client, "hello", "sess-fallback", "copilot/gpt-4o")
+        .await
+        .expect("send_message");
+
+    let text = collect_text(&responses);
+    assert!(
+        text.contains("fallback-ok"),
+        "expected fallback response text; got: {text:?}"
+    );
+
+    // Two requests: the failed chat/completions attempt + the successful
+    // Responses API retry.
+    let reqs = server.take_requests();
+    assert_eq!(
+        reqs.len(),
+        2,
+        "expected 2 requests (chat/completions failure + Responses API retry), got {}",
+        reqs.len()
+    );
+
+    // The retry request must use Responses API wire format.
+    assert!(
+        reqs[1].body.get("input").is_some(),
+        "expected Responses API format (input field) on retry; got: {:?}",
+        reqs[1].body
+    );
+    assert!(
+        reqs[1].body.get("max_output_tokens").is_some(),
+        "expected Responses API format (max_output_tokens) on retry; got: {:?}",
+        reqs[1].body
+    );
+}
 
 // ===========================================================================
 // amaebi chat long-connection regression tests

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2050,47 +2050,56 @@ async fn all_models_use_copilot_endpoint_and_jwt() {
     }
 }
 
-/// When `/chat/completions` returns `400 unsupported_api_for_model`, the daemon
-/// must transparently retry via the Responses API (`/v1/responses`) and the
-/// client must receive the final text from that fallback call.
-///
-/// This is the regression test for the gpt-5.4 / gpt-5.x bug: those models
-/// gpt-5.x models are routed directly to the Responses API without a
-/// Chat Completions first-hop.
+/// gpt-5.4 must be routed directly to the Responses API without a first-hop
+/// to `/chat/completions`, sending exactly one request in Responses API wire
+/// format (`input` / `max_output_tokens`).
 #[tokio::test]
-async fn responses_api_fallback_on_unsupported_model() {
+async fn gpt5_direct_to_responses_api() {
     let server = MockLlmServer::start().await;
 
-    // Only one request expected: directly to /v1/responses (no chat/completions first-hop).
-    server.enqueue(ScriptedResponse::text_chunks(vec!["fallback-ok"]));
+    // Only one response queued — direct Responses API call, no /chat/completions.
+    server.enqueue(ScriptedResponse::text_chunks(vec!["responses-ok"]));
 
     let daemon = start_daemon(&server.url()).await.expect("start_daemon");
     let client = connect_client(&daemon.socket);
 
-    let responses = send_message_with_session(&client, "hello", "sess-fallback", "copilot/gpt-5.4")
-        .await
-        .expect("send_message");
+    let responses =
+        send_message_with_session(&client, "hello", "sess-gpt5-direct", "copilot/gpt-5.4")
+            .await
+            .expect("send_message");
 
     let text = collect_text(&responses);
     assert!(
-        text.contains("fallback-ok"),
-        "expected fallback response text; got: {text:?}"
+        text.contains("responses-ok"),
+        "expected Responses API response text; got: {text:?}"
     );
 
-    // Exactly one request must have been made: directly to /v1/responses.
+    // Exactly one request — no /chat/completions first-hop.
     let reqs = server.take_requests();
     assert_eq!(
         reqs.len(),
         1,
-        "expected 1 request (direct to /v1/responses, no chat/completions first-hop), got {}",
+        "expected 1 request (direct Responses API, no first-hop), got {}",
         reqs.len()
+    );
+
+    // Verify Responses API wire format.
+    assert!(
+        reqs[0].body.get("input").is_some(),
+        "expected Responses API format (input field); got: {:?}",
+        reqs[0].body
+    );
+    assert!(
+        reqs[0].body.get("max_output_tokens").is_some(),
+        "expected Responses API format (max_output_tokens field); got: {:?}",
+        reqs[0].body
     );
 }
 
 /// All gpt-5.x model variants must be routed directly to the Responses API
-/// without a Chat Completions first-hop.
+/// without a Chat Completions first-hop, using Responses API wire format.
 #[tokio::test]
-async fn responses_api_fallback_all_gpt5_variants() {
+async fn gpt5_all_variants_direct_to_responses_api() {
     for model in &[
         "copilot/gpt-5.4",
         "copilot/gpt-5.4-mini",
@@ -2098,7 +2107,6 @@ async fn responses_api_fallback_all_gpt5_variants() {
         "copilot/gpt-5-turbo",
     ] {
         let server = MockLlmServer::start().await;
-        // Only one request expected: directly to /v1/responses (no chat/completions first-hop).
         server.enqueue(ScriptedResponse::text_chunks(vec!["responses-ok"]));
 
         let daemon = start_daemon(&server.url()).await.expect("start_daemon");
@@ -2115,12 +2123,25 @@ async fn responses_api_fallback_all_gpt5_variants() {
             "model={model}: expected Responses API text; got: {text:?}"
         );
 
+        // Exactly one request — no /chat/completions first-hop.
         let reqs = server.take_requests();
         assert_eq!(
             reqs.len(),
             1,
-            "model={model}: expected 1 request (direct to /v1/responses), got {}",
+            "model={model}: expected 1 request (direct Responses API, no first-hop), got {}",
             reqs.len()
+        );
+
+        // Verify Responses API wire format.
+        assert!(
+            reqs[0].body.get("input").is_some(),
+            "model={model}: expected Responses API format (input field); got: {:?}",
+            reqs[0].body
+        );
+        assert!(
+            reqs[0].body.get("max_output_tokens").is_some(),
+            "model={model}: expected Responses API format (max_output_tokens field); got: {:?}",
+            reqs[0].body
         );
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2055,17 +2055,13 @@ async fn all_models_use_copilot_endpoint_and_jwt() {
 /// client must receive the final text from that fallback call.
 ///
 /// This is the regression test for the gpt-5.4 / gpt-5.x bug: those models
-/// are not accessible via `/chat/completions` and require the Responses API.
+/// gpt-5.x models are routed directly to the Responses API without a
+/// Chat Completions first-hop.
 #[tokio::test]
 async fn responses_api_fallback_on_unsupported_model() {
     let server = MockLlmServer::start().await;
 
-    // First request hits /chat/completions → 400 unsupported_api_for_model.
-    server.enqueue_error(
-        400,
-        r#"{"error":{"code":"unsupported_api_for_model","message":"model is not accessible via the /chat/completions endpoint"}}"#,
-    );
-    // Second request hits /v1/responses (fallback) → text response.
+    // Only one request expected: directly to /v1/responses (no chat/completions first-hop).
     server.enqueue(ScriptedResponse::text_chunks(vec!["fallback-ok"]));
 
     let daemon = start_daemon(&server.url()).await.expect("start_daemon");
@@ -2081,18 +2077,18 @@ async fn responses_api_fallback_on_unsupported_model() {
         "expected fallback response text; got: {text:?}"
     );
 
-    // Two requests must have been made: one to /chat/completions (400), one to /v1/responses.
+    // Exactly one request must have been made: directly to /v1/responses.
     let reqs = server.take_requests();
     assert_eq!(
         reqs.len(),
-        2,
-        "expected 2 requests (chat completions + responses fallback), got {}",
+        1,
+        "expected 1 request (direct to /v1/responses, no chat/completions first-hop), got {}",
         reqs.len()
     );
 }
 
-/// All gpt-5.x model variants must trigger the Responses API fallback when
-/// /chat/completions returns 400 unsupported_api_for_model.
+/// All gpt-5.x model variants must be routed directly to the Responses API
+/// without a Chat Completions first-hop.
 #[tokio::test]
 async fn responses_api_fallback_all_gpt5_variants() {
     for model in &[
@@ -2102,10 +2098,7 @@ async fn responses_api_fallback_all_gpt5_variants() {
         "copilot/gpt-5-turbo",
     ] {
         let server = MockLlmServer::start().await;
-        server.enqueue_error(
-            400,
-            r#"{"error":{"code":"unsupported_api_for_model","message":"not via chat/completions"}}"#,
-        );
+        // Only one request expected: directly to /v1/responses (no chat/completions first-hop).
         server.enqueue(ScriptedResponse::text_chunks(vec!["responses-ok"]));
 
         let daemon = start_daemon(&server.url()).await.expect("start_daemon");
@@ -2125,8 +2118,8 @@ async fn responses_api_fallback_all_gpt5_variants() {
         let reqs = server.take_requests();
         assert_eq!(
             reqs.len(),
-            2,
-            "model={model}: expected 2 requests (chat/completions + /v1/responses), got {}",
+            1,
+            "model={model}: expected 1 request (direct to /v1/responses), got {}",
             reqs.len()
         );
     }


### PR DESCRIPTION
## Summary

- Add `requires_responses_api(model: &str) -> bool` predicate that returns `true` for the gpt-5 family (`gpt-5`, `gpt-5.*`, `gpt-5-*`)
- Modify `invoke_copilot()` to skip the Chat Completions first-hop for these models and call `responses::stream_chat` directly, with the same auth-error evict-and-retry logic
- Update integration tests to assert exactly 1 request for gpt-5.x models (was 2)
- Add unit tests: `gpt_5_4_requires_responses_api`, `gpt_5_mini_requires_responses_api`, `gpt_4o_does_not_require_responses_api`

Fixes #75.

## Test plan

- [x] `cargo test` — all 33 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)