### PR TITLE
chore: add Claude Code pre-commit hook to enforce test.sh --docker

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+worktrees/

--- a/.claude/hooks/pre-commit.sh
+++ b/.claude/hooks/pre-commit.sh
@@ -33,18 +33,23 @@ print(command)
 fi
 
 # Use token-level parsing to detect 'git commit', correctly handling global
-# git options before the subcommand (e.g. git -c foo=bar commit, git --no-pager commit).
-SHOULD_RUN=$(python3 -c "
-import shlex, sys
+# git options before the subcommand (e.g. git -c foo=bar commit, git -C /path commit).
+# TOOL_CMD is passed via environment to avoid shell-interpolation injection.
+# Outputs two lines: "0" or "1" (should run), then the effective -C work dir (may be empty).
+# Fails with exit 1 on unparseable input so the hook fails closed.
+PARSE_RESULT=$(TOOL_CMD="$TOOL_CMD" python3 -c "
+import os, shlex, sys
 
+cmd = os.environ.get('TOOL_CMD', '')
 try:
-    argv = shlex.split('''$TOOL_CMD''')
+    argv = shlex.split(cmd)
 except Exception:
-    print('0')
-    sys.exit(0)
+    sys.stderr.write('[hook] error: could not tokenize git command\n')
+    sys.exit(1)
 
 if not argv or argv[0] != 'git':
     print('0')
+    print('')
     sys.exit(0)
 
 # Global git options that consume the next token as a value.
@@ -52,26 +57,34 @@ global_opts_with_value = {'-c', '-C', '--git-dir', '--work-tree',
                           '--namespace', '--super-prefix', '--config-env'}
 
 i = 1
+work_dir = ''
 while i < len(argv):
     token = argv[i]
     if token == 'commit':
         break
     if token == '--':
         print('0')
+        print('')
         sys.exit(0)
     if token.startswith('-'):
         opt = token.split('=', 1)[0]
         if opt in global_opts_with_value and '=' not in token:
+            if opt == '-C' and i + 1 < len(argv):
+                work_dir = argv[i + 1]
             i += 2
         else:
+            if opt == '-C' and len(token) > 2:
+                work_dir = token[2:]
             i += 1
         continue
-    # Non-option, non-'commit' token — some other subcommand.
+    # Non-option, non-'commit' token — some other git subcommand.
     print('0')
+    print('')
     sys.exit(0)
 
 if i >= len(argv) or argv[i] != 'commit':
     print('0')
+    print('')
     sys.exit(0)
 
 # Check commit-level bypass flags as exact tokens.
@@ -80,13 +93,24 @@ if any(arg in ('--no-verify', '-n', '--help', '-h') for arg in commit_args):
     print('0')
 else:
     print('1')
-" 2>/dev/null || echo "0")
+print(work_dir)
+") || {
+    echo "[hook] error: failed to parse git command, blocking commit" >&2
+    exit 1
+}
+
+SHOULD_RUN=$(echo "$PARSE_RESULT" | sed -n '1p')
+WORK_DIR=$(echo "$PARSE_RESULT" | sed -n '2p')
 
 if [ "$SHOULD_RUN" != "1" ]; then
     exit 0
 fi
 
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+if [ -n "$WORK_DIR" ]; then
+    REPO_ROOT=$(git -C "$WORK_DIR" rev-parse --show-toplevel 2>/dev/null || echo "$WORK_DIR")
+else
+    REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+fi
 cd "$REPO_ROOT"
 echo "[hook] running scripts/test.sh --docker before commit..."
 exec ./scripts/test.sh --docker

--- a/.claude/hooks/pre-commit.sh
+++ b/.claude/hooks/pre-commit.sh
@@ -7,27 +7,84 @@
 
 set -euo pipefail
 
-# Extract the bash command from the tool input.
-TOOL_CMD=$(python3 -c "
-import os, json
+# python3 is required to parse CLAUDE_TOOL_INPUT; fail closed if missing.
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "[hook] error: python3 is required to parse CLAUDE_TOOL_INPUT" >&2
+    exit 1
+fi
+
+# Extract the bash command from the tool input; fail closed on parse error.
+if ! TOOL_CMD=$(python3 -c "
+import json, os, sys
 raw = os.environ.get('CLAUDE_TOOL_INPUT', '{}')
 try:
-    print(json.loads(raw).get('command', ''))
+    payload = json.loads(raw)
 except Exception:
-    print('')
-" 2>/dev/null || true)
+    sys.exit(1)
+if not isinstance(payload, dict):
+    sys.exit(1)
+command = payload.get('command')
+if not isinstance(command, str):
+    sys.exit(1)
+print(command)
+"); then
+    echo "[hook] error: failed to parse CLAUDE_TOOL_INPUT" >&2
+    exit 1
+fi
 
-# Only intercept actual commit invocations; skip --no-verify and --help.
-case "$TOOL_CMD" in
-    *"git commit"*)
-        if echo "$TOOL_CMD" | grep -qE '(--no-verify|-n[[:space:]]|--help|-h[[:space:]])'; then
-            exit 0
-        fi
-        ;;
-    *)
-        exit 0
-        ;;
-esac
+# Use token-level parsing to detect 'git commit', correctly handling global
+# git options before the subcommand (e.g. git -c foo=bar commit, git --no-pager commit).
+SHOULD_RUN=$(python3 -c "
+import shlex, sys
+
+try:
+    argv = shlex.split('''$TOOL_CMD''')
+except Exception:
+    print('0')
+    sys.exit(0)
+
+if not argv or argv[0] != 'git':
+    print('0')
+    sys.exit(0)
+
+# Global git options that consume the next token as a value.
+global_opts_with_value = {'-c', '-C', '--git-dir', '--work-tree',
+                          '--namespace', '--super-prefix', '--config-env'}
+
+i = 1
+while i < len(argv):
+    token = argv[i]
+    if token == 'commit':
+        break
+    if token == '--':
+        print('0')
+        sys.exit(0)
+    if token.startswith('-'):
+        opt = token.split('=', 1)[0]
+        if opt in global_opts_with_value and '=' not in token:
+            i += 2
+        else:
+            i += 1
+        continue
+    # Non-option, non-'commit' token — some other subcommand.
+    print('0')
+    sys.exit(0)
+
+if i >= len(argv) or argv[i] != 'commit':
+    print('0')
+    sys.exit(0)
+
+# Check commit-level bypass flags as exact tokens.
+commit_args = argv[i + 1:]
+if any(arg in ('--no-verify', '-n', '--help', '-h') for arg in commit_args):
+    print('0')
+else:
+    print('1')
+" 2>/dev/null || echo "0")
+
+if [ "$SHOULD_RUN" != "1" ]; then
+    exit 0
+fi
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 cd "$REPO_ROOT"

--- a/.claude/hooks/pre-commit.sh
+++ b/.claude/hooks/pre-commit.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# .claude/hooks/pre-commit.sh
+#
+# PreToolUse hook: runs scripts/test.sh --docker before every `git commit`.
+# Called by Claude Code with CLAUDE_TOOL_INPUT set to the Bash tool's JSON input.
+# Exit non-zero to block the commit and surface the failure to Claude.
+
+set -euo pipefail
+
+# Extract the bash command from the tool input.
+TOOL_CMD=$(python3 -c "
+import os, json
+raw = os.environ.get('CLAUDE_TOOL_INPUT', '{}')
+try:
+    print(json.loads(raw).get('command', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+# Only intercept actual commit invocations; skip --no-verify and --help.
+case "$TOOL_CMD" in
+    *"git commit"*)
+        if echo "$TOOL_CMD" | grep -qE '(--no-verify|-n[[:space:]]|--help|-h[[:space:]])'; then
+            exit 0
+        fi
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+echo "[hook] running scripts/test.sh --docker before commit..."
+exec ./scripts/test.sh --docker

--- a/.claude/hooks/pre-commit.sh
+++ b/.claude/hooks/pre-commit.sh
@@ -2,33 +2,35 @@
 # .claude/hooks/pre-commit.sh
 #
 # PreToolUse hook: runs scripts/test.sh --docker before every `git commit`.
-# Called by Claude Code with CLAUDE_TOOL_INPUT set to the Bash tool's JSON input.
+# Called by Claude Code with hook JSON piped to stdin.
 # Exit non-zero to block the commit and surface the failure to Claude.
 
 set -euo pipefail
 
-# python3 is required to parse CLAUDE_TOOL_INPUT; fail closed if missing.
+# python3 is required to parse stdin JSON; fail closed if missing.
 if ! command -v python3 >/dev/null 2>&1; then
-    echo "[hook] error: python3 is required to parse CLAUDE_TOOL_INPUT" >&2
+    echo "[hook] error: python3 is required" >&2
     exit 1
 fi
 
-# Extract the bash command from the tool input; fail closed on parse error.
+# Read hook input from stdin; extract the bash command. Fail closed on error.
 if ! TOOL_CMD=$(python3 -c "
-import json, os, sys
-raw = os.environ.get('CLAUDE_TOOL_INPUT', '{}')
+import json, sys
 try:
-    payload = json.loads(raw)
+    payload = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
 if not isinstance(payload, dict):
     sys.exit(1)
-command = payload.get('command')
+tool_input = payload.get('tool_input', {})
+if not isinstance(tool_input, dict):
+    sys.exit(1)
+command = tool_input.get('command')
 if not isinstance(command, str):
     sys.exit(1)
 print(command)
 "); then
-    echo "[hook] error: failed to parse CLAUDE_TOOL_INPUT" >&2
+    echo "[hook] error: failed to parse hook input from stdin" >&2
     exit 1
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-commit.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with a `PreToolUse` hook on Bash that intercepts `git commit` invocations and runs `scripts/test.sh --docker` before the commit proceeds
- `scripts/test.sh --docker` covers both Step 1 (cargo check + test + clippy inside the dev container) and Step 2 (Docker integration tests with `--ignored` on the host)
- Commits with `--no-verify` or `--help` pass through unchanged
- Adds `.claude/.gitignore` to keep the `worktrees/` directory out of the repository

## Test plan

- [x] Make a change, attempt `git commit` — verify `scripts/test.sh --docker` runs and blocks on failure
- [x] Verify `git commit --no-verify` bypasses the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)