### PR TITLE
feat: add amaebi startup ASCII banner and runtime status summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "amaebi"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,44 @@
+//! Build script: inject the current git commit short hash as `AMAEBI_GIT_COMMIT`.
+//!
+//! Falls back to "unknown" if `git` is unavailable or the build is not in a
+//! git worktree (e.g. built from a source tarball). Re-runs when the real
+//! git `HEAD` or `index` paths change so the hash stays fresh across commits,
+//! including worktrees, submodules, and similar setups where `.git` is a file.
+
+use std::process::Command;
+
+fn git_path(name: &str) -> Option<String> {
+    Command::new("git")
+        .args(["rev-parse", "--git-path", name])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn main() {
+    // Re-run when HEAD moves (new commits, checkouts) or the working tree
+    // gets a new index (amends/rebases update the index too).
+    // Use `git rev-parse --git-path` so we find the real paths in worktrees
+    // and submodules where `.git` is a file pointing elsewhere.
+    if let Some(path) = git_path("HEAD") {
+        println!("cargo:rerun-if-changed={path}");
+    }
+    if let Some(path) = git_path("index") {
+        println!("cargo:rerun-if-changed={path}");
+    }
+
+    let commit = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=AMAEBI_GIT_COMMIT={commit}");
+}

--- a/src/banner.rs
+++ b/src/banner.rs
@@ -1,0 +1,100 @@
+use std::io::IsTerminal as _;
+use std::path::Path;
+
+/// Startup logo rendered in Calvin S box-drawing style.
+const LOGO: &str = "
+  ╔═╗╔╦╗╔═╗╔═╗╔╗ ╦
+  ╠═╣║║║╠═╣║╣ ╠╩╗║
+  ╩ ╩╩ ╩╩ ╩╚═╝╚═╝╩
+";
+
+/// Inner logic for [`should_show`], parameterised so tests can inject values
+/// without touching process-global env vars.
+fn should_show_impl(no_banner_env: Option<&str>, stderr_is_tty: bool) -> bool {
+    // Opt-out: only the exact value "1" suppresses.
+    if no_banner_env == Some("1") {
+        return false;
+    }
+    stderr_is_tty
+}
+
+/// Returns `true` when the startup banner should be printed.
+///
+/// Suppressed when either:
+/// - `AMAEBI_NO_BANNER=1` is set in the environment, or
+/// - stderr is not a terminal (non-interactive / pipe / redirect mode).
+pub fn should_show() -> bool {
+    should_show_impl(
+        std::env::var("AMAEBI_NO_BANNER").ok().as_deref(),
+        std::io::stderr().is_terminal(),
+    )
+}
+
+/// Print the banner and a compact runtime status block to stderr.
+///
+/// Callers are responsible for gating this behind [`should_show`].
+pub fn print(model: &str, session_id: &str, cwd: &Path) {
+    let version = env!("CARGO_PKG_VERSION");
+    let commit = env!("AMAEBI_GIT_COMMIT");
+
+    let sandbox = match std::env::var("AMAEBI_SANDBOX").as_deref() {
+        Ok("docker") => {
+            let image = std::env::var("AMAEBI_SANDBOX_IMAGE")
+                .unwrap_or_else(|_| "amaebi-sandbox:bookworm-slim".to_string());
+            format!("docker ({image})")
+        }
+        _ => "off".to_string(),
+    };
+
+    // Always show the resolved provider/ prefix so users see which backend
+    // will be hit.  Unknown prefixes (e.g. `azure/`) route to Bedrock by
+    // default — reflect that rather than echoing the raw input.
+    let spec = crate::provider::resolve(model);
+    let model_display = if model.starts_with("copilot/") || model.starts_with("bedrock/") {
+        model.to_string()
+    } else {
+        format!("{}/{}", spec.provider, model)
+    };
+
+    eprint!("{LOGO}");
+    eprintln!("  version  {version} ({commit})");
+    eprintln!("  model    {model_display}");
+    eprintln!("  sandbox  {sandbox}");
+    eprintln!("  session  {session_id}");
+    eprintln!("  cwd      {}", cwd.display());
+    eprintln!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logo_is_non_empty() {
+        assert!(!LOGO.trim().is_empty());
+    }
+
+    #[test]
+    fn suppressed_when_no_banner_env_is_one_regardless_of_tty() {
+        assert!(!should_show_impl(Some("1"), true));
+        assert!(!should_show_impl(Some("1"), false));
+    }
+
+    #[test]
+    fn suppressed_when_not_tty() {
+        assert!(!should_show_impl(None, false));
+        assert!(!should_show_impl(Some("0"), false));
+    }
+
+    #[test]
+    fn shown_when_tty_and_no_env_override() {
+        assert!(should_show_impl(None, true));
+    }
+
+    #[test]
+    fn env_var_value_other_than_one_does_not_suppress() {
+        assert!(should_show_impl(Some("true"), true));
+        assert!(should_show_impl(Some("yes"), true));
+        assert!(should_show_impl(Some(""), true));
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -604,6 +604,11 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
         });
     let session_id_copy = session_id.clone();
 
+    // Show startup banner when running interactively (TTY, not opted out).
+    if crate::banner::should_show() {
+        crate::banner::print(&model, &session_id_copy, &cwd);
+    }
+
     // Build and send the request as a single JSON line.
     let req = Request::Chat {
         prompt,
@@ -910,7 +915,10 @@ pub async fn run_chat_loop(
             "global".to_string()
         });
 
-    if std::io::stderr().is_terminal() {
+    if crate::banner::should_show() {
+        crate::banner::print(&model, &session_id, &cwd);
+    } else if std::io::stderr().is_terminal() {
+        // Minimal fallback when the banner is opted out but we're still on a TTY.
         eprintln!("Chat session started (ID: {session_id}). Empty line or Ctrl-D to exit.\n");
     }
 
@@ -1520,6 +1528,12 @@ pub async fn run_resume(
     let model = model
         .or_else(|| std::env::var("AMAEBI_MODEL").ok())
         .unwrap_or_else(|| crate::provider::DEFAULT_MODEL.to_string());
+
+    // Show startup banner when running interactively (TTY, not opted out).
+    if crate::banner::should_show() {
+        let cwd = std::env::current_dir().context("getting current directory")?;
+        crate::banner::print(&model, &session_uuid, &cwd);
+    }
 
     let req = Request::Resume {
         prompt,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 mod agent_server;
 mod auth;
 mod auth_flow;
+mod banner;
 mod bedrock;
 mod cli;
 mod client;


### PR DESCRIPTION
Implements issue #81.

## What changed
- Add startup banner module (`src/banner.rs`) with amaebi ASCII art.
- Show runtime summary (version, model/provider, sandbox mode, session short id, cwd/workdir).
- Wire banner into both startup paths:
  - `amaebi ask`
  - `amaebi chat`
- Add opt-out via `AMAEBI_NO_BANNER=1`.
- Keep output minimal/safe for non-interactive scenarios.

## Validation
- `bash scripts/test.sh`
- `bash scripts/test.sh --docker`

Closes #81
