### PR TITLE
feat(pane-scheduler): tmux pane lease system and /claude command (#76)

### DIFF
--- a/src/agent_server.rs
+++ b/src/agent_server.rs
@@ -330,6 +330,10 @@ impl acp::Agent for AmaebiAgent {
                     // ACP mode never submits detach requests.
                     tracing::debug!("unexpected DetachAccepted in ACP mode");
                 }
+                Response::PaneAssigned { .. } | Response::CapacityError { .. } => {
+                    // ACP mode never sends ClaudeLaunch requests.
+                    tracing::debug!("unexpected pane scheduler response in ACP mode");
+                }
             }
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -310,6 +310,14 @@ fn parse_claude_command(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> 
             .join(" ")]
     };
 
+    // --worktree is a single path — it cannot be shared across multiple tasks
+    // because the daemon enforces worktree uniqueness per pane.
+    if worktree.is_some() && descriptions.len() > 1 {
+        return Some(Err("--worktree cannot be used with multiple tasks; \
+             each task gets its own auto-created worktree"
+            .to_string()));
+    }
+
     let tasks: Vec<ClaudeTask> = descriptions
         .into_iter()
         .enumerate()
@@ -351,15 +359,26 @@ fn make_task_id(description: &str, idx: usize) -> String {
     }
     let trimmed = result.trim_matches('-');
 
-    let base = if trimmed.is_empty() {
-        format!("task-{idx}")
-    } else if trimmed.len() > 32 {
+    // For non-ASCII-only descriptions that produce an empty slug, use
+    // "task-{idx}" which already encodes the index — no suffix needed.
+    if trimmed.is_empty() {
+        return format!("task-{idx}");
+    }
+
+    let base = if trimmed.len() > 32 {
         trimmed[..32].trim_end_matches('-').to_string()
     } else {
         trimmed.to_string()
     };
 
-    base
+    // Append the index for tasks beyond the first so that duplicate
+    // descriptions within a single /claude invocation get distinct task_ids
+    // (and therefore distinct auto-worktree paths / branch names).
+    if idx > 0 {
+        format!("{base}-{idx}")
+    } else {
+        base
+    }
 }
 
 /// Parse shell-style arguments, supporting both quoted and unquoted tokens.
@@ -463,6 +482,9 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                     task_id: t.task_id,
                     description: t.description,
                     worktree: t.worktree,
+                    client_cwd: std::env::current_dir()
+                        .ok()
+                        .map(|p| p.to_string_lossy().into_owned()),
                     auto_enter: t.auto_enter,
                 })
                 .collect(),
@@ -887,6 +909,9 @@ pub async fn run_chat_loop(
                         task_id: t.task_id,
                         description: t.description,
                         worktree: t.worktree,
+                        client_cwd: std::env::current_dir()
+                            .ok()
+                            .map(|p| p.to_string_lossy().into_owned()),
                         auto_enter: t.auto_enter,
                     })
                     .collect(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -221,18 +221,26 @@ struct ClaudeTask {
 /// /claude [--worktree <path>] [--no-enter] "task description" ["task2" ...]
 /// ```
 ///
-/// Returns `None` if the input does not start with `/claude ` (trailing space
-/// required) or has no task descriptions.
-fn parse_claude_command(input: &str) -> Option<Vec<ClaudeTask>> {
+/// Returns:
+/// - `None` — input does not start with `/claude ` (not a `/claude` command)
+/// - `Some(Err(msg))` — input is a `/claude` command but has a parse error
+/// - `Some(Ok(tasks))` — successfully parsed task list
+fn parse_claude_command(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> {
     let rest = input.strip_prefix("/claude ")?.trim();
     if rest.is_empty() {
-        return None;
+        return Some(Err(
+            "usage: /claude [--worktree <path>] [--no-enter] \"task description\" [...]"
+                .to_string(),
+        ));
     }
 
     // Tokenise (shell-style quoting); each entry is (token, was_quoted).
     let tokens = parse_quoted_args(rest);
     if tokens.is_empty() {
-        return None;
+        return Some(Err(
+            "usage: /claude [--worktree <path>] [--no-enter] \"task description\" [...]"
+                .to_string(),
+        ));
     }
 
     let mut worktree: Option<String> = None;
@@ -247,9 +255,15 @@ fn parse_claude_command(input: &str) -> Option<Vec<ClaudeTask>> {
                 i += 1;
                 // Require a non-flag value to follow --worktree.
                 if i >= tokens.len() || tokens[i].0.starts_with("--") {
-                    return None; // missing value
+                    return Some(Err("--worktree requires a path argument".to_string()));
                 }
-                worktree = Some(tokens[i].0.clone());
+                // Canonicalize to an absolute path so worktree uniqueness
+                // checks in the daemon are reliable regardless of how the
+                // path was spelled (relative vs. symlink vs. absolute).
+                let raw = &tokens[i].0;
+                let abs =
+                    std::fs::canonicalize(raw).unwrap_or_else(|_| std::path::PathBuf::from(raw));
+                worktree = Some(abs.to_string_lossy().into_owned());
             }
             "--no-enter" => {
                 auto_enter = false;
@@ -262,7 +276,10 @@ fn parse_claude_command(input: &str) -> Option<Vec<ClaudeTask>> {
     }
 
     if desc_tokens.is_empty() {
-        return None;
+        return Some(Err(
+            "usage: /claude [--worktree <path>] [--no-enter] \"task description\" [...]"
+                .to_string(),
+        ));
     }
 
     // Build task list.  Quoted tokens each become a separate task.  Unquoted
@@ -294,7 +311,7 @@ fn parse_claude_command(input: &str) -> Option<Vec<ClaudeTask>> {
         })
         .collect();
 
-    Some(tasks)
+    Some(Ok(tasks))
 }
 
 /// Derive a short task label from a description + index.
@@ -415,7 +432,17 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
     let session_id_copy = session_id.clone();
 
     // Intercept `/claude` commands: send a ClaudeLaunch request instead of Chat.
-    if let Some(tasks) = parse_claude_command(&prompt) {
+    if let Some(parse_result) = parse_claude_command(&prompt) {
+        let tasks = match parse_result {
+            Ok(t) => t,
+            Err(msg) => {
+                let mut stdout = tokio::io::stdout();
+                stdout.write_all(msg.as_bytes()).await?;
+                stdout.write_all(b"\n").await?;
+                stdout.flush().await?;
+                return Ok(());
+            }
+        };
         let req = Request::ClaudeLaunch {
             tasks: tasks
                 .into_iter()
@@ -830,7 +857,16 @@ pub async fn run_chat_loop(
 
         // Intercept `/claude` commands: send ClaudeLaunch and handle the response
         // before resuming the normal chat loop.
-        if let Some(tasks) = parse_claude_command(&prompt) {
+        if let Some(parse_result) = parse_claude_command(&prompt) {
+            let tasks = match parse_result {
+                Ok(t) => t,
+                Err(msg) => {
+                    stdout.write_all(msg.as_bytes()).await?;
+                    stdout.write_all(b"\n").await?;
+                    stdout.flush().await?;
+                    continue 'session;
+                }
+            };
             let req = Request::ClaudeLaunch {
                 tasks: tasks
                     .into_iter()
@@ -3276,7 +3312,7 @@ mod tests {
     #[test]
     fn parse_claude_two_quoted_tasks() {
         let result = parse_claude_command(r#"/claude "task one" "task two""#);
-        let tasks = result.expect("should parse");
+        let tasks = result.expect("should be Some").expect("should be Ok");
         assert_eq!(tasks.len(), 2);
         assert_eq!(tasks[0].description, "task one");
         assert_eq!(tasks[1].description, "task two");
@@ -3286,7 +3322,7 @@ mod tests {
     #[test]
     fn parse_claude_single_quoted_task() {
         let result = parse_claude_command(r#"/claude "implement something""#);
-        let tasks = result.expect("should parse");
+        let tasks = result.expect("should be Some").expect("should be Ok");
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].description, "implement something");
     }
@@ -3294,7 +3330,7 @@ mod tests {
     #[test]
     fn parse_claude_unquoted_tokens_join_as_single_task() {
         let result = parse_claude_command("/claude implement something");
-        let tasks = result.expect("should parse");
+        let tasks = result.expect("should be Some").expect("should be Ok");
         // Unquoted words are joined into one task (avoids surprising N-task launch).
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].description, "implement something");
@@ -3302,12 +3338,15 @@ mod tests {
 
     #[test]
     fn parse_claude_no_args_returns_none() {
+        // No trailing space — not a /claude command at all.
         assert!(parse_claude_command("/claude").is_none());
     }
 
     #[test]
-    fn parse_claude_only_space_returns_none() {
-        assert!(parse_claude_command("/claude   ").is_none());
+    fn parse_claude_only_space_returns_err() {
+        // Has trailing spaces → recognized as /claude command but missing description.
+        let result = parse_claude_command("/claude   ");
+        assert!(result.expect("should be Some").is_err());
     }
 
     #[test]
@@ -3318,7 +3357,7 @@ mod tests {
     #[test]
     fn parse_claude_no_enter_flag() {
         let result = parse_claude_command(r#"/claude --no-enter "do something""#);
-        let tasks = result.expect("should parse");
+        let tasks = result.expect("should be Some").expect("should be Ok");
         assert_eq!(tasks.len(), 1);
         assert!(!tasks[0].auto_enter);
         assert_eq!(tasks[0].description, "do something");
@@ -3326,8 +3365,9 @@ mod tests {
 
     #[test]
     fn parse_claude_worktree_flag() {
+        // Non-existent path: canonicalize falls back to the raw string.
         let result = parse_claude_command(r#"/claude --worktree /repo/wt/t1 "implement X""#);
-        let tasks = result.expect("should parse");
+        let tasks = result.expect("should be Some").expect("should be Ok");
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].worktree.as_deref(), Some("/repo/wt/t1"));
         assert_eq!(tasks[0].description, "implement X");
@@ -3336,7 +3376,7 @@ mod tests {
     #[test]
     fn parse_claude_escaped_quotes_in_description() {
         let result = parse_claude_command(r#"/claude "task with \"quotes\"""#);
-        let tasks = result.expect("should parse");
+        let tasks = result.expect("should be Some").expect("should be Ok");
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].description, r#"task with "quotes""#);
     }
@@ -3344,7 +3384,7 @@ mod tests {
     #[test]
     fn parse_claude_task_id_derived_from_description() {
         let result = parse_claude_command(r#"/claude "Implement Cron Scheduling""#);
-        let tasks = result.expect("should parse");
+        let tasks = result.expect("should be Some").expect("should be Ok");
         assert_eq!(tasks[0].task_id, "implement-cron-scheduling");
     }
 
@@ -3352,7 +3392,7 @@ mod tests {
     fn parse_claude_task_id_truncated() {
         let long = format!("/claude \"{}\"", "a".repeat(100));
         let result = parse_claude_command(&long);
-        let tasks = result.expect("should parse");
+        let tasks = result.expect("should be Some").expect("should be Ok");
         assert!(tasks[0].task_id.len() <= 32);
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -204,7 +204,7 @@ fn render_markdown(text: &str) -> String {
 /// A task parsed from the `/claude` command.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ClaudeTask {
-    /// User-supplied task label (derived from description if not given with --id).
+    /// Short task label derived from the description.
     task_id: String,
     /// Task description / opening prompt.
     description: String,
@@ -229,7 +229,7 @@ fn parse_claude_command(input: &str) -> Option<Vec<ClaudeTask>> {
         return None;
     }
 
-    // Tokenise (shell-style quoting).
+    // Tokenise (shell-style quoting); each entry is (token, was_quoted).
     let tokens = parse_quoted_args(rest);
     if tokens.is_empty() {
         return None;
@@ -237,30 +237,48 @@ fn parse_claude_command(input: &str) -> Option<Vec<ClaudeTask>> {
 
     let mut worktree: Option<String> = None;
     let mut auto_enter = true;
-    let mut descriptions: Vec<String> = Vec::new();
+    // (description, was_quoted) pairs for non-flag tokens.
+    let mut desc_tokens: Vec<(String, bool)> = Vec::new();
 
     let mut i = 0;
     while i < tokens.len() {
-        match tokens[i].as_str() {
+        match tokens[i].0.as_str() {
             "--worktree" => {
                 i += 1;
-                if i < tokens.len() {
-                    worktree = Some(tokens[i].clone());
+                // Require a non-flag value to follow --worktree.
+                if i >= tokens.len() || tokens[i].0.starts_with("--") {
+                    return None; // missing value
                 }
+                worktree = Some(tokens[i].0.clone());
             }
             "--no-enter" => {
                 auto_enter = false;
             }
             tok => {
-                descriptions.push(tok.to_string());
+                desc_tokens.push((tok.to_string(), tokens[i].1));
             }
         }
         i += 1;
     }
 
-    if descriptions.is_empty() {
+    if desc_tokens.is_empty() {
         return None;
     }
+
+    // Build task list.  Quoted tokens each become a separate task.  Unquoted
+    // tokens are joined as a single task (e.g. `/claude write some code` →
+    // one task "write some code", not three separate tasks).
+    let all_quoted = desc_tokens.iter().all(|(_, q)| *q);
+    let descriptions: Vec<String> = if all_quoted || desc_tokens.len() == 1 {
+        desc_tokens.into_iter().map(|(s, _)| s).collect()
+    } else {
+        // Mix of quoted and unquoted, or all unquoted: join as one description.
+        vec![desc_tokens
+            .into_iter()
+            .map(|(s, _)| s)
+            .collect::<Vec<_>>()
+            .join(" ")]
+    };
 
     let tasks: Vec<ClaudeTask> = descriptions
         .into_iter()
@@ -316,10 +334,14 @@ fn make_task_id(description: &str, idx: usize) -> String {
 
 /// Parse shell-style arguments, supporting both quoted and unquoted tokens.
 ///
-/// - `"implement cron" "fix context limit"` → `["implement cron", "fix context limit"]`
-/// - `foo "bar"` → `["foo", "bar"]`  (mixed quoted/unquoted)
+/// Returns `(token, was_quoted)` pairs so callers can distinguish
+/// `"foo" "bar"` (two separately-quoted tasks) from `foo bar` (one task whose
+/// words were split by whitespace).
+///
+/// - `"implement cron" "fix context limit"` → two quoted tokens
+/// - `foo "bar"` → one unquoted + one quoted token
 /// - Escaped quotes inside quoted strings: `"say \"hi\""` → `[r#"say "hi""#]`
-fn parse_quoted_args(input: &str) -> Vec<String> {
+fn parse_quoted_args(input: &str) -> Vec<(String, bool)> {
     let mut results = Vec::new();
     let mut chars = input.chars().peekable();
 
@@ -341,7 +363,7 @@ fn parse_quoted_args(input: &str) -> Vec<String> {
             }
             let trimmed = arg.trim().to_string();
             if !trimmed.is_empty() {
-                results.push(trimmed);
+                results.push((trimmed, true));
             }
         } else if ch.is_whitespace() {
             chars.next();
@@ -355,7 +377,7 @@ fn parse_quoted_args(input: &str) -> Vec<String> {
                 chars.next();
             }
             if !arg.is_empty() {
-                results.push(arg);
+                results.push((arg, false));
             }
         }
     }
@@ -3270,13 +3292,12 @@ mod tests {
     }
 
     #[test]
-    fn parse_claude_unquoted_tokens_become_separate_tasks() {
+    fn parse_claude_unquoted_tokens_join_as_single_task() {
         let result = parse_claude_command("/claude implement something");
         let tasks = result.expect("should parse");
-        // Unquoted: each whitespace-separated token is a separate task.
-        assert_eq!(tasks.len(), 2);
-        assert_eq!(tasks[0].description, "implement");
-        assert_eq!(tasks[1].description, "something");
+        // Unquoted words are joined into one task (avoids surprising N-task launch).
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].description, "implement something");
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -278,8 +278,20 @@ fn parse_claude_command(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> 
             "--no-enter" => {
                 auto_enter = false;
             }
+            // `--` marks end of flags; everything after is a description token.
+            "--" => {
+                i += 1;
+                while i < tokens.len() {
+                    desc_tokens.push((tokens[i].0.clone(), tokens[i].1));
+                    i += 1;
+                }
+                break;
+            }
             tok => {
-                if tok.starts_with("--") {
+                // Only treat unquoted tokens starting with `--` as unknown
+                // flags.  A quoted token like `"--investigate"` is a valid
+                // task description and must not be rejected.
+                if !tokens[i].1 && tok.starts_with("--") {
                     return Some(Err(format!("unknown flag: {tok}")));
                 }
                 desc_tokens.push((tok.to_string(), tokens[i].1));

--- a/src/client.rs
+++ b/src/client.rs
@@ -448,22 +448,11 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
         .or_else(|| std::env::var("AMAEBI_MODEL").ok())
         .unwrap_or_else(|| crate::provider::DEFAULT_MODEL.to_string());
 
-    // Resolve the session UUID for the current working directory.
-    // Wrapped in spawn_blocking because session::get_or_create does file I/O.
     let cwd = std::env::current_dir().context("getting current directory")?;
-    let cwd_for_session = cwd.clone();
-    let session_id = tokio::task::spawn_blocking(move || session::get_or_create(&cwd_for_session))
-        .await
-        .context("session::get_or_create panicked")?
-        .unwrap_or_else(|e| {
-            tracing::warn!(error = %e, "failed to resolve session id; using \"global\"");
-            "global".to_string()
-        });
-
-    // Keep a copy for the steering requests and the exit footer.
-    let session_id_copy = session_id.clone();
 
     // Intercept `/claude` commands: send a ClaudeLaunch request instead of Chat.
+    // Checked before session::get_or_create to avoid unnecessary disk I/O for
+    // commands that don't use the chat session.
     if let Some(parse_result) = parse_claude_command(&prompt) {
         let tasks = match parse_result {
             Ok(t) => t,
@@ -536,6 +525,19 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
         stdout.flush().await?;
         return Ok(());
     }
+
+    // Resolve the session UUID now that we know this is a chat request
+    // (not a /claude command).  Done after the /claude check to avoid
+    // unnecessary disk I/O for commands that don't use the chat session.
+    let cwd_for_session = cwd.clone();
+    let session_id = tokio::task::spawn_blocking(move || session::get_or_create(&cwd_for_session))
+        .await
+        .context("session::get_or_create panicked")?
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "failed to resolve session id; using \"global\"");
+            "global".to_string()
+        });
+    let session_id_copy = session_id.clone();
 
     // Build and send the request as a single JSON line.
     let req = Request::Chat {

--- a/src/client.rs
+++ b/src/client.rs
@@ -260,15 +260,28 @@ fn parse_claude_command(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> 
                 // Canonicalize to an absolute path so worktree uniqueness
                 // checks in the daemon are reliable regardless of how the
                 // path was spelled (relative vs. symlink vs. absolute).
+                // If canonicalize fails (path doesn't exist yet), fall back to
+                // an explicit absolute path rather than leaving it relative.
                 let raw = &tokens[i].0;
-                let abs =
-                    std::fs::canonicalize(raw).unwrap_or_else(|_| std::path::PathBuf::from(raw));
+                let raw_path = std::path::PathBuf::from(raw);
+                let abs = std::fs::canonicalize(&raw_path).unwrap_or_else(|_| {
+                    if raw_path.is_absolute() {
+                        raw_path.clone()
+                    } else {
+                        std::env::current_dir()
+                            .map(|cwd| cwd.join(&raw_path))
+                            .unwrap_or(raw_path)
+                    }
+                });
                 worktree = Some(abs.to_string_lossy().into_owned());
             }
             "--no-enter" => {
                 auto_enter = false;
             }
             tok => {
+                if tok.starts_with("--") {
+                    return Some(Err(format!("unknown flag: {tok}")));
+                }
                 desc_tokens.push((tok.to_string(), tokens[i].1));
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,13 +1,13 @@
 use anyhow::{Context, Result};
 use std::collections::VecDeque;
 use std::io::IsTerminal as _;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 use tokio::signal::unix::{signal, SignalKind};
 
-use crate::ipc::{Request, Response};
+use crate::ipc::{Request, Response, TaskSpec};
 use crate::session;
 
 /// How long the user has to press Ctrl-C a second time to exit.
@@ -198,48 +198,80 @@ fn render_markdown(text: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// /dev command parsing and prompt synthesis
+// /claude command parsing
 // ---------------------------------------------------------------------------
 
-/// A single development task parsed from the `/dev` command.
+/// A task parsed from the `/claude` command.
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct DevTask {
-    /// Sanitized branch-safe name, e.g. "cron-scheduling".
-    name: String,
-    /// Original task description.
+struct ClaudeTask {
+    /// User-supplied task label (derived from description if not given with --id).
+    task_id: String,
+    /// Task description / opening prompt.
     description: String,
+    /// Optional absolute worktree path.
+    worktree: Option<String>,
+    /// Whether to auto-send Enter after injecting the command into the pane.
+    auto_enter: bool,
 }
 
-/// Parse a `/dev` command into a list of [`DevTask`]s.
+/// Parse a `/claude` command into a list of [`ClaudeTask`]s.
 ///
-/// Returns `None` if the input does not start with `/dev ` (with a trailing
-/// space).  Supports two forms:
-/// - Quoted tasks: `/dev "implement cron" "fix context limit"` -> 2 tasks
-/// - Single unquoted task: `/dev implement cron scheduling` -> 1 task
-fn parse_dev_command(input: &str) -> Option<Vec<DevTask>> {
-    let rest = input.strip_prefix("/dev ")?;
-    let rest = rest.trim();
+/// Syntax:
+/// ```text
+/// /claude [--worktree <path>] [--no-enter] "task description" ["task2" ...]
+/// ```
+///
+/// Returns `None` if the input does not start with `/claude ` (trailing space
+/// required) or has no task descriptions.
+fn parse_claude_command(input: &str) -> Option<Vec<ClaudeTask>> {
+    let rest = input.strip_prefix("/claude ")?.trim();
     if rest.is_empty() {
         return None;
     }
 
-    let descriptions = if rest.contains('"') {
-        parse_quoted_args(rest)
-    } else {
-        vec![rest.to_string()]
-    };
+    // Tokenise (shell-style quoting).
+    let tokens = parse_quoted_args(rest);
+    if tokens.is_empty() {
+        return None;
+    }
+
+    let mut worktree: Option<String> = None;
+    let mut auto_enter = true;
+    let mut descriptions: Vec<String> = Vec::new();
+
+    let mut i = 0;
+    while i < tokens.len() {
+        match tokens[i].as_str() {
+            "--worktree" => {
+                i += 1;
+                if i < tokens.len() {
+                    worktree = Some(tokens[i].clone());
+                }
+            }
+            "--no-enter" => {
+                auto_enter = false;
+            }
+            tok => {
+                descriptions.push(tok.to_string());
+            }
+        }
+        i += 1;
+    }
 
     if descriptions.is_empty() {
         return None;
     }
 
-    let tasks: Vec<DevTask> = descriptions
+    let tasks: Vec<ClaudeTask> = descriptions
         .into_iter()
-        .map(|desc| {
-            let name = sanitize_task_name(&desc);
-            DevTask {
-                name,
+        .enumerate()
+        .map(|(idx, desc)| {
+            let task_id = make_task_id(&desc, idx);
+            ClaudeTask {
+                task_id,
                 description: desc,
+                worktree: worktree.clone(),
+                auto_enter,
             }
         })
         .collect();
@@ -247,18 +279,53 @@ fn parse_dev_command(input: &str) -> Option<Vec<DevTask>> {
     Some(tasks)
 }
 
+/// Derive a short task label from a description + index.
+fn make_task_id(description: &str, idx: usize) -> String {
+    let lower = description.to_lowercase();
+    let slug: String = lower
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+
+    // Collapse runs of dashes.
+    let mut result = String::new();
+    let mut prev_dash = false;
+    for c in slug.chars() {
+        if c == '-' {
+            if !prev_dash {
+                result.push('-');
+            }
+            prev_dash = true;
+        } else {
+            result.push(c);
+            prev_dash = false;
+        }
+    }
+    let trimmed = result.trim_matches('-');
+
+    let base = if trimmed.is_empty() {
+        format!("task-{idx}")
+    } else if trimmed.len() > 32 {
+        trimmed[..32].trim_end_matches('-').to_string()
+    } else {
+        trimmed.to_string()
+    };
+
+    base
+}
+
 /// Parse shell-style arguments, supporting both quoted and unquoted tokens.
 ///
 /// - `"implement cron" "fix context limit"` → `["implement cron", "fix context limit"]`
 /// - `foo "bar"` → `["foo", "bar"]`  (mixed quoted/unquoted)
-/// - Escaped quotes inside quoted strings are supported: `"say \"hi\""` → `[r#"say "hi""#]`
+/// - Escaped quotes inside quoted strings: `"say \"hi\""` → `[r#"say "hi""#]`
 fn parse_quoted_args(input: &str) -> Vec<String> {
     let mut results = Vec::new();
     let mut chars = input.chars().peekable();
 
     while let Some(&ch) = chars.peek() {
         if ch == '"' {
-            chars.next(); // consume opening quote
+            chars.next();
             let mut arg = String::new();
             loop {
                 match chars.next() {
@@ -277,9 +344,8 @@ fn parse_quoted_args(input: &str) -> Vec<String> {
                 results.push(trimmed);
             }
         } else if ch.is_whitespace() {
-            chars.next(); // skip whitespace between tokens
+            chars.next();
         } else {
-            // Unquoted token: collect until whitespace or quote.
             let mut arg = String::new();
             while let Some(&c) = chars.peek() {
                 if c.is_whitespace() || c == '"' {
@@ -295,160 +361,6 @@ fn parse_quoted_args(input: &str) -> Vec<String> {
     }
 
     results
-}
-
-/// Sanitize a task description into a branch-safe name.
-///
-/// - Lowercase
-/// - Replace spaces and non-ASCII with `-`
-/// - Truncate to 40 chars max
-/// - Remove leading/trailing `-`
-/// - For pure non-ASCII (no ASCII alpha left), use `task-<first-8-hex-of-hash>`
-fn sanitize_task_name(description: &str) -> String {
-    let lower = description.to_lowercase();
-    let sanitized: String = lower
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect();
-
-    let collapsed = collapse_dashes(&sanitized);
-    let trimmed = collapsed.trim_matches('-');
-
-    if trimmed.is_empty() {
-        return hash_based_name(description);
-    }
-
-    // Truncate to 40 chars, re-trimming trailing dash if truncation split a word.
-    let truncated = if trimmed.len() > 40 {
-        trimmed[..40].trim_end_matches('-')
-    } else {
-        trimmed
-    };
-
-    truncated.to_string()
-}
-
-/// Collapse runs of consecutive dashes into a single dash.
-fn collapse_dashes(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut prev_dash = false;
-    for c in s.chars() {
-        if c == '-' {
-            if !prev_dash {
-                result.push('-');
-            }
-            prev_dash = true;
-        } else {
-            result.push(c);
-            prev_dash = false;
-        }
-    }
-    result
-}
-
-/// Generate a `task-<hex>` name from a deterministic hash of the description.
-///
-/// Uses `std::hash::DefaultHasher` (SipHash) — not cryptographic, but
-/// deterministic within a process and sufficient for branch-name uniqueness.
-fn hash_based_name(description: &str) -> String {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    description.hash(&mut hasher);
-    let hash = hasher.finish();
-    // Use the upper 32 bits formatted as 8 hex digits: "task-" (5) + 8 = 13 chars.
-    format!("task-{:08x}", (hash >> 32) as u32)
-}
-
-/// Build the orchestration prompt that instructs the parent agent to create
-/// worktrees and launch Claude Code CLI processes for parallel development.
-fn build_dev_prompt(tasks: &[DevTask], cwd: &Path) -> String {
-    let cwd_display = cwd.display();
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .unwrap_or_else(|_| "/tmp".to_string());
-    let worktree_base = format!("{home}/amaebi-wt");
-    let claude = std::env::var("CLAUDE").unwrap_or_else(|_| "claude".to_string());
-
-    let mut task_list = String::new();
-    for (i, task) in tasks.iter().enumerate() {
-        task_list.push_str(&format!(
-            "{}. **{}**: {}\n",
-            i + 1,
-            task.name,
-            task.description
-        ));
-    }
-
-    let mut worktree_commands = String::new();
-    for task in tasks {
-        worktree_commands.push_str(&format!(
-            "   git worktree add \"{worktree_base}/{name}\" -b feat/{name} origin/master\n",
-            worktree_base = worktree_base,
-            name = task.name,
-        ));
-    }
-
-    // Build the background launch command: run all Claude processes in parallel.
-    let mut launch_parts = Vec::new();
-    for task in tasks {
-        let escaped_desc = task
-            .description
-            .replace('\\', "\\\\")
-            .replace('\'', "'\\''");
-        launch_parts.push(format!(
-            "cd \"{worktree_base}/{name}\" && \
-             {claude} --print \
-             --permission-mode bypassPermissions \
-             -p '{escaped_desc}. \
-             Follow the project CLAUDE.md rules. \
-             After implementation, run: cargo fmt && cargo clippy -- -D warnings && cargo test. \
-             Fix any issues until all checks pass. \
-             Then commit with a conventional commit message (feat:, fix:, etc.). \
-             Report what you did and the branch name.' \
-             > \"{worktree_base}/{name}/claude.log\" 2>&1",
-            worktree_base = worktree_base,
-            name = task.name,
-            claude = claude,
-        ));
-    }
-
-    let parallel_cmd = if launch_parts.len() == 1 {
-        launch_parts[0].clone()
-    } else {
-        // Launch all in background, wait for all to finish.
-        let bg_cmds: Vec<String> = launch_parts
-            .iter()
-            .map(|cmd| format!("({cmd}) &"))
-            .collect();
-        format!("{}\nwait", bg_cmds.join("\n"))
-    };
-
-    format!(
-        "You are orchestrating a parallel development session for a Rust project.\n\
-         \n\
-         ## Tasks\n\
-         {task_list}\n\
-         ## Instructions\n\
-         \n\
-         Execute these steps IN ORDER using shell_command:\n\
-         \n\
-         1. Fetch latest upstream:\n\
-         \x20  cd \"{cwd_display}\" && git fetch origin\n\
-         \n\
-         2. Create worktree base and worktrees:\n\
-         \x20  mkdir -p \"{worktree_base}\"\n\
-         \x20  cd \"{cwd_display}\"\n\
-         {worktree_commands}\n\
-         3. Launch Claude Code in each worktree (this runs on the host, not in a sandbox):\n\
-         \x20  Use a SINGLE shell_command to run all tasks in parallel:\n\
-         ```\n\
-         {parallel_cmd}\n\
-         ```\n\
-         \n\
-         4. After the command completes, read each log file and report:\n\
-         \x20  - For each task: branch name (feat/<name>), worktree path, what Claude accomplished\n\
-         \x20  - Any failures (check the log files at {worktree_base}/<name>/claude.log)\n",
-    )
 }
 
 pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Result<()> {
@@ -480,11 +392,66 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
     // Keep a copy for the steering requests and the exit footer.
     let session_id_copy = session_id.clone();
 
-    // Intercept `/dev` commands and rewrite to an orchestration prompt.
-    let prompt = match parse_dev_command(&prompt) {
-        Some(tasks) => build_dev_prompt(&tasks, &cwd),
-        None => prompt,
-    };
+    // Intercept `/claude` commands: send a ClaudeLaunch request instead of Chat.
+    if let Some(tasks) = parse_claude_command(&prompt) {
+        let req = Request::ClaudeLaunch {
+            tasks: tasks
+                .into_iter()
+                .map(|t| TaskSpec {
+                    task_id: t.task_id,
+                    description: t.description,
+                    worktree: t.worktree,
+                    auto_enter: t.auto_enter,
+                })
+                .collect(),
+        };
+        let mut req_line = serde_json::to_string(&req).context("serializing ClaudeLaunch")?;
+        req_line.push('\n');
+        writer
+            .write_all(req_line.as_bytes())
+            .await
+            .context("sending ClaudeLaunch to daemon")?;
+
+        let mut lines = BufReader::new(reader).lines();
+        let mut stdout = tokio::io::stdout();
+        loop {
+            let line = lines.next_line().await.context("reading daemon response")?;
+            let Some(line) = line else { break };
+            let frame: Response = serde_json::from_str(&line).context("parsing daemon response")?;
+            match frame {
+                Response::Done => break,
+                Response::Error { message } => {
+                    stdout.write_all(message.as_bytes()).await?;
+                    stdout.write_all(b"\n").await?;
+                    break;
+                }
+                Response::PaneAssigned {
+                    task_id,
+                    pane_id,
+                    session_id: sid,
+                } => {
+                    let msg = format!("[pane {pane_id}] {task_id} → session {sid}\n");
+                    stdout.write_all(msg.as_bytes()).await?;
+                }
+                Response::CapacityError {
+                    requested,
+                    max_panes,
+                    current_busy,
+                } => {
+                    let msg = format!(
+                        "[error] capacity limit reached: max_panes={max_panes}, \
+                         busy={current_busy}, requested={requested}; \
+                         free existing panes to continue\n"
+                    );
+                    stdout.write_all(msg.as_bytes()).await?;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        stdout.flush().await?;
+        return Ok(());
+    }
 
     // Build and send the request as a single JSON line.
     let req = Request::Chat {
@@ -692,6 +659,10 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                             let _ = tokio::io::stderr().flush().await;
                         }
                     }
+                    Response::PaneAssigned { .. } | Response::CapacityError { .. } => {
+                        // Not expected in a normal Chat response stream.
+                        tracing::debug!("unexpected pane scheduler response in chat loop");
+                    }
                 }
             }
 
@@ -835,11 +806,65 @@ pub async fn run_chat_loop(
             }
         };
 
-        // Intercept `/dev` commands and rewrite to an orchestration prompt.
-        let prompt = match parse_dev_command(&prompt) {
-            Some(tasks) => build_dev_prompt(&tasks, &cwd),
-            None => prompt,
-        };
+        // Intercept `/claude` commands: send ClaudeLaunch and handle the response
+        // before resuming the normal chat loop.
+        if let Some(tasks) = parse_claude_command(&prompt) {
+            let req = Request::ClaudeLaunch {
+                tasks: tasks
+                    .into_iter()
+                    .map(|t| TaskSpec {
+                        task_id: t.task_id,
+                        description: t.description,
+                        worktree: t.worktree,
+                        auto_enter: t.auto_enter,
+                    })
+                    .collect(),
+            };
+            let mut req_line = serde_json::to_string(&req)?;
+            req_line.push('\n');
+            write_half.write_all(req_line.as_bytes()).await?;
+
+            // Read ClaudeLaunch responses until Done/Error.
+            loop {
+                let line = lines.next_line().await.context("reading daemon response")?;
+                let Some(line) = line else { break 'session };
+                let frame: Response =
+                    serde_json::from_str(&line).context("parsing daemon response")?;
+                match frame {
+                    Response::Done => break,
+                    Response::Error { message } => {
+                        stdout.write_all(message.as_bytes()).await?;
+                        stdout.write_all(b"\n").await?;
+                        break;
+                    }
+                    Response::PaneAssigned {
+                        task_id,
+                        pane_id,
+                        session_id: sid,
+                    } => {
+                        let msg = format!("[pane {pane_id}] {task_id} → session {sid}\n");
+                        stdout.write_all(msg.as_bytes()).await?;
+                    }
+                    Response::CapacityError {
+                        requested,
+                        max_panes,
+                        current_busy,
+                    } => {
+                        let msg = format!(
+                            "[error] capacity limit reached: max_panes={max_panes}, \
+                             busy={current_busy}, requested={requested}; \
+                             free existing panes to continue\n"
+                        );
+                        stdout.write_all(msg.as_bytes()).await?;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            stdout.flush().await?;
+            // Continue the chat loop for the next user input.
+            continue 'session;
+        }
 
         let req = Request::Chat {
             prompt: prompt.clone(),
@@ -1294,6 +1319,9 @@ pub async fn run_resume(
                             eprint!(">");
                             let _ = tokio::io::stderr().flush().await;
                         }
+                    }
+                    Response::PaneAssigned { .. } | Response::CapacityError { .. } => {
+                        tracing::debug!("unexpected pane scheduler response in resume loop");
                     }
                 }
             }
@@ -3220,197 +3248,110 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // /dev command parsing
+    // /claude command parsing
     // -----------------------------------------------------------------------
 
     #[test]
-    fn parse_dev_two_quoted_tasks() {
-        let result = parse_dev_command(r#"/dev "task one" "task two""#);
+    fn parse_claude_two_quoted_tasks() {
+        let result = parse_claude_command(r#"/claude "task one" "task two""#);
         let tasks = result.expect("should parse");
         assert_eq!(tasks.len(), 2);
         assert_eq!(tasks[0].description, "task one");
         assert_eq!(tasks[1].description, "task two");
+        assert!(tasks[0].auto_enter);
     }
 
     #[test]
-    fn parse_dev_single_unquoted_task() {
-        let result = parse_dev_command("/dev implement something");
+    fn parse_claude_single_quoted_task() {
+        let result = parse_claude_command(r#"/claude "implement something""#);
         let tasks = result.expect("should parse");
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].description, "implement something");
-        assert_eq!(tasks[0].name, "implement-something");
     }
 
     #[test]
-    fn parse_dev_no_args_returns_none() {
-        assert!(parse_dev_command("/dev").is_none());
-    }
-
-    #[test]
-    fn parse_dev_only_space_returns_none() {
-        assert!(parse_dev_command("/dev   ").is_none());
-    }
-
-    #[test]
-    fn parse_not_dev_command_returns_none() {
-        assert!(parse_dev_command("not a dev command").is_none());
-    }
-
-    #[test]
-    fn parse_develop_is_not_dev() {
-        // Must be exactly `/dev `, not `/develop`.
-        assert!(parse_dev_command("/develop something").is_none());
-    }
-
-    #[test]
-    fn parse_dev_escaped_quotes() {
-        let result = parse_dev_command(r#"/dev "task with \"quotes\"" "other""#);
+    fn parse_claude_unquoted_tokens_become_separate_tasks() {
+        let result = parse_claude_command("/claude implement something");
         let tasks = result.expect("should parse");
+        // Unquoted: each whitespace-separated token is a separate task.
         assert_eq!(tasks.len(), 2);
+        assert_eq!(tasks[0].description, "implement");
+        assert_eq!(tasks[1].description, "something");
+    }
+
+    #[test]
+    fn parse_claude_no_args_returns_none() {
+        assert!(parse_claude_command("/claude").is_none());
+    }
+
+    #[test]
+    fn parse_claude_only_space_returns_none() {
+        assert!(parse_claude_command("/claude   ").is_none());
+    }
+
+    #[test]
+    fn parse_not_claude_command_returns_none() {
+        assert!(parse_claude_command("not a claude command").is_none());
+    }
+
+    #[test]
+    fn parse_claude_no_enter_flag() {
+        let result = parse_claude_command(r#"/claude --no-enter "do something""#);
+        let tasks = result.expect("should parse");
+        assert_eq!(tasks.len(), 1);
+        assert!(!tasks[0].auto_enter);
+        assert_eq!(tasks[0].description, "do something");
+    }
+
+    #[test]
+    fn parse_claude_worktree_flag() {
+        let result = parse_claude_command(r#"/claude --worktree /repo/wt/t1 "implement X""#);
+        let tasks = result.expect("should parse");
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].worktree.as_deref(), Some("/repo/wt/t1"));
+        assert_eq!(tasks[0].description, "implement X");
+    }
+
+    #[test]
+    fn parse_claude_escaped_quotes_in_description() {
+        let result = parse_claude_command(r#"/claude "task with \"quotes\"""#);
+        let tasks = result.expect("should parse");
+        assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].description, r#"task with "quotes""#);
-        assert_eq!(tasks[1].description, "other");
     }
 
     #[test]
-    fn parse_dev_mixed_quoted_unquoted() {
-        let result = parse_dev_command(r#"/dev foo "bar baz""#);
+    fn parse_claude_task_id_derived_from_description() {
+        let result = parse_claude_command(r#"/claude "Implement Cron Scheduling""#);
         let tasks = result.expect("should parse");
-        assert_eq!(tasks.len(), 2);
-        assert_eq!(tasks[0].description, "foo");
-        assert_eq!(tasks[1].description, "bar baz");
+        assert_eq!(tasks[0].task_id, "implement-cron-scheduling");
     }
 
-    // -----------------------------------------------------------------------
-    // Task name sanitization
-    // -----------------------------------------------------------------------
+    #[test]
+    fn parse_claude_task_id_truncated() {
+        let long = format!("/claude \"{}\"", "a".repeat(100));
+        let result = parse_claude_command(&long);
+        let tasks = result.expect("should parse");
+        assert!(tasks[0].task_id.len() <= 32);
+    }
 
     #[test]
-    fn sanitize_simple_english() {
+    fn make_task_id_simple() {
         assert_eq!(
-            sanitize_task_name("implement cron scheduling"),
-            "implement-cron-scheduling"
+            make_task_id("implement something", 0),
+            "implement-something"
         );
     }
 
     #[test]
-    fn sanitize_preserves_lowercase() {
-        assert_eq!(sanitize_task_name("Fix Context Limit"), "fix-context-limit");
+    fn make_task_id_collapses_dashes() {
+        assert_eq!(make_task_id("hello   world", 0), "hello-world");
     }
 
     #[test]
-    fn sanitize_truncates_to_40_chars() {
-        let long_desc = "a very long task description that exceeds the maximum allowed length";
-        let name = sanitize_task_name(long_desc);
-        assert!(
-            name.len() <= 40,
-            "name too long: {} (len={})",
-            name,
-            name.len()
-        );
-        assert!(!name.ends_with('-'));
-    }
-
-    #[test]
-    fn sanitize_removes_leading_trailing_dashes() {
-        assert_eq!(sanitize_task_name("  hello world  "), "hello-world");
-    }
-
-    #[test]
-    fn sanitize_collapses_consecutive_dashes() {
-        assert_eq!(sanitize_task_name("hello   world"), "hello-world");
-    }
-
-    #[test]
-    fn sanitize_pure_cjk_uses_hash() {
-        let name = sanitize_task_name("実装クロン");
-        assert!(
-            name.starts_with("task-"),
-            "expected hash-based name, got: {}",
-            name
-        );
-        assert!(name.len() <= 13);
-    }
-
-    #[test]
-    fn sanitize_mixed_ascii_and_non_ascii() {
-        let name = sanitize_task_name("fix 日本語 bug");
-        // Should contain the ASCII parts with dashes for non-ASCII.
-        assert!(name.contains("fix"));
-        assert!(name.contains("bug"));
-    }
-
-    #[test]
-    fn sanitize_hash_is_deterministic() {
-        let a = sanitize_task_name("こんにちは");
-        let b = sanitize_task_name("こんにちは");
-        assert_eq!(a, b);
-    }
-
-    #[test]
-    fn sanitize_different_cjk_different_hash() {
-        let a = sanitize_task_name("こんにちは");
-        let b = sanitize_task_name("さようなら");
-        assert_ne!(a, b);
-    }
-
-    // -----------------------------------------------------------------------
-    // build_dev_prompt
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn build_dev_prompt_contains_tasks() {
-        let tasks = vec![
-            DevTask {
-                name: "cron-scheduling".into(),
-                description: "implement cron".into(),
-            },
-            DevTask {
-                name: "fix-context".into(),
-                description: "fix context limit".into(),
-            },
-        ];
-        let prompt = build_dev_prompt(&tasks, Path::new("/home/user/project"));
-        assert!(prompt.contains("cron-scheduling"));
-        assert!(prompt.contains("fix-context"));
-        assert!(prompt.contains("implement cron"));
-        assert!(prompt.contains("fix context limit"));
-        assert!(prompt.contains("git worktree add"));
-        assert!(prompt.contains("amaebi-wt"));
-        assert!(prompt.contains("/home/user/project"));
-        // Should use claude CLI, not spawn_agent
-        assert!(prompt.contains("claude"));
-        assert!(prompt.contains("--print"));
-        assert!(!prompt.contains("spawn_agent"));
-    }
-
-    #[test]
-    fn build_dev_prompt_contains_worktree_paths() {
-        let tasks = vec![DevTask {
-            name: "my-task".into(),
-            description: "do something".into(),
-        }];
-        let prompt = build_dev_prompt(&tasks, Path::new("/tmp"));
-        assert!(prompt.contains("amaebi-wt/my-task"));
-        assert!(prompt.contains("feat/my-task"));
-        assert!(prompt.contains("claude.log"));
-    }
-
-    #[test]
-    fn build_dev_prompt_parallel_uses_background() {
-        let tasks = vec![
-            DevTask {
-                name: "task-a".into(),
-                description: "do A".into(),
-            },
-            DevTask {
-                name: "task-b".into(),
-                description: "do B".into(),
-            },
-        ];
-        let prompt = build_dev_prompt(&tasks, Path::new("/tmp"));
-        // Multiple tasks should use background processes + wait
-        assert!(prompt.contains(") &"));
-        assert!(prompt.contains("wait"));
+    fn make_task_id_fallback_for_pure_non_ascii() {
+        let id = make_task_id("こんにちは", 3);
+        assert_eq!(id, "task-3");
     }
 
     // -----------------------------------------------------------------------

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -875,15 +875,37 @@ async fn handle_claude_launch(
         let (pane_id, had_claude) = match pane_result {
             Ok(p) => p,
             Err(e) => {
-                // If the worktree was auto-created, clean it up to avoid
-                // orphaned git branches sitting around after a capacity error.
+                // If the worktree was auto-created, remove it and its branch
+                // to avoid orphaned state after a capacity error.
+                // Use client_cwd with -C so git targets the right repo
+                // regardless of where the daemon was started.
+                // The branch name equals the worktree directory's basename
+                // (both set to unique_name = "<task_id>-<uuid8>").
                 if !was_explicit_worktree {
                     if let Some(ref wt) = worktree {
                         let wt_path = wt.clone();
+                        let cleanup_cwd = task.client_cwd.clone();
                         tokio::task::spawn_blocking(move || {
-                            let _ = std::process::Command::new("git")
+                            let branch = std::path::Path::new(&wt_path)
+                                .file_name()
+                                .and_then(|n| n.to_str())
+                                .map(str::to_string);
+                            let mut rm_cmd = std::process::Command::new("git");
+                            if let Some(ref cwd) = cleanup_cwd {
+                                rm_cmd.args(["-C", cwd.as_str()]);
+                            }
+                            let removed = rm_cmd
                                 .args(["worktree", "remove", "--force", &wt_path])
-                                .output();
+                                .output()
+                                .map(|o| o.status.success())
+                                .unwrap_or(false);
+                            if removed {
+                                if let (Some(ref cwd), Some(ref br)) = (&cleanup_cwd, &branch) {
+                                    let _ = std::process::Command::new("git")
+                                        .args(["-C", cwd.as_str(), "branch", "-D", br.as_str()])
+                                        .output();
+                                }
+                            }
                         })
                         .await
                         .ok();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -791,15 +791,16 @@ async fn drive_agentic_loop(
 // Sub-handlers — one per Request variant
 // ---------------------------------------------------------------------------
 
-/// Handle `Request::ClaudeLaunch`: assign tmux panes and launch amaebi chat
+/// Handle `Request::ClaudeLaunch`: assign tmux panes and launch `amaebi chat`
 /// sessions for each task.
 ///
 /// Steps for each task:
-/// 1. `ensure_idle_panes(n)` — auto-expand pane pool if needed.
-/// 2. For each task: `acquire_first_idle` → get a pane.
-/// 3. Rename the pane title to `"amaebi | <task_id>"`.
-/// 4. Send `tmux send-keys` to start `amaebi chat` (in the worktree if set).
-/// 5. Stream `Response::PaneAssigned` for each task, then `Response::Done`.
+/// 1. `ensure_and_acquire_idle` — atomically expand the pane pool if needed
+///    and acquire an idle pane.
+/// 2. Rename the pane title to `"amaebi | <task_id>"`.
+/// 3. Inject `amaebi chat <description>` (with optional `cd <worktree>`)
+///    via `tmux send-keys`.
+/// 4. Stream `Response::PaneAssigned` for each task, then `Response::Done`.
 async fn handle_claude_launch(
     writer: &Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
     tasks: Vec<crate::ipc::TaskSpec>,
@@ -810,9 +811,10 @@ async fn handle_claude_launch(
         return Ok(());
     }
 
-    // Acquire a lease and launch a chat session for each task.
-    // `ensure_and_acquire_idle` holds a single LOCK_EX for both the
-    // ensure-idle-panes expansion and the acquire, eliminating the TOCTOU race.
+    // For each task: acquire a pane (auto-expanding the pool if needed), then
+    // inject `amaebi chat <description>` via tmux send-keys.
+    // `ensure_and_acquire_idle` holds a single LOCK_EX for both expansion and
+    // acquisition, eliminating the TOCTOU race.
     for task in tasks {
         let task_id = task.task_id.clone();
         let worktree = task.worktree.clone();
@@ -835,7 +837,7 @@ async fn handle_claude_launch(
         .await
         .context("ensure_and_acquire_idle task panicked")?;
 
-        let pane_id = match pane_result {
+        let (pane_id, had_claude) = match pane_result {
             Ok(p) => p,
             Err(e) => {
                 // Surface CapacityError as a typed terminal response.
@@ -886,27 +888,34 @@ async fn handle_claude_launch(
         .await
         .ok();
 
-        // Build the command to inject into the pane.
-        let amaebi_cmd = std::env::current_exe()
-            .ok()
-            .and_then(|p| p.to_str().map(str::to_string))
-            .unwrap_or_else(|| "amaebi".to_string());
-
-        // Build the shell command string and assemble tmux send-keys args.
-        // The description is passed as the opening prompt to `amaebi chat`.
-        let cmd = if let Some(ref wt) = worktree {
-            format!(
-                "cd {} && {} chat {}",
-                shell_escape(wt),
-                shell_escape(&amaebi_cmd),
-                shell_escape(&description)
-            )
+        // Build the keys to inject into the pane.
+        //
+        // Priority:
+        //  - `had_claude = true`: pane already has `amaebi chat` running at
+        //    its prompt → send just the description as a new user message.
+        //  - `had_claude = false`: pane is blank (freshly created or at a
+        //    shell prompt) → launch `amaebi chat <description>`.
+        let cmd = if had_claude {
+            description.clone()
         } else {
-            format!(
-                "{} chat {}",
-                shell_escape(&amaebi_cmd),
-                shell_escape(&description)
-            )
+            let amaebi_cmd = std::env::current_exe()
+                .ok()
+                .and_then(|p| p.to_str().map(str::to_string))
+                .unwrap_or_else(|| "amaebi".to_string());
+            if let Some(ref wt) = worktree {
+                format!(
+                    "cd {} && {} chat {}",
+                    shell_escape(wt),
+                    shell_escape(&amaebi_cmd),
+                    shell_escape(&description)
+                )
+            } else {
+                format!(
+                    "{} chat {}",
+                    shell_escape(&amaebi_cmd),
+                    shell_escape(&description)
+                )
+            }
         };
 
         let send_pane = pane_id.clone();
@@ -943,6 +952,17 @@ async fn handle_claude_launch(
             )
             .await?;
             return Ok(());
+        }
+
+        // If we just launched `amaebi chat` in a blank pane, record that so
+        // future task assignments can inject prompts directly.
+        if !had_claude {
+            let started_pane = pane_id.clone();
+            tokio::task::spawn_blocking(move || {
+                let _ = pane_lease::mark_claude_started(&started_pane);
+            })
+            .await
+            .ok();
         }
 
         let mut w = writer.lock().await;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -797,7 +797,7 @@ async fn drive_agentic_loop(
 /// Steps for each task:
 /// 1. `ensure_and_acquire_idle` — atomically expand the pane pool if needed
 ///    and acquire an idle pane.
-/// 2. Rename the pane title to `"claude | <task_id>"`.
+/// 2. Rename the pane title to `"cc-{N}"` (tmux pane numeric index).
 /// 3. If the pane already has `claude` running, inject `description` as a new
 ///    prompt.  Otherwise launch `claude` (with optional `cd <worktree>`) via
 ///    `tmux send-keys`, then inject `description` as a second keystroke.
@@ -817,7 +817,8 @@ async fn handle_claude_launch(
     // tmux send-keys.
     // `ensure_and_acquire_idle` holds a single LOCK_EX for both expansion and
     // acquisition, eliminating the TOCTOU race.
-    for task in tasks {
+    let total_tasks = tasks.len();
+    for (task_idx, task) in tasks.into_iter().enumerate() {
         let task_id = task.task_id.clone();
         let worktree = task.worktree.clone();
         let description = task.description.clone();
@@ -827,6 +828,8 @@ async fn handle_claude_launch(
 
         // Acquire a pane lease *before* creating session state so that a
         // capacity failure does not leave orphan session entries on disk.
+        // A placeholder session_id is stored now; it is corrected to the real
+        // UUID via `update_session_id` after `session::get_or_create` returns.
         let sid_placeholder = uuid::Uuid::new_v4().to_string();
         let sid_for_lease = sid_placeholder.clone();
         let pane_result = tokio::task::spawn_blocking(move || {
@@ -843,12 +846,15 @@ async fn handle_claude_launch(
             Ok(p) => p,
             Err(e) => {
                 // Surface CapacityError as a typed terminal response.
+                // Report tasks still unassigned (including this one) so the
+                // caller sees the real demand that exceeded capacity.
+                let remaining = total_tasks - task_idx;
                 let mut w = writer.lock().await;
                 if let Some(cap) = e.downcast_ref::<pane_lease::CapacityError>() {
                     write_frame(
                         &mut *w,
                         &Response::CapacityError {
-                            requested: cap.requested,
+                            requested: remaining,
                             max_panes: cap.max_panes,
                             current_busy: cap.current_busy,
                         },
@@ -869,7 +875,8 @@ async fn handle_claude_launch(
             }
         };
 
-        // Resolve the real session UUID now that the pane is secured.
+        // Resolve the real session UUID now that the pane is secured, then
+        // correct the placeholder stored in the lease.
         let session_dir = worktree
             .as_deref()
             .map(std::path::Path::new)
@@ -879,6 +886,13 @@ async fn handle_claude_launch(
             .await
             .context("session::get_or_create panicked")?
             .context("resolving session ID")?;
+        let update_pane = pane_id.clone();
+        let update_sid = session_id.clone();
+        tokio::task::spawn_blocking(move || {
+            let _ = pane_lease::update_session_id(&update_pane, &update_sid);
+        })
+        .await
+        .ok();
 
         // Rename the pane for visibility.  Use the tmux pane numeric index
         // (strip the leading '%' from e.g. "%5") to keep the title short.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -880,9 +880,11 @@ async fn handle_claude_launch(
             .context("session::get_or_create panicked")?
             .context("resolving session ID")?;
 
-        // Rename the pane for visibility.
+        // Rename the pane for visibility.  Use the tmux pane numeric index
+        // (strip the leading '%' from e.g. "%5") to keep the title short.
         let rename_pane = pane_id.clone();
-        let rename_title = format!("claude | {}", task_id);
+        let pane_num = pane_id.trim_start_matches('%');
+        let rename_title = format!("cc-{}", pane_num);
         tokio::task::spawn_blocking(move || {
             // Best-effort — ignore errors (non-tmux environments).
             let _ = pane_lease::rename_pane(&rename_pane, &rename_title);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -904,10 +904,14 @@ async fn handle_claude_launch(
 
         // Resolve the real session UUID now that the pane is secured, then
         // correct the placeholder stored in the lease.
+        // Prefer the worktree path for session identity; fall back to the
+        // client's cwd (not the daemon's cwd, which may be unrelated to the
+        // repo the client was invoked from).
         let session_dir = worktree
             .as_deref()
             .map(std::path::Path::new)
             .map(std::path::Path::to_path_buf)
+            .or_else(|| task.client_cwd.as_deref().map(std::path::PathBuf::from))
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
         let session_id = tokio::task::spawn_blocking(move || session::get_or_create(&session_dir))
             .await

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -941,15 +941,25 @@ async fn handle_claude_launch(
         //
         // Each element is (keys, press_enter).
         let key_sequence: Vec<(String, bool)> = if had_claude {
-            vec![(description.clone(), auto_enter)]
+            // Reusing an existing claude session in the same worktree: compact
+            // the prior conversation first so stale context does not pollute
+            // the new task, then inject the description.
+            vec![
+                ("/compact".to_string(), true),
+                (description.clone(), auto_enter),
+            ]
         } else {
+            // Fresh pane: launch claude with --dangerously-skip-permissions so
+            // the autonomous session never blocks on an interactive approval
+            // prompt, then inject the description as the opening message.
             let launch_cmd = if let Some(ref wt) = worktree {
-                format!("cd {} && claude", shell_escape(wt))
+                format!(
+                    "cd {} && claude --dangerously-skip-permissions",
+                    shell_escape(wt)
+                )
             } else {
-                "claude".to_string()
+                "claude --dangerously-skip-permissions".to_string()
             };
-            // Launch `claude` with Enter, then queue the description without
-            // Enter so the user can review it before submitting.
             vec![(launch_cmd, true), (description.clone(), auto_enter)]
         };
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12,6 +12,7 @@ use crate::inbox::InboxStore;
 use crate::ipc::{write_frame, Request, Response};
 use crate::memory_db;
 use crate::pane_lease;
+use crate::session;
 use crate::tools::{self, ToolExecutor};
 
 /// Resolve the raw model string to the API-level model ID for token lookups.
@@ -809,59 +810,58 @@ async fn handle_claude_launch(
         return Ok(());
     }
 
-    let needed = tasks.len();
-
-    // Ensure enough idle panes exist (auto-expand via tmux split-window).
-    let expand_result = tokio::task::spawn_blocking(move || pane_lease::ensure_idle_panes(needed))
-        .await
-        .context("ensure_idle_panes task panicked")?;
-
-    if let Err(e) = expand_result {
-        // Detect capacity errors specifically so we can send the typed response.
-        if let Some(cap) = e.downcast_ref::<pane_lease::CapacityError>() {
-            let mut w = writer.lock().await;
-            write_frame(
-                &mut *w,
-                &Response::CapacityError {
-                    requested: cap.requested,
-                    max_panes: cap.max_panes,
-                    current_busy: cap.current_busy,
-                },
-            )
-            .await?;
-            write_frame(&mut *w, &Response::Done).await?;
-            return Ok(());
-        }
-        let mut w = writer.lock().await;
-        write_frame(
-            &mut *w,
-            &Response::Error {
-                message: format!("[error] {e:#}"),
-            },
-        )
-        .await?;
-        write_frame(&mut *w, &Response::Done).await?;
-        return Ok(());
-    }
-
     // Acquire a lease and launch a chat session for each task.
+    // `ensure_and_acquire_idle` holds a single LOCK_EX for both the
+    // ensure-idle-panes expansion and the acquire, eliminating the TOCTOU race.
     for task in tasks {
         let task_id = task.task_id.clone();
         let worktree = task.worktree.clone();
-        let session_id = uuid::Uuid::new_v4().to_string();
-        let sid_for_lease = session_id.clone();
+        let description = task.description.clone();
+        let auto_enter = task.auto_enter;
         let tid_for_lease = task_id.clone();
         let wt_for_lease = worktree.clone();
 
+        // Compute the session UUID the launched `amaebi chat` will use, so
+        // the PaneAssigned response carries the real session ID rather than a
+        // random placeholder.
+        let session_dir = worktree
+            .as_deref()
+            .map(std::path::Path::new)
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+        let session_id = tokio::task::spawn_blocking(move || session::get_or_create(&session_dir))
+            .await
+            .context("session::get_or_create panicked")?
+            .context("resolving session ID")?;
+
+        let sid_for_lease = session_id.clone();
         let pane_result = tokio::task::spawn_blocking(move || {
-            pane_lease::acquire_first_idle(&tid_for_lease, &sid_for_lease, wt_for_lease.as_deref())
+            pane_lease::ensure_and_acquire_idle(
+                &tid_for_lease,
+                &sid_for_lease,
+                wt_for_lease.as_deref(),
+            )
         })
         .await
-        .context("acquire_first_idle task panicked")?;
+        .context("ensure_and_acquire_idle task panicked")?;
 
         let pane_id = match pane_result {
             Ok(p) => p,
             Err(e) => {
+                // Surface CapacityError as the typed response.
+                if let Some(cap) = e.downcast_ref::<pane_lease::CapacityError>() {
+                    let mut w = writer.lock().await;
+                    write_frame(
+                        &mut *w,
+                        &Response::CapacityError {
+                            requested: cap.requested,
+                            max_panes: cap.max_panes,
+                            current_busy: cap.current_busy,
+                        },
+                    )
+                    .await?;
+                    continue;
+                }
                 let mut w = writer.lock().await;
                 write_frame(
                     &mut *w,
@@ -890,21 +890,34 @@ async fn handle_claude_launch(
             .and_then(|p| p.to_str().map(str::to_string))
             .unwrap_or_else(|| "amaebi".to_string());
 
+        // Build the shell command string and assemble tmux send-keys args.
+        // The description is passed as the opening prompt to `amaebi chat`.
         let cmd = if let Some(ref wt) = worktree {
-            format!("cd {} && {} chat", shell_escape(wt), amaebi_cmd)
+            format!(
+                "cd {} && {} chat {}",
+                shell_escape(wt),
+                shell_escape(&amaebi_cmd),
+                shell_escape(&description)
+            )
         } else {
-            format!("{} chat", amaebi_cmd)
+            format!(
+                "{} chat {}",
+                shell_escape(&amaebi_cmd),
+                shell_escape(&description)
+            )
         };
 
-        let enter_suffix = if task.auto_enter { " Enter" } else { "" };
-        let keys_arg = format!("{cmd}{enter_suffix}");
         let send_pane = pane_id.clone();
 
-        // Send the command to the pane.
+        // Send the command to the pane. "Enter" must be a separate argument —
+        // passing it as part of the keys string would send the literal text
+        // " Enter" rather than pressing the Enter key.
         tokio::task::spawn_blocking(move || {
-            let _ = std::process::Command::new("tmux")
-                .args(["send-keys", "-t", &send_pane, &keys_arg])
-                .output();
+            let mut cmd_args = vec!["send-keys", "-t", &send_pane, &cmd];
+            if auto_enter {
+                cmd_args.push("Enter");
+            }
+            let _ = std::process::Command::new("tmux").args(&cmd_args).output();
         })
         .await
         .ok();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1124,8 +1124,19 @@ fn create_task_worktree(
         .and_then(|n| n.to_str())
         .unwrap_or("repo");
 
-    // Place worktrees under ~/.amaebi/worktrees/<repo>/<task_id> so they are
-    // centralised alongside other amaebi state and never pollute the repo tree.
+    // Place worktrees under ~/.amaebi/worktrees/<repo>/<task_id>-<uuid8>.
+    // A short UUID suffix guarantees uniqueness across runs so repeated
+    // invocations with the same task description never collide on the branch
+    // name or directory path — the same approach Claude Code uses for its own
+    // agent worktrees (agent-{uuid8}).
+    let short_id = uuid::Uuid::new_v4()
+        .to_string()
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(8)
+        .collect::<String>();
+    let unique_name = format!("{task_id}-{short_id}");
+
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .context("HOME environment variable not set")?;
@@ -1133,7 +1144,7 @@ fn create_task_worktree(
         .join(".amaebi")
         .join("worktrees")
         .join(repo_name)
-        .join(task_id);
+        .join(&unique_name);
 
     // Ensure the parent directory exists before calling git.
     let wt_parent = wt_path
@@ -1142,7 +1153,7 @@ fn create_task_worktree(
     std::fs::create_dir_all(wt_parent)
         .with_context(|| format!("creating worktree parent directory {}", wt_parent.display()))?;
 
-    // Create the worktree on a new branch with the same name as the task.
+    // Create the worktree on a new branch named <task_id>-<uuid8>.
     let mut git_cmd = std::process::Command::new("git");
     if let Some(cwd) = client_cwd {
         git_cmd.args(["-C", cwd]);
@@ -1155,7 +1166,7 @@ fn create_task_worktree(
                 .to_str()
                 .context("worktree path is not valid UTF-8")?,
             "-b",
-            task_id,
+            &unique_name,
         ])
         .output()
         .context("spawning git worktree add")?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -791,15 +791,16 @@ async fn drive_agentic_loop(
 // Sub-handlers — one per Request variant
 // ---------------------------------------------------------------------------
 
-/// Handle `Request::ClaudeLaunch`: assign tmux panes and launch `amaebi chat`
-/// sessions for each task.
+/// Handle `Request::ClaudeLaunch`: assign tmux panes and launch `claude`
+/// (Claude Code CLI) sessions for each task.
 ///
 /// Steps for each task:
 /// 1. `ensure_and_acquire_idle` — atomically expand the pane pool if needed
 ///    and acquire an idle pane.
-/// 2. Rename the pane title to `"amaebi | <task_id>"`.
-/// 3. Inject `amaebi chat <description>` (with optional `cd <worktree>`)
-///    via `tmux send-keys`.
+/// 2. Rename the pane title to `"claude | <task_id>"`.
+/// 3. If the pane already has `claude` running, inject `description` as a new
+///    prompt.  Otherwise launch `claude` (with optional `cd <worktree>`) via
+///    `tmux send-keys`, then inject `description` as a second keystroke.
 /// 4. Stream `Response::PaneAssigned` for each task, then `Response::Done`.
 async fn handle_claude_launch(
     writer: &Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
@@ -812,7 +813,8 @@ async fn handle_claude_launch(
     }
 
     // For each task: acquire a pane (auto-expanding the pool if needed), then
-    // inject `amaebi chat <description>` via tmux send-keys.
+    // launch `claude` (or inject a prompt into an already-running session) via
+    // tmux send-keys.
     // `ensure_and_acquire_idle` holds a single LOCK_EX for both expansion and
     // acquisition, eliminating the TOCTOU race.
     for task in tasks {
@@ -880,7 +882,7 @@ async fn handle_claude_launch(
 
         // Rename the pane for visibility.
         let rename_pane = pane_id.clone();
-        let rename_title = format!("amaebi | {}", task_id);
+        let rename_title = format!("claude | {}", task_id);
         tokio::task::spawn_blocking(move || {
             // Best-effort — ignore errors (non-tmux environments).
             let _ = pane_lease::rename_pane(&rename_pane, &rename_title);
@@ -888,51 +890,52 @@ async fn handle_claude_launch(
         .await
         .ok();
 
-        // Build the keys to inject into the pane.
+        // Build the key sequences to inject into the pane.
         //
         // Priority:
-        //  - `had_claude = true`: pane already has `amaebi chat` running at
-        //    its prompt → send just the description as a new user message.
+        //  - `had_claude = true`: pane already has `claude` running at its
+        //    prompt → send just the description as a new user message.
         //  - `had_claude = false`: pane is blank (freshly created or at a
-        //    shell prompt) → launch `amaebi chat <description>`.
-        let cmd = if had_claude {
-            description.clone()
+        //    shell prompt) → launch `claude` first, then send the description
+        //    as a second keystroke so it lands at the Claude Code prompt.
+        //
+        // Each element is (keys, press_enter).
+        let key_sequence: Vec<(String, bool)> = if had_claude {
+            vec![(description.clone(), auto_enter)]
         } else {
-            let amaebi_cmd = std::env::current_exe()
-                .ok()
-                .and_then(|p| p.to_str().map(str::to_string))
-                .unwrap_or_else(|| "amaebi".to_string());
-            if let Some(ref wt) = worktree {
-                format!(
-                    "cd {} && {} chat {}",
-                    shell_escape(wt),
-                    shell_escape(&amaebi_cmd),
-                    shell_escape(&description)
-                )
+            let launch_cmd = if let Some(ref wt) = worktree {
+                format!("cd {} && claude", shell_escape(wt))
             } else {
-                format!(
-                    "{} chat {}",
-                    shell_escape(&amaebi_cmd),
-                    shell_escape(&description)
-                )
-            }
+                "claude".to_string()
+            };
+            // Launch `claude` with Enter, then queue the description without
+            // Enter so the user can review it before submitting.
+            vec![(launch_cmd, true), (description.clone(), auto_enter)]
         };
 
         let send_pane = pane_id.clone();
 
-        // Send the command to the pane. "Enter" must be a separate argument —
-        // passing it as part of the keys string would send the literal text
-        // " Enter" rather than pressing the Enter key.
+        // Send all key sequences to the pane.  "Enter" must be a separate
+        // argument — passing it as part of the keys string would send the
+        // literal text " Enter" rather than pressing the Enter key.
         let send_result = tokio::task::spawn_blocking(move || {
-            let mut cmd_args = vec!["send-keys", "-t", &send_pane, &cmd];
-            if auto_enter {
-                cmd_args.push("Enter");
+            for (keys, press_enter) in &key_sequence {
+                let mut cmd_args = vec!["send-keys", "-t", &send_pane, keys.as_str()];
+                if *press_enter {
+                    cmd_args.push("Enter");
+                }
+                let out = std::process::Command::new("tmux")
+                    .args(&cmd_args)
+                    .output()?;
+                if !out.status.success() {
+                    return Ok::<bool, std::io::Error>(false);
+                }
             }
-            std::process::Command::new("tmux").args(&cmd_args).output()
+            Ok(true)
         })
         .await;
 
-        let send_ok = matches!(send_result, Ok(Ok(ref out)) if out.status.success());
+        let send_ok = matches!(send_result, Ok(Ok(true)));
         if !send_ok {
             // Injection failed — release the lease so the pane is not stuck Busy.
             let failed_pane = pane_id.clone();
@@ -954,7 +957,7 @@ async fn handle_claude_launch(
             return Ok(());
         }
 
-        // If we just launched `amaebi chat` in a blank pane, record that so
+        // If we just launched `claude` in a blank pane, record that so
         // future task assignments can inject prompts directly.
         if !had_claude {
             let started_pane = pane_id.clone();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -11,6 +11,7 @@ use crate::cron;
 use crate::inbox::InboxStore;
 use crate::ipc::{write_frame, Request, Response};
 use crate::memory_db;
+use crate::pane_lease;
 use crate::tools::{self, ToolExecutor};
 
 /// Resolve the raw model string to the API-level model ID for token lookups.
@@ -677,6 +678,10 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                     ConnAction::Break => break 'connection,
                 }
             }
+
+            Request::ClaudeLaunch { tasks } => {
+                handle_claude_launch(&writer, tasks).await?;
+            }
         }
     }
 
@@ -784,6 +789,147 @@ async fn drive_agentic_loop(
 // ---------------------------------------------------------------------------
 // Sub-handlers — one per Request variant
 // ---------------------------------------------------------------------------
+
+/// Handle `Request::ClaudeLaunch`: assign tmux panes and launch amaebi chat
+/// sessions for each task.
+///
+/// Steps for each task:
+/// 1. `ensure_idle_panes(n)` — auto-expand pane pool if needed.
+/// 2. For each task: `acquire_first_idle` → get a pane.
+/// 3. Rename the pane title to `"amaebi | <task_id>"`.
+/// 4. Send `tmux send-keys` to start `amaebi chat` (in the worktree if set).
+/// 5. Stream `Response::PaneAssigned` for each task, then `Response::Done`.
+async fn handle_claude_launch(
+    writer: &Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    tasks: Vec<crate::ipc::TaskSpec>,
+) -> Result<()> {
+    if tasks.is_empty() {
+        let mut w = writer.lock().await;
+        write_frame(&mut *w, &Response::Done).await?;
+        return Ok(());
+    }
+
+    let needed = tasks.len();
+
+    // Ensure enough idle panes exist (auto-expand via tmux split-window).
+    let expand_result = tokio::task::spawn_blocking(move || pane_lease::ensure_idle_panes(needed))
+        .await
+        .context("ensure_idle_panes task panicked")?;
+
+    if let Err(e) = expand_result {
+        // Detect capacity errors specifically so we can send the typed response.
+        if let Some(cap) = e.downcast_ref::<pane_lease::CapacityError>() {
+            let mut w = writer.lock().await;
+            write_frame(
+                &mut *w,
+                &Response::CapacityError {
+                    requested: cap.requested,
+                    max_panes: cap.max_panes,
+                    current_busy: cap.current_busy,
+                },
+            )
+            .await?;
+            write_frame(&mut *w, &Response::Done).await?;
+            return Ok(());
+        }
+        let mut w = writer.lock().await;
+        write_frame(
+            &mut *w,
+            &Response::Error {
+                message: format!("[error] {e:#}"),
+            },
+        )
+        .await?;
+        write_frame(&mut *w, &Response::Done).await?;
+        return Ok(());
+    }
+
+    // Acquire a lease and launch a chat session for each task.
+    for task in tasks {
+        let task_id = task.task_id.clone();
+        let worktree = task.worktree.clone();
+        let session_id = uuid::Uuid::new_v4().to_string();
+        let sid_for_lease = session_id.clone();
+        let tid_for_lease = task_id.clone();
+        let wt_for_lease = worktree.clone();
+
+        let pane_result = tokio::task::spawn_blocking(move || {
+            pane_lease::acquire_first_idle(&tid_for_lease, &sid_for_lease, wt_for_lease.as_deref())
+        })
+        .await
+        .context("acquire_first_idle task panicked")?;
+
+        let pane_id = match pane_result {
+            Ok(p) => p,
+            Err(e) => {
+                let mut w = writer.lock().await;
+                write_frame(
+                    &mut *w,
+                    &Response::Error {
+                        message: format!("[error] {e:#}"),
+                    },
+                )
+                .await?;
+                continue;
+            }
+        };
+
+        // Rename the pane for visibility.
+        let rename_pane = pane_id.clone();
+        let rename_title = format!("amaebi | {}", task_id);
+        tokio::task::spawn_blocking(move || {
+            // Best-effort — ignore errors (non-tmux environments).
+            let _ = pane_lease::rename_pane(&rename_pane, &rename_title);
+        })
+        .await
+        .ok();
+
+        // Build the command to inject into the pane.
+        let amaebi_cmd = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.to_str().map(str::to_string))
+            .unwrap_or_else(|| "amaebi".to_string());
+
+        let cmd = if let Some(ref wt) = worktree {
+            format!("cd {} && {} chat", shell_escape(wt), amaebi_cmd)
+        } else {
+            format!("{} chat", amaebi_cmd)
+        };
+
+        let enter_suffix = if task.auto_enter { " Enter" } else { "" };
+        let keys_arg = format!("{cmd}{enter_suffix}");
+        let send_pane = pane_id.clone();
+
+        // Send the command to the pane.
+        tokio::task::spawn_blocking(move || {
+            let _ = std::process::Command::new("tmux")
+                .args(["send-keys", "-t", &send_pane, &keys_arg])
+                .output();
+        })
+        .await
+        .ok();
+
+        let mut w = writer.lock().await;
+        write_frame(
+            &mut *w,
+            &Response::PaneAssigned {
+                task_id: task.task_id,
+                pane_id,
+                session_id,
+            },
+        )
+        .await?;
+    }
+
+    let mut w = writer.lock().await;
+    write_frame(&mut *w, &Response::Done).await?;
+    Ok(())
+}
+
+/// Escape a string for safe use as a single shell argument (single-quote wrapping).
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
 
 /// Handle `Request::ClearMemory`: clear the memory DB and send `Done`.
 async fn handle_clear_memory(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -830,9 +830,12 @@ async fn handle_claude_launch(
             Some(wt) => Some(wt),
             None => {
                 let tid = task_id.clone();
-                match tokio::task::spawn_blocking(move || create_task_worktree(&tid))
-                    .await
-                    .context("create_task_worktree panicked")?
+                let cwd = task.client_cwd.clone();
+                match tokio::task::spawn_blocking(move || {
+                    create_task_worktree(&tid, cwd.as_deref())
+                })
+                .await
+                .context("create_task_worktree panicked")?
                 {
                     Ok(path) => Some(path.to_string_lossy().into_owned()),
                     Err(e) => {
@@ -1059,16 +1062,47 @@ async fn handle_claude_launch(
 /// A per-repo subdirectory (the basename of the git root) prevents task-id
 /// collisions across different repositories.
 ///
+/// `client_cwd` is the working directory of the invoking client.  Git is run
+/// with `-C <client_cwd>` so the correct repository is targeted even when the
+/// daemon was started from a different directory.
+///
 /// Returns the absolute path of the newly created worktree, or an error if:
-/// - the current directory is not inside a git repository, or
+/// - `task_id` contains unsafe characters (path separators, `..`), or
+/// - the client's directory is not inside a git repository, or
 /// - `git worktree add` fails (e.g. branch name already exists).
 ///
 /// All git commands are synchronous; call this from `spawn_blocking`.
-fn create_task_worktree(task_id: &str) -> anyhow::Result<std::path::PathBuf> {
+fn create_task_worktree(
+    task_id: &str,
+    client_cwd: Option<&str>,
+) -> anyhow::Result<std::path::PathBuf> {
     use std::path::PathBuf;
 
-    // Locate the repository root.
-    let out = std::process::Command::new("git")
+    // Sanitize task_id: allow only characters that are safe as both a
+    // filesystem path component and a git branch name.
+    if task_id.is_empty()
+        || task_id == ".."
+        || task_id.contains('/')
+        || task_id.contains('\\')
+        || task_id.contains("..")
+        || !task_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    {
+        anyhow::bail!(
+            "task_id {:?} contains unsafe characters; \
+             only ASCII alphanumerics, '-', '_', and '.' are allowed",
+            task_id
+        );
+    }
+
+    // Locate the repository root using the client's cwd so the daemon (which
+    // may have been started from a different directory) targets the right repo.
+    let mut git_cmd = std::process::Command::new("git");
+    if let Some(cwd) = client_cwd {
+        git_cmd.args(["-C", cwd]);
+    }
+    let out = git_cmd
         .args(["rev-parse", "--show-toplevel"])
         .output()
         .context("spawning git rev-parse")?;
@@ -1097,8 +1131,19 @@ fn create_task_worktree(task_id: &str) -> anyhow::Result<std::path::PathBuf> {
         .join(repo_name)
         .join(task_id);
 
+    // Ensure the parent directory exists before calling git.
+    let wt_parent = wt_path
+        .parent()
+        .context("worktree path has no parent directory")?;
+    std::fs::create_dir_all(wt_parent)
+        .with_context(|| format!("creating worktree parent directory {}", wt_parent.display()))?;
+
     // Create the worktree on a new branch with the same name as the task.
-    let out = std::process::Command::new("git")
+    let mut git_cmd = std::process::Command::new("git");
+    if let Some(cwd) = client_cwd {
+        git_cmd.args(["-C", cwd]);
+    }
+    let out = git_cmd
         .args([
             "worktree",
             "add",

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -965,20 +965,33 @@ async fn handle_claude_launch(
 
         let send_pane = pane_id.clone();
 
-        // Send all key sequences to the pane.  "Enter" must be a separate
-        // argument — passing it as part of the keys string would send the
-        // literal text " Enter" rather than pressing the Enter key.
+        // Send all key sequences to the pane.
+        //
+        // Text (user-provided descriptions and shell commands) is sent with
+        // `send-keys -l --` so tmux treats the argument as a literal string
+        // rather than a key name.  Without `-l`, strings like "Enter" or
+        // "C-c" would be interpreted as key presses, and strings starting
+        // with "-" would be parsed as send-keys options.
+        //
+        // The Enter key itself is sent in a separate invocation without `-l`
+        // so it remains a real key press (not the literal text "Enter").
         let send_result = tokio::task::spawn_blocking(move || {
             for (keys, press_enter) in &key_sequence {
-                let mut cmd_args = vec!["send-keys", "-t", &send_pane, keys.as_str()];
-                if *press_enter {
-                    cmd_args.push("Enter");
-                }
+                // Send text literally.
                 let out = std::process::Command::new("tmux")
-                    .args(&cmd_args)
+                    .args(["send-keys", "-t", &send_pane, "-l", "--", keys.as_str()])
                     .output()?;
                 if !out.status.success() {
                     return Ok::<bool, std::io::Error>(false);
+                }
+                // Press Enter as a real key in a separate call.
+                if *press_enter {
+                    let out = std::process::Command::new("tmux")
+                        .args(["send-keys", "-t", &send_pane, "Enter"])
+                        .output()?;
+                    if !out.status.success() {
+                        return Ok::<bool, std::io::Error>(false);
+                    }
                 }
             }
             Ok(true)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -942,11 +942,15 @@ async fn handle_claude_launch(
         };
         let update_pane = pane_id.clone();
         let update_sid = session_id.clone();
-        tokio::task::spawn_blocking(move || {
-            let _ = pane_lease::update_session_id(&update_pane, &update_sid);
+        if let Err(e) = tokio::task::spawn_blocking(move || {
+            pane_lease::update_session_id(&update_pane, &update_sid)
         })
         .await
-        .ok();
+        .map_err(|e| anyhow::anyhow!("update_session_id panicked: {e}"))
+        .and_then(|r| r)
+        {
+            tracing::warn!(pane_id = %pane_id, error = %e, "failed to persist session ID in pane lease; tmux-state.json may be inconsistent");
+        }
 
         // Rename the pane for visibility.  Use the tmux pane numeric index
         // (strip the leading '%' from e.g. "%5") to keep the title short.
@@ -1005,6 +1009,7 @@ async fn handle_claude_launch(
         //
         // The Enter key itself is sent in a separate invocation without `-l`
         // so it remains a real key press (not the literal text "Enter").
+        // Returns Ok(None) on success, Ok(Some(stderr)) on tmux failure.
         let send_result = tokio::task::spawn_blocking(move || {
             for (keys, press_enter) in &key_sequence {
                 // Send text literally.
@@ -1012,7 +1017,9 @@ async fn handle_claude_launch(
                     .args(["send-keys", "-t", &send_pane, "-l", "--", keys.as_str()])
                     .output()?;
                 if !out.status.success() {
-                    return Ok::<bool, std::io::Error>(false);
+                    return Ok::<Option<String>, std::io::Error>(Some(
+                        String::from_utf8_lossy(&out.stderr).trim().to_string(),
+                    ));
                 }
                 // Press Enter as a real key in a separate call.
                 if *press_enter {
@@ -1020,16 +1027,23 @@ async fn handle_claude_launch(
                         .args(["send-keys", "-t", &send_pane, "Enter"])
                         .output()?;
                     if !out.status.success() {
-                        return Ok::<bool, std::io::Error>(false);
+                        return Ok(Some(
+                            String::from_utf8_lossy(&out.stderr).trim().to_string(),
+                        ));
                     }
                 }
             }
-            Ok(true)
+            Ok(None)
         })
         .await;
 
-        let send_ok = matches!(send_result, Ok(Ok(true)));
-        if !send_ok {
+        let tmux_err = match send_result {
+            Ok(Ok(None)) => None,
+            Ok(Ok(Some(stderr))) => Some(stderr),
+            Ok(Err(e)) => Some(e.to_string()),
+            Err(e) => Some(format!("send-keys task panicked: {e}")),
+        };
+        if let Some(err_msg) = tmux_err {
             // Injection failed — release the lease so the pane is not stuck Busy.
             let failed_pane = pane_id.clone();
             tokio::task::spawn_blocking(move || {
@@ -1042,7 +1056,7 @@ async fn handle_claude_launch(
                 &mut *w,
                 &Response::Error {
                     message: format!(
-                        "[error] failed to inject command into pane {pane_id}: tmux send-keys failed"
+                        "[error] failed to inject command into pane {pane_id}: {err_msg}"
                     ),
                 },
             )
@@ -1078,16 +1092,17 @@ async fn handle_claude_launch(
     Ok(())
 }
 
-/// Create a git worktree at `~/.amaebi/worktrees/<repo-name>/<task_id>` on a
-/// new branch named `<task_id>`.
+/// Create a git worktree at `~/.amaebi/worktrees/<repo-name>/<task_id>-<uuid8>`
+/// on a new branch named `<task_id>-<uuid8>`.
 ///
 /// Every parallel `/claude` task needs its own worktree so that concurrent
 /// Claude sessions editing the same repository do not trample each other's
 /// in-progress changes.  Worktrees are stored under `~/.amaebi/worktrees/`
 /// (alongside other amaebi state) rather than inside the repository directory,
 /// which avoids polluting the project tree and requires no `.gitignore` entry.
-/// A per-repo subdirectory (the basename of the git root) prevents task-id
-/// collisions across different repositories.
+/// A per-repo subdirectory (the basename of the git root) prevents collisions
+/// across different repositories; the `-<uuid8>` suffix makes each
+/// worktree/branch unique for a given `task_id` across runs.
 ///
 /// `client_cwd` is the working directory of the invoking client.  Git is run
 /// with `-C <client_cwd>` so the correct repository is targeted even when the

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1025,12 +1025,16 @@ async fn handle_claude_launch(
     Ok(())
 }
 
-/// Create a git worktree at `<git-root>/amaebi-wt/<task_id>` on a new branch
-/// named `<task_id>`.
+/// Create a git worktree at `~/.amaebi/worktrees/<repo-name>/<task_id>` on a
+/// new branch named `<task_id>`.
 ///
 /// Every parallel `/claude` task needs its own worktree so that concurrent
 /// Claude sessions editing the same repository do not trample each other's
-/// in-progress changes.
+/// in-progress changes.  Worktrees are stored under `~/.amaebi/worktrees/`
+/// (alongside other amaebi state) rather than inside the repository directory,
+/// which avoids polluting the project tree and requires no `.gitignore` entry.
+/// A per-repo subdirectory (the basename of the git root) prevents task-id
+/// collisions across different repositories.
 ///
 /// Returns the absolute path of the newly created worktree, or an error if:
 /// - the current directory is not inside a git repository, or
@@ -1052,7 +1056,23 @@ fn create_task_worktree(task_id: &str) -> anyhow::Result<std::path::PathBuf> {
         );
     }
     let git_root = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-    let wt_path = git_root.join("amaebi-wt").join(task_id);
+
+    // Derive a short repo name from the git root basename for namespacing.
+    let repo_name = git_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("repo");
+
+    // Place worktrees under ~/.amaebi/worktrees/<repo>/<task_id> so they are
+    // centralised alongside other amaebi state and never pollute the repo tree.
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .context("HOME environment variable not set")?;
+    let wt_path = PathBuf::from(home)
+        .join(".amaebi")
+        .join("worktrees")
+        .join(repo_name)
+        .join(task_id);
 
     // Create the worktree on a new branch with the same name as the task.
     let out = std::process::Command::new("git")

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -821,20 +821,10 @@ async fn handle_claude_launch(
         let tid_for_lease = task_id.clone();
         let wt_for_lease = worktree.clone();
 
-        // Compute the session UUID the launched `amaebi chat` will use, so
-        // the PaneAssigned response carries the real session ID rather than a
-        // random placeholder.
-        let session_dir = worktree
-            .as_deref()
-            .map(std::path::Path::new)
-            .map(std::path::Path::to_path_buf)
-            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-        let session_id = tokio::task::spawn_blocking(move || session::get_or_create(&session_dir))
-            .await
-            .context("session::get_or_create panicked")?
-            .context("resolving session ID")?;
-
-        let sid_for_lease = session_id.clone();
+        // Acquire a pane lease *before* creating session state so that a
+        // capacity failure does not leave orphan session entries on disk.
+        let sid_placeholder = uuid::Uuid::new_v4().to_string();
+        let sid_for_lease = sid_placeholder.clone();
         let pane_result = tokio::task::spawn_blocking(move || {
             pane_lease::ensure_and_acquire_idle(
                 &tid_for_lease,
@@ -848,9 +838,9 @@ async fn handle_claude_launch(
         let pane_id = match pane_result {
             Ok(p) => p,
             Err(e) => {
-                // Surface CapacityError as the typed response.
+                // Surface CapacityError as a typed terminal response.
+                let mut w = writer.lock().await;
                 if let Some(cap) = e.downcast_ref::<pane_lease::CapacityError>() {
-                    let mut w = writer.lock().await;
                     write_frame(
                         &mut *w,
                         &Response::CapacityError {
@@ -860,19 +850,31 @@ async fn handle_claude_launch(
                         },
                     )
                     .await?;
-                    continue;
+                } else {
+                    write_frame(
+                        &mut *w,
+                        &Response::Error {
+                            message: format!("[error] {e:#}"),
+                        },
+                    )
+                    .await?;
                 }
-                let mut w = writer.lock().await;
-                write_frame(
-                    &mut *w,
-                    &Response::Error {
-                        message: format!("[error] {e:#}"),
-                    },
-                )
-                .await?;
-                continue;
+                // Both Error and CapacityError are terminal: the client
+                // breaks its read loop on either, so return immediately.
+                return Ok(());
             }
         };
+
+        // Resolve the real session UUID now that the pane is secured.
+        let session_dir = worktree
+            .as_deref()
+            .map(std::path::Path::new)
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+        let session_id = tokio::task::spawn_blocking(move || session::get_or_create(&session_dir))
+            .await
+            .context("session::get_or_create panicked")?
+            .context("resolving session ID")?;
 
         // Rename the pane for visibility.
         let rename_pane = pane_id.clone();
@@ -912,15 +914,36 @@ async fn handle_claude_launch(
         // Send the command to the pane. "Enter" must be a separate argument —
         // passing it as part of the keys string would send the literal text
         // " Enter" rather than pressing the Enter key.
-        tokio::task::spawn_blocking(move || {
+        let send_result = tokio::task::spawn_blocking(move || {
             let mut cmd_args = vec!["send-keys", "-t", &send_pane, &cmd];
             if auto_enter {
                 cmd_args.push("Enter");
             }
-            let _ = std::process::Command::new("tmux").args(&cmd_args).output();
+            std::process::Command::new("tmux").args(&cmd_args).output()
         })
-        .await
-        .ok();
+        .await;
+
+        let send_ok = matches!(send_result, Ok(Ok(ref out)) if out.status.success());
+        if !send_ok {
+            // Injection failed — release the lease so the pane is not stuck Busy.
+            let failed_pane = pane_id.clone();
+            tokio::task::spawn_blocking(move || {
+                let _ = pane_lease::release_lease(&failed_pane);
+            })
+            .await
+            .ok();
+            let mut w = writer.lock().await;
+            write_frame(
+                &mut *w,
+                &Response::Error {
+                    message: format!(
+                        "[error] failed to inject command into pane {pane_id}: tmux send-keys failed"
+                    ),
+                },
+            )
+            .await?;
+            return Ok(());
+        }
 
         let mut w = writer.lock().await;
         write_frame(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -826,6 +826,9 @@ async fn handle_claude_launch(
         // Each parallel Claude session must work in its own git worktree so
         // concurrent tasks cannot trample each other's in-progress file edits.
         // Auto-create a worktree when the caller did not supply one explicitly.
+        // Track whether the worktree was auto-created so we can clean it up
+        // if pane acquisition subsequently fails (avoiding orphaned branches).
+        let was_explicit_worktree = task.worktree.is_some();
         let worktree: Option<String> = match task.worktree {
             Some(wt) => Some(wt),
             None => {
@@ -872,6 +875,20 @@ async fn handle_claude_launch(
         let (pane_id, had_claude) = match pane_result {
             Ok(p) => p,
             Err(e) => {
+                // If the worktree was auto-created, clean it up to avoid
+                // orphaned git branches sitting around after a capacity error.
+                if !was_explicit_worktree {
+                    if let Some(ref wt) = worktree {
+                        let wt_path = wt.clone();
+                        tokio::task::spawn_blocking(move || {
+                            let _ = std::process::Command::new("git")
+                                .args(["worktree", "remove", "--force", &wt_path])
+                                .output();
+                        })
+                        .await
+                        .ok();
+                    }
+                }
                 // Surface CapacityError as a typed terminal response.
                 // Report tasks still unassigned (including this one) so the
                 // caller sees the real demand that exceeded capacity.
@@ -1044,10 +1061,19 @@ async fn handle_claude_launch(
             Err(e) => Some(format!("send-keys task panicked: {e}")),
         };
         if let Some(err_msg) = tmux_err {
-            // Injection failed — release the lease so the pane is not stuck Busy.
+            // Injection failed.  If tmux reports the pane no longer exists,
+            // remove it from the lease map entirely so the scheduler stops
+            // selecting it.  Otherwise just release it back to Idle.
             let failed_pane = pane_id.clone();
+            let is_stale = err_msg.contains("unknown pane")
+                || err_msg.contains("can't find pane")
+                || err_msg.contains("no server running");
             tokio::task::spawn_blocking(move || {
-                let _ = pane_lease::release_lease(&failed_pane);
+                if is_stale {
+                    let _ = pane_lease::remove_pane(&failed_pane);
+                } else {
+                    let _ = pane_lease::release_lease(&failed_pane);
+                }
             })
             .await
             .ok();
@@ -1156,13 +1182,26 @@ fn create_task_worktree(
     }
     let git_root = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
 
-    // Derive a short repo name from the git root basename for namespacing.
-    let repo_name = git_root
+    // Build a repo namespace that combines the basename with a short hash of
+    // the full path.  The basename alone is not unique: `~/src/api` and
+    // `~/work/api` share the same name but are different repos.
+    let repo_basename = git_root
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("repo");
+    let path_hash = {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut h = DefaultHasher::new();
+        git_root.hash(&mut h);
+        format!("{:016x}", h.finish())
+            .chars()
+            .take(8)
+            .collect::<String>()
+    };
+    let repo_namespace = format!("{repo_basename}-{path_hash}");
 
-    // Place worktrees under ~/.amaebi/worktrees/<repo>/<task_id>-<uuid8>.
+    // Place worktrees under ~/.amaebi/worktrees/<repo-hash>/<task_id>-<uuid8>.
     // A short UUID suffix guarantees uniqueness across runs so repeated
     // invocations with the same task description never collide on the branch
     // name or directory path — the same approach Claude Code uses for its own
@@ -1177,7 +1216,7 @@ fn create_task_worktree(
 
     let wt_path = amaebi_home()?
         .join("worktrees")
-        .join(repo_name)
+        .join(&repo_namespace)
         .join(&unique_name);
 
     // Ensure the parent directory exists before calling git.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -820,9 +820,33 @@ async fn handle_claude_launch(
     let total_tasks = tasks.len();
     for (task_idx, task) in tasks.into_iter().enumerate() {
         let task_id = task.task_id.clone();
-        let worktree = task.worktree.clone();
         let description = task.description.clone();
         let auto_enter = task.auto_enter;
+
+        // Each parallel Claude session must work in its own git worktree so
+        // concurrent tasks cannot trample each other's in-progress file edits.
+        // Auto-create a worktree when the caller did not supply one explicitly.
+        let worktree: Option<String> = match task.worktree {
+            Some(wt) => Some(wt),
+            None => {
+                let tid = task_id.clone();
+                match tokio::task::spawn_blocking(move || create_task_worktree(&tid))
+                    .await
+                    .context("create_task_worktree panicked")?
+                {
+                    Ok(path) => Some(path.to_string_lossy().into_owned()),
+                    Err(e) => {
+                        tracing::warn!(
+                            task_id = %task_id,
+                            error = %e,
+                            "auto-worktree creation failed; launching claude without worktree isolation"
+                        );
+                        None
+                    }
+                }
+            }
+        };
+
         let tid_for_lease = task_id.clone();
         let wt_for_lease = worktree.clone();
 
@@ -999,6 +1023,57 @@ async fn handle_claude_launch(
     let mut w = writer.lock().await;
     write_frame(&mut *w, &Response::Done).await?;
     Ok(())
+}
+
+/// Create a git worktree at `<git-root>/amaebi-wt/<task_id>` on a new branch
+/// named `<task_id>`.
+///
+/// Every parallel `/claude` task needs its own worktree so that concurrent
+/// Claude sessions editing the same repository do not trample each other's
+/// in-progress changes.
+///
+/// Returns the absolute path of the newly created worktree, or an error if:
+/// - the current directory is not inside a git repository, or
+/// - `git worktree add` fails (e.g. branch name already exists).
+///
+/// All git commands are synchronous; call this from `spawn_blocking`.
+fn create_task_worktree(task_id: &str) -> anyhow::Result<std::path::PathBuf> {
+    use std::path::PathBuf;
+
+    // Locate the repository root.
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .context("spawning git rev-parse")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "not in a git repository (git rev-parse failed: {})",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    let git_root = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
+    let wt_path = git_root.join("amaebi-wt").join(task_id);
+
+    // Create the worktree on a new branch with the same name as the task.
+    let out = std::process::Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            wt_path
+                .to_str()
+                .context("worktree path is not valid UTF-8")?,
+            "-b",
+            task_id,
+        ])
+        .output()
+        .context("spawning git worktree add")?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(wt_path)
 }
 
 /// Escape a string for safe use as a single shell argument (single-quote wrapping).

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -913,10 +913,33 @@ async fn handle_claude_launch(
             .map(std::path::Path::to_path_buf)
             .or_else(|| task.client_cwd.as_deref().map(std::path::PathBuf::from))
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-        let session_id = tokio::task::spawn_blocking(move || session::get_or_create(&session_dir))
-            .await
-            .context("session::get_or_create panicked")?
-            .context("resolving session ID")?;
+        // If session resolution fails, release the pane so it doesn't get
+        // stuck Busy until TTL expiry.
+        let session_id_result =
+            tokio::task::spawn_blocking(move || session::get_or_create(&session_dir))
+                .await
+                .map_err(|e| anyhow::anyhow!("session::get_or_create panicked: {e}"))
+                .and_then(|r| r.context("resolving session ID"));
+        let session_id = match session_id_result {
+            Ok(id) => id,
+            Err(e) => {
+                let failed_pane = pane_id.clone();
+                tokio::task::spawn_blocking(move || {
+                    let _ = pane_lease::release_lease(&failed_pane);
+                })
+                .await
+                .ok();
+                let mut w = writer.lock().await;
+                write_frame(
+                    &mut *w,
+                    &Response::Error {
+                        message: format!("[error] {e:#}"),
+                    },
+                )
+                .await?;
+                return Ok(());
+            }
+        };
         let update_pane = pane_id.clone();
         let update_sid = session_id.clone();
         tokio::task::spawn_blocking(move || {
@@ -1137,11 +1160,7 @@ fn create_task_worktree(
         .collect::<String>();
     let unique_name = format!("{task_id}-{short_id}");
 
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .context("HOME environment variable not set")?;
-    let wt_path = PathBuf::from(home)
-        .join(".amaebi")
+    let wt_path = amaebi_home()?
         .join("worktrees")
         .join(repo_name)
         .join(&unique_name);

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -8,6 +8,11 @@ pub struct TaskSpec {
     /// Optional absolute path to a git worktree for this task.
     /// Enforced as unique across all currently Busy panes.
     pub worktree: Option<String>,
+    /// Absolute path to the client's working directory at the time `/claude`
+    /// was invoked.  Used by the daemon to locate the correct git repository
+    /// for auto-worktree creation, since the daemon may have been started from
+    /// a different directory.
+    pub client_cwd: Option<String>,
     /// If `false`, the command is injected into the pane without a trailing
     /// Enter key (useful for commands the user wants to review first).
     pub auto_enter: bool,
@@ -187,7 +192,11 @@ pub enum Response {
     /// The [`Request::ClaudeLaunch`] was rejected because adding the requested
     /// panes would exceed the configured maximum.
     CapacityError {
-        /// Number of panes that were requested.
+        /// Number of tasks still unassigned when capacity was reached.
+        ///
+        /// This is the remaining portion of the launch request at the point of
+        /// failure, not necessarily the original total number of tasks
+        /// submitted by the client.
         requested: usize,
         /// Configured maximum total pane count.
         max_panes: usize,
@@ -518,6 +527,7 @@ mod tests {
             task_id: "pr-123".into(),
             description: "implement feature X".into(),
             worktree: Some("/home/user/repo-wt/feat-x".into()),
+            client_cwd: Some("/home/user/repo".into()),
             auto_enter: true,
         };
         let json = serde_json::to_string(&spec).unwrap();
@@ -536,12 +546,14 @@ mod tests {
                     task_id: "t1".into(),
                     description: "do A".into(),
                     worktree: None,
+                    client_cwd: Some("/home/user/repo".into()),
                     auto_enter: true,
                 },
                 TaskSpec {
                     task_id: "t2".into(),
                     description: "do B".into(),
                     worktree: Some("/wt/b".into()),
+                    client_cwd: None,
                     auto_enter: false,
                 },
             ],

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,3 +1,18 @@
+/// A single task specification for [`Request::ClaudeLaunch`].
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct TaskSpec {
+    /// User-supplied label, e.g. `"pr-123"` or `"issue-76"`.
+    pub task_id: String,
+    /// Description sent to the Claude session as the opening prompt.
+    pub description: String,
+    /// Optional absolute path to a git worktree for this task.
+    /// Enforced as unique across all currently Busy panes.
+    pub worktree: Option<String>,
+    /// If `false`, the command is injected into the pane without a trailing
+    /// Enter key (useful for commands the user wants to review first).
+    pub auto_enter: bool,
+}
+
 /// A message sent from the client to the daemon over the Unix socket.
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -92,6 +107,17 @@ pub enum Request {
     /// The daemon responds with zero or more [`Response::MemoryEntry`] frames
     /// followed by a single [`Response::Done`] frame.
     RetrieveContext { prompt: String },
+    /// Launch one or more independent `chat ↔ Claude` pairs in separate tmux
+    /// panes.
+    ///
+    /// The daemon acquires pane leases (auto-expanding tmux panes if needed),
+    /// starts each session, and responds with one [`Response::PaneAssigned`]
+    /// per task followed by [`Response::Done`].  If the pane capacity limit
+    /// would be exceeded it responds with [`Response::CapacityError`] instead.
+    ClaudeLaunch {
+        /// The tasks to launch in parallel.
+        tasks: Vec<TaskSpec>,
+    },
 }
 
 /// A single frame streamed from the daemon back to the client.
@@ -144,6 +170,29 @@ pub enum Response {
         /// was not part of the streamed text (e.g. a synthesised prompt);
         /// the client should print this text before the `>` cursor.
         prompt: String,
+    },
+    /// One tmux pane has been successfully assigned to a task launched via
+    /// [`Request::ClaudeLaunch`].
+    ///
+    /// The client receives one frame per task, in submission order, before the
+    /// final [`Response::Done`].
+    PaneAssigned {
+        /// The task label supplied in [`TaskSpec::task_id`].
+        task_id: String,
+        /// tmux pane ID, e.g. `"%3"`.
+        pane_id: String,
+        /// amaebi session UUID for the new chat session running in the pane.
+        session_id: String,
+    },
+    /// The [`Request::ClaudeLaunch`] was rejected because adding the requested
+    /// panes would exceed the configured maximum.
+    CapacityError {
+        /// Number of panes that were requested.
+        requested: usize,
+        /// Configured maximum total pane count.
+        max_panes: usize,
+        /// Number of panes currently in Busy state.
+        current_busy: usize,
     },
 }
 
@@ -439,6 +488,8 @@ mod tests {
             r#"{"type":"memory_entry","role":"user","content":"hi"}"#,
             r#"{"type":"waiting_for_input","prompt":"Which language?"}"#,
             r#"{"type":"compacting"}"#,
+            r#"{"type":"pane_assigned","task_id":"pr-1","pane_id":"%3","session_id":"uuid-abc"}"#,
+            r#"{"type":"capacity_error","requested":3,"max_panes":16,"current_busy":14}"#,
         ];
         for frame in frames {
             let r: Response = serde_json::from_str(frame).unwrap();
@@ -453,8 +504,95 @@ mod tests {
                     | Response::MemoryEntry { .. }
                     | Response::WaitingForInput { .. }
                     | Response::Compacting
+                    | Response::PaneAssigned { .. }
+                    | Response::CapacityError { .. }
             ));
         }
+    }
+
+    // ---- ClaudeLaunch / TaskSpec ------------------------------------------
+
+    #[test]
+    fn task_spec_round_trip() {
+        let spec = TaskSpec {
+            task_id: "pr-123".into(),
+            description: "implement feature X".into(),
+            worktree: Some("/home/user/repo-wt/feat-x".into()),
+            auto_enter: true,
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        let back: TaskSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.task_id, "pr-123");
+        assert_eq!(back.description, "implement feature X");
+        assert_eq!(back.worktree.as_deref(), Some("/home/user/repo-wt/feat-x"));
+        assert!(back.auto_enter);
+    }
+
+    #[test]
+    fn request_claude_launch_round_trip() {
+        let req = Request::ClaudeLaunch {
+            tasks: vec![
+                TaskSpec {
+                    task_id: "t1".into(),
+                    description: "do A".into(),
+                    worktree: None,
+                    auto_enter: true,
+                },
+                TaskSpec {
+                    task_id: "t2".into(),
+                    description: "do B".into(),
+                    worktree: Some("/wt/b".into()),
+                    auto_enter: false,
+                },
+            ],
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "claude_launch");
+        assert_eq!(v["tasks"][0]["task_id"], "t1");
+        assert_eq!(v["tasks"][1]["worktree"], "/wt/b");
+
+        let back: Request = serde_json::from_str(&json).unwrap();
+        let Request::ClaudeLaunch { tasks } = back else {
+            panic!("expected ClaudeLaunch");
+        };
+        assert_eq!(tasks.len(), 2);
+    }
+
+    #[test]
+    fn response_pane_assigned_round_trip() {
+        let r = Response::PaneAssigned {
+            task_id: "pr-123".into(),
+            pane_id: "%3".into(),
+            session_id: "uuid-xyz".into(),
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "pane_assigned");
+        assert_eq!(v["task_id"], "pr-123");
+        assert_eq!(v["pane_id"], "%3");
+        assert_eq!(v["session_id"], "uuid-xyz");
+
+        let back: Response = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, Response::PaneAssigned { .. }));
+    }
+
+    #[test]
+    fn response_capacity_error_round_trip() {
+        let r = Response::CapacityError {
+            requested: 3,
+            max_panes: 16,
+            current_busy: 14,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "capacity_error");
+        assert_eq!(v["requested"], 3);
+        assert_eq!(v["max_panes"], 16);
+        assert_eq!(v["current_busy"], 14);
+
+        let back: Response = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, Response::CapacityError { .. }));
     }
 
     // ---- write_frame -----------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod inbox;
 mod ipc;
 mod memory_db;
 mod models;
+mod pane_lease;
 mod provider;
 mod responses;
 mod retry;

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -291,11 +291,16 @@ fn acquire_first_idle_locked(
     //    those panes alone and let auto-expansion create a new blank one.
     // Use state.iter() so the HashMap key is carried through the selection,
     // avoiding a second get_mut lookup (and the unwrap it would require).
+    // Tier-1 reuse requires a known, non-None worktree to match against.
+    // When worktree is None (auto-creation failed), None==None would match any
+    // pane with worktree=None, injecting a prompt into an arbitrary claude
+    // session with unknown directory context.  Guard with worktree.is_some().
     let pane_id = state
         .iter()
         .find(|(_, l)| {
             l.effective_status() == PaneStatus::Idle
                 && l.has_claude
+                && worktree.is_some()
                 && l.worktree.as_deref() == worktree
         })
         .or_else(|| {
@@ -309,11 +314,10 @@ fn acquire_first_idle_locked(
     let lease = state
         .get_mut(&pane_id)
         .ok_or_else(|| anyhow::anyhow!("pane {pane_id} disappeared after selection"))?;
-    // `had_claude` is only true when the pane's stored worktree matches the
-    // requested one — only then can we safely inject a prompt directly into
-    // the running claude session.  A pane with claude in a *different* worktree
-    // must be treated as blank (triggers a fresh `cd <wt> && claude` launch).
-    let had_claude = lease.has_claude && lease.worktree.as_deref() == worktree;
+    // `had_claude` is only true when the pane has a known matching worktree.
+    // worktree.is_some() prevents None==None from triggering tier-1 reuse.
+    let had_claude =
+        lease.has_claude && worktree.is_some() && lease.worktree.as_deref() == worktree;
     lease.status = PaneStatus::Busy;
     lease.task_id = Some(task_id.to_string());
     lease.session_id = Some(session_id.to_string());
@@ -410,6 +414,26 @@ pub fn release_lease(pane_id: &str) -> Result<()> {
 
     lock.unlock()
         .context("releasing flock after release_lease")?;
+    result
+}
+
+/// Remove a pane entry entirely from the lease map.
+///
+/// Used when a tmux pane no longer exists (e.g. "unknown pane" error from
+/// `tmux send-keys`).  Unlike [`release_lease`], this removes the entry so
+/// the scheduler does not keep selecting the same stale pane.
+pub fn remove_pane(pane_id: &str) -> Result<()> {
+    let lock = open_lock_file()?;
+    lock.lock_exclusive()
+        .context("acquiring flock for remove_pane")?;
+
+    let result = (|| {
+        let mut state = read_state_unlocked()?;
+        state.remove(pane_id);
+        write_state_unlocked(&state)
+    })();
+
+    lock.unlock().context("releasing flock after remove_pane")?;
     result
 }
 

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -739,9 +739,6 @@ fn tmux_split_window_sync(window_id: &str) -> Result<String> {
 mod tests {
     use super::*;
 
-    // Mutex to serialize tests that mutate the HOME env var.
-    static HOME_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     fn make_idle(pane_id: &str, window_id: &str) -> PaneLease {
         PaneLease::new_idle(pane_id.to_string(), window_id.to_string())
     }
@@ -833,28 +830,11 @@ mod tests {
     // ── file-based state ops (use tempdir via HOME override) ───────────────
 
     // Helper: redirect HOME to a tempdir, run f(), restore HOME.
-    fn with_temp_home<F, R>(f: F) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        // Recover from a poisoned mutex (a previous test panicked while holding
-        // it) so remaining tests can still run.
-        let _guard = HOME_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
-        let dir = tempfile::tempdir().expect("tempdir");
-        let orig = std::env::var("HOME").ok();
-        // Safety: we hold the HOME_MUTEX so no other test can mutate HOME.
-        unsafe { std::env::set_var("HOME", dir.path()) };
-        let result = f();
-        match orig {
-            Some(h) => unsafe { std::env::set_var("HOME", &h) },
-            None => unsafe { std::env::remove_var("HOME") },
-        }
-        result
-    }
 
     #[test]
     fn acquire_lease_on_idle_pane_succeeds() {
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             // Seed one idle pane directly.
             let mut state: PaneState = HashMap::new();
             state.insert("%0".to_string(), make_idle("%0", "@0"));
@@ -865,24 +845,26 @@ mod tests {
             let s = read_state_unlocked().expect("read back");
             assert_eq!(s["%0"].effective_status(), PaneStatus::Busy);
             assert_eq!(s["%0"].task_id.as_deref(), Some("task-x"));
-        });
+        }
     }
 
     #[test]
     fn acquire_lease_on_busy_pane_returns_err() {
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             let mut state: PaneState = HashMap::new();
             state.insert("%0".to_string(), make_busy("%0", "@0", None));
             write_state_unlocked(&state).expect("seed state");
 
             let err = acquire_lease("%0", "task-y", "sess-y", None);
             assert!(err.is_err(), "expected Err for busy pane");
-        });
+        }
     }
 
     #[test]
     fn acquire_lease_on_expired_busy_pane_succeeds() {
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             let mut expired = make_busy("%0", "@0", None);
             expired.heartbeat_at = now_secs().saturating_sub(LEASE_TTL_SECS + 1);
             let mut state: PaneState = HashMap::new();
@@ -893,12 +875,13 @@ mod tests {
 
             let s = read_state_unlocked().expect("read back");
             assert_eq!(s["%0"].task_id.as_deref(), Some("task-new"));
-        });
+        }
     }
 
     #[test]
     fn acquire_first_idle_finds_idle_pane() {
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             let mut state: PaneState = HashMap::new();
             state.insert("%0".to_string(), make_busy("%0", "@0", None));
             state.insert("%1".to_string(), make_idle("%1", "@0"));
@@ -907,12 +890,13 @@ mod tests {
             let (pane, _had_claude) =
                 acquire_first_idle("t", "s", None).expect("acquire first idle");
             assert_eq!(pane, "%1");
-        });
+        }
     }
 
     #[test]
     fn acquire_first_idle_rejects_duplicate_worktree() {
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             let mut state: PaneState = HashMap::new();
             state.insert(
                 "%0".to_string(),
@@ -923,12 +907,13 @@ mod tests {
 
             let err = acquire_first_idle("t2", "s2", Some("/repo/wt/task1"));
             assert!(err.is_err(), "expected Err for duplicate worktree");
-        });
+        }
     }
 
     #[test]
     fn acquire_first_idle_prefers_has_claude_pane_with_matching_worktree() {
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             let mut state: PaneState = HashMap::new();
             // Pane with claude already running in the target worktree — should be preferred.
             let mut has_claude_matching = make_idle("%0", "@0");
@@ -944,12 +929,13 @@ mod tests {
                 acquire_first_idle("t", "s", Some("/repo/wt/task1")).expect("acquire");
             assert_eq!(pane, "%0", "should prefer matching has_claude pane");
             assert!(had_claude, "had_claude should be true for reused pane");
-        });
+        }
     }
 
     #[test]
     fn acquire_first_idle_skips_has_claude_pane_with_different_worktree() {
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             let mut state: PaneState = HashMap::new();
             // Pane with claude in a *different* worktree — must not be preferred.
             let mut has_claude_other = make_idle("%0", "@0");
@@ -971,7 +957,7 @@ mod tests {
                 "must skip has_claude pane with different worktree"
             );
             assert!(!had_claude, "had_claude must be false for blank pane");
-        });
+        }
     }
 
     #[test]
@@ -979,7 +965,8 @@ mod tests {
         // All idle panes have claude running in a different worktree — none
         // are usable for a fresh task.  ensure_and_acquire_idle must attempt
         // expansion rather than returning "no idle panes available" immediately.
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             let mut state: PaneState = HashMap::new();
             let mut pane = make_idle("%0", "@0");
             pane.has_claude = true;
@@ -1005,12 +992,13 @@ mod tests {
                     );
                 }
             }
-        });
+        }
     }
 
     #[test]
     fn release_lease_marks_pane_idle() {
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             let mut state: PaneState = HashMap::new();
             state.insert("%0".to_string(), make_busy("%0", "@0", None));
             write_state_unlocked(&state).expect("seed state");
@@ -1020,14 +1008,15 @@ mod tests {
             let s = read_state_unlocked().expect("read back");
             assert_eq!(s["%0"].effective_status(), PaneStatus::Idle);
             assert!(s["%0"].task_id.is_none());
-        });
+        }
     }
 
     #[test]
     fn release_lease_preserves_worktree_and_has_claude() {
         // worktree and has_claude must survive release so the scheduler can
         // reuse the pane for a future task in the same worktree (tier-1 reuse).
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             let mut lease = make_busy("%0", "@0", Some("/repo/wt/task1"));
             lease.has_claude = true;
             let mut state: PaneState = HashMap::new();
@@ -1044,12 +1033,13 @@ mod tests {
                 "worktree must be preserved so tier-1 reuse can match it"
             );
             assert!(s["%0"].has_claude, "has_claude must be preserved");
-        });
+        }
     }
 
     #[test]
     fn heartbeat_updates_timestamp() {
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             let mut lease = make_busy("%0", "@0", None);
             // Set an old heartbeat.
             lease.heartbeat_at = 1000;
@@ -1064,12 +1054,13 @@ mod tests {
                 s["%0"].heartbeat_at > 1000,
                 "heartbeat should have been updated"
             );
-        });
+        }
     }
 
     #[test]
     fn ensure_idle_panes_capacity_exceeded_returns_err() {
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             // Fill all MAX_PANES slots with Busy leases.
             let mut state: PaneState = HashMap::new();
             for i in 0..MAX_PANES {
@@ -1089,12 +1080,13 @@ mod tests {
             let cap = err.downcast_ref::<CapacityError>().expect("CapacityError");
             assert_eq!(cap.max_panes, MAX_PANES);
             assert_eq!(cap.requested, 1);
-        });
+        }
     }
 
     #[test]
     fn ensure_idle_panes_noop_when_enough_idle() {
-        with_temp_home(|| {
+        {
+            let _guard = crate::test_utils::with_temp_home();
             let mut state: PaneState = HashMap::new();
             state.insert("%0".to_string(), make_idle("%0", "@0"));
             state.insert("%1".to_string(), make_idle("%1", "@0"));
@@ -1107,6 +1099,6 @@ mod tests {
             lock.unlock().expect("unlock");
 
             result.expect("should succeed without calling tmux");
-        });
+        }
     }
 }

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -39,7 +39,12 @@ pub const MAX_PANES: usize = 16;
 
 /// Seconds after which a Busy pane whose heartbeat has not been refreshed is
 /// treated as Idle (allows dead processes to release their pane automatically).
-pub const LEASE_TTL_SECS: u64 = 120;
+///
+/// Set to 24 hours so long-running `claude` sessions are not mistakenly
+/// reclaimed.  Proper heartbeat support (periodic refresh while a lease is
+/// active) is a future enhancement; until then TTL serves only as a
+/// crash-recovery safety net.
+pub const LEASE_TTL_SECS: u64 = 86_400;
 
 // ---------------------------------------------------------------------------
 // Data types
@@ -183,8 +188,9 @@ fn read_state_unlocked() -> Result<PaneState> {
         return Ok(PaneState::new());
     }
     // Tolerate corrupt JSON: reset to empty state rather than hard-erroring.
-    // A corrupt file is treated the same as a missing one — the panes will
-    // be re-discovered on the next `ensure_idle_panes` call.
+    // A corrupt file is treated the same as a missing one; persisted lease
+    // state is discarded and rebuilt through normal pane creation / lease
+    // updates going forward.
     Ok(serde_json::from_str(&contents).unwrap_or_default())
 }
 
@@ -197,10 +203,16 @@ fn write_state_unlocked(state: &PaneState) -> Result<()> {
     let contents = serde_json::to_string_pretty(state)?;
 
     // Atomic write: write to a temp file then rename so readers never see a
-    // partially-written file.
+    // partially-written file.  Restrict permissions to 0o600 so session IDs
+    // and worktree paths are not world-readable.
     let tmp_path = path.with_extension("tmp");
     std::fs::write(&tmp_path, &contents)
         .with_context(|| format!("writing tmp {}", tmp_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600));
+    }
     std::fs::rename(&tmp_path, &path)
         .with_context(|| format!("renaming {} → {}", tmp_path.display(), path.display()))
 }
@@ -577,6 +589,30 @@ pub fn ensure_and_acquire_idle(
 
     lock.unlock()
         .context("releasing flock after ensure_and_acquire_idle")?;
+    result
+}
+
+/// Correct the session ID stored in the pane lease after the real
+/// `session::get_or_create` UUID is known.
+///
+/// `ensure_and_acquire_idle` is called with a placeholder UUID so the pane is
+/// secured before the (potentially fallible) session creation step.  This
+/// function patches the stored value to the real ID.
+pub fn update_session_id(pane_id: &str, session_id: &str) -> Result<()> {
+    let lock = open_lock_file()?;
+    lock.lock_exclusive()
+        .context("acquiring flock for update_session_id")?;
+
+    let result = (|| {
+        let mut state = read_state_unlocked()?;
+        if let Some(lease) = state.get_mut(pane_id) {
+            lease.session_id = Some(session_id.to_string());
+        }
+        write_state_unlocked(&state)
+    })();
+
+    lock.unlock()
+        .context("releasing flock after update_session_id")?;
     result
 }
 

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -628,16 +628,20 @@ pub fn ensure_and_acquire_idle(
     let result = (|| {
         // Count panes that can actually serve this request:
         //   - blank panes (has_claude = false): always usable
-        //   - same-worktree claude panes: reusable via /compact + inject
-        // Panes with claude running in a *different* worktree are skipped by
-        // acquire_first_idle_locked, so they must not count as available here.
+        //   - same-worktree claude panes: reusable via /compact + inject,
+        //     but only when worktree.is_some() — when worktree is None,
+        //     None==None would match any no-worktree claude pane, but
+        //     acquire_first_idle_locked guards tier-1 reuse with
+        //     worktree.is_some(), so those panes won't actually be selected.
+        //     Counting them as available suppresses expansion and leads to
+        //     "no idle panes available" instead.
         // If none are available, expand the pool with a new blank pane.
         let state = read_state_unlocked()?;
         let available = state
             .values()
             .filter(|l| {
                 l.effective_status() == PaneStatus::Idle
-                    && (!l.has_claude || l.worktree.as_deref() == worktree)
+                    && (!l.has_claude || (worktree.is_some() && l.worktree.as_deref() == worktree))
             })
             .count();
         if available == 0 {
@@ -981,6 +985,39 @@ mod tests {
                 "must skip has_claude pane with different worktree"
             );
             assert!(!had_claude, "had_claude must be false for blank pane");
+        }
+    }
+
+    #[test]
+    fn ensure_and_acquire_expands_when_worktree_none_and_only_claude_panes_exist() {
+        // When worktree=None and the only idle pane has has_claude=true with
+        // worktree=None, None==None must NOT suppress expansion.
+        // acquire_first_idle_locked requires worktree.is_some() for tier-1
+        // reuse, so that pane is not selectable — expansion must be attempted.
+        {
+            let _guard = crate::test_utils::with_temp_home();
+            let mut state: PaneState = HashMap::new();
+            let mut pane = make_idle("%0", "@0");
+            pane.has_claude = true;
+            pane.worktree = None; // matches None==None but must NOT count as available
+            state.insert("%0".to_string(), pane);
+            write_state_unlocked(&state).expect("seed state");
+
+            match ensure_and_acquire_idle("t", "s", None) {
+                Ok((_, had_claude)) => {
+                    assert!(
+                        !had_claude,
+                        "None-worktree pane must not trigger tier-1 reuse"
+                    );
+                }
+                Err(e) => {
+                    let msg = format!("{e:#}");
+                    assert!(
+                        !msg.contains("no idle panes available"),
+                        "should attempt expansion, not short-circuit: {msg}"
+                    );
+                }
+            }
         }
     }
 

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -462,7 +462,7 @@ fn ensure_idle_panes_locked(needed: usize) -> Result<()> {
 
     if total + deficit > MAX_PANES {
         return Err(anyhow::Error::new(CapacityError {
-            requested: needed,
+            requested: deficit,
             max_panes: MAX_PANES,
             current_busy: busy_count,
         }));
@@ -543,15 +543,16 @@ pub fn ensure_and_acquire_idle(
     lock.lock_exclusive()
         .context("acquiring flock for ensure_and_acquire_idle")?;
 
-    // Ensure at least 1 idle pane exists (expand if necessary).
-    ensure_idle_panes_locked(1)?;
-
-    // Acquire the first idle pane.
-    let pane_id = acquire_first_idle_locked(task_id, session_id, worktree)?;
+    let result = (|| {
+        // Ensure at least 1 idle pane exists (expand if necessary).
+        ensure_idle_panes_locked(1)?;
+        // Acquire the first idle pane.
+        acquire_first_idle_locked(task_id, session_id, worktree)
+    })();
 
     lock.unlock()
         .context("releasing flock after ensure_and_acquire_idle")?;
-    Ok(pane_id)
+    result
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -1,0 +1,827 @@
+//! Pane lease management for tmux-based parallel Claude sessions.
+//!
+//! Provides atomic acquisition, release, and auto-expansion of tmux panes so
+//! that multiple `amaebi` instances launched via `/claude` cannot steal the
+//! same pane from each other.
+//!
+//! ## State file
+//!
+//! Pane state is persisted in `~/.amaebi/tmux-state.json` (a `HashMap<pane_id,
+//! PaneLease>`) protected by an exclusive `flock` on
+//! `~/.amaebi/tmux-state.lock`.  The JSON format is intentional: the file is a
+//! runtime/operational state store similar to `sessions.json`, where multiple
+//! CLI processes may need to check the lock quickly.
+//!
+//! ## Thread / process safety
+//!
+//! Every mutating operation acquires `LOCK_EX` for the duration of the
+//! read-modify-write cycle.  [`ensure_idle_panes`] holds the lock for the
+//! entire expansion loop (including any `tmux split-window` calls) so two
+//! concurrent `ClaudeLaunch` requests never create duplicate panes.
+//!
+//! All public functions are **synchronous** and must be called from inside
+//! `tokio::task::spawn_blocking` when used from async code.
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+
+/// Maximum total number of panes (Idle + Busy) that the daemon will manage.
+pub const MAX_PANES: usize = 16;
+
+/// Seconds after which a Busy pane whose heartbeat has not been refreshed is
+/// treated as Idle (allows dead processes to release their pane automatically).
+pub const LEASE_TTL_SECS: u64 = 120;
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PaneStatus {
+    Idle,
+    Busy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaneLease {
+    /// tmux pane ID, e.g. `"%3"`.
+    pub pane_id: String,
+    /// tmux window ID that contains this pane, e.g. `"@2"`.
+    pub window_id: String,
+    pub status: PaneStatus,
+    /// User-supplied task label (e.g. `"pr-123"`).
+    pub task_id: Option<String>,
+    /// amaebi session UUID assigned when the lease was acquired.
+    pub session_id: Option<String>,
+    /// Absolute path to the git worktree for this task (uniqueness key).
+    pub worktree: Option<String>,
+    /// Unix timestamp of the last heartbeat (or acquisition time).
+    pub heartbeat_at: u64,
+}
+
+impl PaneLease {
+    pub fn new_idle(pane_id: String, window_id: String) -> Self {
+        Self {
+            pane_id,
+            window_id,
+            status: PaneStatus::Idle,
+            task_id: None,
+            session_id: None,
+            worktree: None,
+            heartbeat_at: now_secs(),
+        }
+    }
+
+    /// Returns the *effective* status, treating expired Busy leases as Idle.
+    pub fn effective_status(&self) -> PaneStatus {
+        if self.status == PaneStatus::Busy
+            && now_secs().saturating_sub(self.heartbeat_at) > LEASE_TTL_SECS
+        {
+            PaneStatus::Idle
+        } else {
+            self.status.clone()
+        }
+    }
+}
+
+/// Keyed by `pane_id`.
+pub type PaneState = HashMap<String, PaneLease>;
+
+// ---------------------------------------------------------------------------
+// Error type for capacity violations
+// ---------------------------------------------------------------------------
+
+/// Returned by [`ensure_idle_panes`] when adding the requested panes would
+/// push the total past [`MAX_PANES`].
+#[derive(Debug)]
+pub struct CapacityError {
+    pub requested: usize,
+    pub max_panes: usize,
+    pub current_busy: usize,
+}
+
+impl std::fmt::Display for CapacityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "capacity limit reached: max_panes={}, busy={}, requested={}; \
+             free existing panes to continue",
+            self.max_panes, self.current_busy, self.requested
+        )
+    }
+}
+
+impl std::error::Error for CapacityError {}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn amaebi_dir() -> Result<PathBuf> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .context("HOME environment variable not set")?;
+    Ok(PathBuf::from(home).join(".amaebi"))
+}
+
+fn state_path() -> Result<PathBuf> {
+    Ok(amaebi_dir()?.join("tmux-state.json"))
+}
+
+fn lock_path() -> Result<PathBuf> {
+    Ok(amaebi_dir()?.join("tmux-state.lock"))
+}
+
+fn open_lock_file() -> Result<File> {
+    let dir = amaebi_dir()?;
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("creating directory {}", dir.display()))?;
+    let path = lock_path()?;
+    OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&path)
+        .with_context(|| format!("opening lock file {}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Raw (unlocked) state I/O
+// ---------------------------------------------------------------------------
+
+fn read_state_unlocked() -> Result<PaneState> {
+    let path = state_path()?;
+    if !path.exists() {
+        return Ok(PaneState::new());
+    }
+    let contents =
+        std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&contents).context("parsing tmux-state.json")
+}
+
+fn write_state_unlocked(state: &PaneState) -> Result<()> {
+    let path = state_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating directory {}", parent.display()))?;
+    }
+    let contents = serde_json::to_string_pretty(state)?;
+    std::fs::write(&path, contents).with_context(|| format!("writing {}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Read the current pane state (acquires a shared lock, read-only).
+///
+/// Used by `amaebi pane list` (P1) and for heartbeat monitoring.
+#[allow(dead_code)]
+pub fn read_state() -> Result<PaneState> {
+    let lock = open_lock_file()?;
+    lock.lock_shared()
+        .context("acquiring shared flock for read_state")?;
+    let state = read_state_unlocked()?;
+    lock.unlock().context("releasing flock after read_state")?;
+    Ok(state)
+}
+
+/// Acquire a lease on the **first available idle pane** for the given task.
+///
+/// Returns the `pane_id` of the acquired pane.  If `worktree` is provided it
+/// is checked against all currently Busy panes for uniqueness.
+pub fn acquire_first_idle(
+    task_id: &str,
+    session_id: &str,
+    worktree: Option<&str>,
+) -> Result<String> {
+    let lock = open_lock_file()?;
+    lock.lock_exclusive()
+        .context("acquiring flock for acquire_first_idle")?;
+
+    let result = acquire_first_idle_locked(task_id, session_id, worktree);
+
+    lock.unlock()
+        .context("releasing flock after acquire_first_idle")?;
+    result
+}
+
+fn acquire_first_idle_locked(
+    task_id: &str,
+    session_id: &str,
+    worktree: Option<&str>,
+) -> Result<String> {
+    let mut state = read_state_unlocked()?;
+
+    // Worktree uniqueness check.
+    if let Some(wt) = worktree {
+        for (pid, l) in &state {
+            if l.effective_status() == PaneStatus::Busy && l.worktree.as_deref() == Some(wt) {
+                anyhow::bail!(
+                    "worktree {} already held by task {:?} on pane {}",
+                    wt,
+                    l.task_id,
+                    pid
+                );
+            }
+        }
+    }
+
+    // Find first idle pane.
+    let pane_id = state
+        .values()
+        .find(|l| l.effective_status() == PaneStatus::Idle)
+        .map(|l| l.pane_id.clone())
+        .ok_or_else(|| anyhow::anyhow!("no idle panes available"))?;
+
+    let lease = state.get_mut(&pane_id).unwrap();
+    lease.status = PaneStatus::Busy;
+    lease.task_id = Some(task_id.to_string());
+    lease.session_id = Some(session_id.to_string());
+    lease.worktree = worktree.map(str::to_string);
+    lease.heartbeat_at = now_secs();
+
+    write_state_unlocked(&state)?;
+    Ok(pane_id)
+}
+
+/// Acquire a lease on a **specific pane** by ID.
+///
+/// Returns `Err` if the pane is already Busy (and not expired), or if the
+/// `worktree` conflicts with another Busy pane.
+#[allow(dead_code)]
+pub fn acquire_lease(
+    pane_id: &str,
+    task_id: &str,
+    session_id: &str,
+    worktree: Option<&str>,
+) -> Result<()> {
+    let lock = open_lock_file()?;
+    lock.lock_exclusive()
+        .context("acquiring flock for acquire_lease")?;
+
+    let result = (|| {
+        let mut state = read_state_unlocked()?;
+
+        let lease = state
+            .get(pane_id)
+            .ok_or_else(|| anyhow::anyhow!("pane {pane_id} not found in state"))?;
+
+        if lease.effective_status() == PaneStatus::Busy {
+            anyhow::bail!("pane {} is busy (task: {:?})", pane_id, lease.task_id);
+        }
+
+        // Worktree uniqueness check.
+        if let Some(wt) = worktree {
+            for (pid, l) in &state {
+                if pid != pane_id
+                    && l.effective_status() == PaneStatus::Busy
+                    && l.worktree.as_deref() == Some(wt)
+                {
+                    anyhow::bail!(
+                        "worktree {} already held by task {:?} on pane {}",
+                        wt,
+                        l.task_id,
+                        pid
+                    );
+                }
+            }
+        }
+
+        let lease = state.get_mut(pane_id).unwrap();
+        lease.status = PaneStatus::Busy;
+        lease.task_id = Some(task_id.to_string());
+        lease.session_id = Some(session_id.to_string());
+        lease.worktree = worktree.map(str::to_string);
+        lease.heartbeat_at = now_secs();
+
+        write_state_unlocked(&state)?;
+        Ok(())
+    })();
+
+    lock.unlock()
+        .context("releasing flock after acquire_lease")?;
+    result
+}
+
+/// Release the lease on a pane, marking it as Idle and clearing task metadata.
+#[allow(dead_code)]
+pub fn release_lease(pane_id: &str) -> Result<()> {
+    let lock = open_lock_file()?;
+    lock.lock_exclusive()
+        .context("acquiring flock for release_lease")?;
+
+    let result = (|| {
+        let mut state = read_state_unlocked()?;
+        if let Some(lease) = state.get_mut(pane_id) {
+            lease.status = PaneStatus::Idle;
+            lease.task_id = None;
+            lease.session_id = None;
+            lease.worktree = None;
+            lease.heartbeat_at = now_secs();
+        }
+        write_state_unlocked(&state)?;
+        Ok(())
+    })();
+
+    lock.unlock()
+        .context("releasing flock after release_lease")?;
+    result
+}
+
+/// Refresh the heartbeat timestamp for a Busy pane to prevent TTL expiry.
+#[allow(dead_code)]
+pub fn heartbeat(pane_id: &str) -> Result<()> {
+    let lock = open_lock_file()?;
+    lock.lock_exclusive()
+        .context("acquiring flock for heartbeat")?;
+
+    let result = (|| {
+        let mut state = read_state_unlocked()?;
+        if let Some(lease) = state.get_mut(pane_id) {
+            lease.heartbeat_at = now_secs();
+        }
+        write_state_unlocked(&state)?;
+        Ok(())
+    })();
+
+    lock.unlock().context("releasing flock after heartbeat")?;
+    result
+}
+
+/// Rename a tmux pane's title.
+///
+/// Uses `tmux select-pane -t <pane_id> -T <title>`.  Silently succeeds when
+/// tmux is not running (non-zero exit is returned as `Err` but callers may
+/// choose to ignore it).
+pub fn rename_pane(pane_id: &str, title: &str) -> Result<()> {
+    let output = std::process::Command::new("tmux")
+        .args(["select-pane", "-t", pane_id, "-T", title])
+        .output()
+        .context("spawning tmux select-pane")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("tmux select-pane -T failed: {stderr}");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Auto-expansion
+// ---------------------------------------------------------------------------
+
+/// Ensure at least `needed` Idle panes exist.
+///
+/// If the current number of Idle panes is insufficient, this function splits
+/// existing tmux windows to create new panes (up to [`MAX_PANES`] total).
+/// The entire operation runs inside a single `LOCK_EX`, so concurrent calls
+/// never create duplicate panes.
+///
+/// **Priority order for splitting:**
+/// 1. Windows that contain *no* Busy panes (least disruptive).
+/// 2. Any remaining window (contains at least one Busy pane).
+/// 3. If total + deficit would exceed `MAX_PANES` → `Err(CapacityError)`.
+///
+/// # Errors
+///
+/// - [`CapacityError`] (as a boxed `anyhow::Error`) when capacity would be
+///   exceeded.
+/// - `anyhow::Error` with `"not in a tmux session"` when `tmux list-windows`
+///   fails (no `$TMUX` set).
+/// - `anyhow::Error` with `"no tmux window available to split"` when all
+///   split attempts fail (extremely rare).
+pub fn ensure_idle_panes(needed: usize) -> Result<()> {
+    if needed == 0 {
+        return Ok(());
+    }
+
+    let lock = open_lock_file()?;
+    lock.lock_exclusive()
+        .context("acquiring flock for ensure_idle_panes")?;
+
+    let result = ensure_idle_panes_locked(needed);
+
+    lock.unlock()
+        .context("releasing flock after ensure_idle_panes")?;
+    result
+}
+
+fn ensure_idle_panes_locked(needed: usize) -> Result<()> {
+    let mut state = read_state_unlocked()?;
+
+    let idle_count = state
+        .values()
+        .filter(|l| l.effective_status() == PaneStatus::Idle)
+        .count();
+
+    if idle_count >= needed {
+        return Ok(());
+    }
+
+    let mut deficit = needed - idle_count;
+    let total = state.len();
+    let busy_count = state
+        .values()
+        .filter(|l| l.effective_status() == PaneStatus::Busy)
+        .count();
+
+    if total + deficit > MAX_PANES {
+        return Err(anyhow::Error::new(CapacityError {
+            requested: needed,
+            max_panes: MAX_PANES,
+            current_busy: busy_count,
+        }));
+    }
+
+    let all_windows = tmux_list_windows_sync().context("listing tmux windows")?;
+
+    if all_windows.is_empty() {
+        anyhow::bail!("not in a tmux session; /claude requires tmux");
+    }
+
+    // Window IDs that have at least one Busy pane (owned strings to avoid
+    // borrowing `state` while we mutate it below).
+    let busy_window_ids: std::collections::HashSet<String> = state
+        .values()
+        .filter(|l| l.effective_status() == PaneStatus::Busy)
+        .map(|l| l.window_id.clone())
+        .collect();
+
+    // Step 1: prefer windows with no Busy panes.
+    for win in all_windows.iter().filter(|w| !busy_window_ids.contains(*w)) {
+        if deficit == 0 || state.len() >= MAX_PANES {
+            break;
+        }
+        match tmux_split_window_sync(win) {
+            Ok(new_pane) => {
+                state.insert(new_pane.clone(), PaneLease::new_idle(new_pane, win.clone()));
+                deficit -= 1;
+            }
+            Err(e) => {
+                tracing::warn!(window = %win, error = %e, "failed to split tmux window");
+            }
+        }
+    }
+
+    // Step 2: fall back to windows with Busy panes.
+    if deficit > 0 {
+        for win in all_windows.iter().filter(|w| busy_window_ids.contains(*w)) {
+            if deficit == 0 || state.len() >= MAX_PANES {
+                break;
+            }
+            match tmux_split_window_sync(win) {
+                Ok(new_pane) => {
+                    state.insert(new_pane.clone(), PaneLease::new_idle(new_pane, win.clone()));
+                    deficit -= 1;
+                }
+                Err(e) => {
+                    tracing::warn!(window = %win, error = %e, "failed to split tmux window");
+                }
+            }
+        }
+    }
+
+    write_state_unlocked(&state)?;
+
+    if deficit > 0 {
+        anyhow::bail!(
+            "no tmux window available to split; \
+             create a new window with 'tmux new-window'"
+        );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Private tmux helpers (sync, safe to call inside spawn_blocking / flock)
+// ---------------------------------------------------------------------------
+
+/// Run `tmux list-windows -F "#{window_id}"` and return a list of window IDs.
+fn tmux_list_windows_sync() -> Result<Vec<String>> {
+    let output = std::process::Command::new("tmux")
+        .args(["list-windows", "-F", "#{window_id}"])
+        .output()
+        .context("spawning tmux list-windows")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("tmux list-windows failed: {stderr}");
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// Run `tmux split-window -t <window_id> -d -P -F "#{pane_id}"` and return
+/// the new pane's ID.
+fn tmux_split_window_sync(window_id: &str) -> Result<String> {
+    let output = std::process::Command::new("tmux")
+        .args([
+            "split-window",
+            "-t",
+            window_id,
+            "-d",
+            "-P",
+            "-F",
+            "#{pane_id}",
+        ])
+        .output()
+        .context("spawning tmux split-window")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("tmux split-window failed: {stderr}");
+    }
+    let pane_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if pane_id.is_empty() {
+        anyhow::bail!("tmux split-window produced no pane ID");
+    }
+    Ok(pane_id)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mutex to serialize tests that mutate the HOME env var.
+    static HOME_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn make_idle(pane_id: &str, window_id: &str) -> PaneLease {
+        PaneLease::new_idle(pane_id.to_string(), window_id.to_string())
+    }
+
+    fn make_busy(pane_id: &str, window_id: &str, worktree: Option<&str>) -> PaneLease {
+        PaneLease {
+            pane_id: pane_id.to_string(),
+            window_id: window_id.to_string(),
+            status: PaneStatus::Busy,
+            task_id: Some("task-1".to_string()),
+            session_id: Some("sess-1".to_string()),
+            worktree: worktree.map(str::to_string),
+            heartbeat_at: now_secs(),
+        }
+    }
+
+    // ── effective_status ──────────────────────────────────────────────────
+
+    #[test]
+    fn effective_status_idle_is_idle() {
+        let l = make_idle("%0", "@0");
+        assert_eq!(l.effective_status(), PaneStatus::Idle);
+    }
+
+    #[test]
+    fn effective_status_busy_fresh_is_busy() {
+        let l = make_busy("%0", "@0", None);
+        assert_eq!(l.effective_status(), PaneStatus::Busy);
+    }
+
+    #[test]
+    fn effective_status_busy_expired_becomes_idle() {
+        let mut l = make_busy("%0", "@0", None);
+        // Expire the heartbeat.
+        l.heartbeat_at = now_secs().saturating_sub(LEASE_TTL_SECS + 1);
+        assert_eq!(l.effective_status(), PaneStatus::Idle);
+    }
+
+    #[test]
+    fn effective_status_busy_at_boundary_still_busy() {
+        let mut l = make_busy("%0", "@0", None);
+        // Exactly at TTL boundary — should still be Busy.
+        l.heartbeat_at = now_secs().saturating_sub(LEASE_TTL_SECS);
+        assert_eq!(l.effective_status(), PaneStatus::Busy);
+    }
+
+    // ── serialization ─────────────────────────────────────────────────────
+
+    #[test]
+    fn pane_lease_round_trip() {
+        let l = make_busy("%3", "@2", Some("/home/user/repo-wt/task1"));
+        let json = serde_json::to_string(&l).expect("serialize");
+        let back: PaneLease = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.pane_id, "%3");
+        assert_eq!(back.window_id, "@2");
+        assert_eq!(back.worktree.as_deref(), Some("/home/user/repo-wt/task1"));
+        assert_eq!(back.status, PaneStatus::Busy);
+    }
+
+    #[test]
+    fn pane_state_round_trip() {
+        let mut state: PaneState = HashMap::new();
+        state.insert("%0".to_string(), make_idle("%0", "@0"));
+        state.insert("%1".to_string(), make_busy("%1", "@0", None));
+
+        let json = serde_json::to_string_pretty(&state).expect("serialize");
+        let back: PaneState = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.len(), 2);
+        assert_eq!(back["%0"].effective_status(), PaneStatus::Idle);
+        assert_eq!(back["%1"].effective_status(), PaneStatus::Busy);
+    }
+
+    // ── CapacityError display ─────────────────────────────────────────────
+
+    #[test]
+    fn capacity_error_display() {
+        let e = CapacityError {
+            requested: 3,
+            max_panes: 16,
+            current_busy: 14,
+        };
+        let s = e.to_string();
+        assert!(s.contains("max_panes=16"), "got: {s}");
+        assert!(s.contains("busy=14"), "got: {s}");
+        assert!(s.contains("requested=3"), "got: {s}");
+    }
+
+    // ── file-based state ops (use tempdir via HOME override) ───────────────
+
+    // Helper: redirect HOME to a tempdir, run f(), restore HOME.
+    fn with_temp_home<F, R>(f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        // Recover from a poisoned mutex (a previous test panicked while holding
+        // it) so remaining tests can still run.
+        let _guard = HOME_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let orig = std::env::var("HOME").ok();
+        // Safety: we hold the HOME_MUTEX so no other test can mutate HOME.
+        unsafe { std::env::set_var("HOME", dir.path()) };
+        let result = f();
+        match orig {
+            Some(h) => unsafe { std::env::set_var("HOME", &h) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        result
+    }
+
+    #[test]
+    fn acquire_lease_on_idle_pane_succeeds() {
+        with_temp_home(|| {
+            // Seed one idle pane directly.
+            let mut state: PaneState = HashMap::new();
+            state.insert("%0".to_string(), make_idle("%0", "@0"));
+            write_state_unlocked(&state).expect("seed state");
+
+            acquire_lease("%0", "task-x", "sess-x", None).expect("acquire");
+
+            let s = read_state_unlocked().expect("read back");
+            assert_eq!(s["%0"].effective_status(), PaneStatus::Busy);
+            assert_eq!(s["%0"].task_id.as_deref(), Some("task-x"));
+        });
+    }
+
+    #[test]
+    fn acquire_lease_on_busy_pane_returns_err() {
+        with_temp_home(|| {
+            let mut state: PaneState = HashMap::new();
+            state.insert("%0".to_string(), make_busy("%0", "@0", None));
+            write_state_unlocked(&state).expect("seed state");
+
+            let err = acquire_lease("%0", "task-y", "sess-y", None);
+            assert!(err.is_err(), "expected Err for busy pane");
+        });
+    }
+
+    #[test]
+    fn acquire_lease_on_expired_busy_pane_succeeds() {
+        with_temp_home(|| {
+            let mut expired = make_busy("%0", "@0", None);
+            expired.heartbeat_at = now_secs().saturating_sub(LEASE_TTL_SECS + 1);
+            let mut state: PaneState = HashMap::new();
+            state.insert("%0".to_string(), expired);
+            write_state_unlocked(&state).expect("seed state");
+
+            acquire_lease("%0", "task-new", "sess-new", None).expect("should succeed after expiry");
+
+            let s = read_state_unlocked().expect("read back");
+            assert_eq!(s["%0"].task_id.as_deref(), Some("task-new"));
+        });
+    }
+
+    #[test]
+    fn acquire_first_idle_finds_idle_pane() {
+        with_temp_home(|| {
+            let mut state: PaneState = HashMap::new();
+            state.insert("%0".to_string(), make_busy("%0", "@0", None));
+            state.insert("%1".to_string(), make_idle("%1", "@0"));
+            write_state_unlocked(&state).expect("seed state");
+
+            let pane = acquire_first_idle("t", "s", None).expect("acquire first idle");
+            assert_eq!(pane, "%1");
+        });
+    }
+
+    #[test]
+    fn acquire_first_idle_rejects_duplicate_worktree() {
+        with_temp_home(|| {
+            let mut state: PaneState = HashMap::new();
+            state.insert(
+                "%0".to_string(),
+                make_busy("%0", "@0", Some("/repo/wt/task1")),
+            );
+            state.insert("%1".to_string(), make_idle("%1", "@0"));
+            write_state_unlocked(&state).expect("seed state");
+
+            let err = acquire_first_idle("t2", "s2", Some("/repo/wt/task1"));
+            assert!(err.is_err(), "expected Err for duplicate worktree");
+        });
+    }
+
+    #[test]
+    fn release_lease_marks_pane_idle() {
+        with_temp_home(|| {
+            let mut state: PaneState = HashMap::new();
+            state.insert("%0".to_string(), make_busy("%0", "@0", None));
+            write_state_unlocked(&state).expect("seed state");
+
+            release_lease("%0").expect("release");
+
+            let s = read_state_unlocked().expect("read back");
+            assert_eq!(s["%0"].effective_status(), PaneStatus::Idle);
+            assert!(s["%0"].task_id.is_none());
+        });
+    }
+
+    #[test]
+    fn heartbeat_updates_timestamp() {
+        with_temp_home(|| {
+            let mut lease = make_busy("%0", "@0", None);
+            // Set an old heartbeat.
+            lease.heartbeat_at = 1000;
+            let mut state: PaneState = HashMap::new();
+            state.insert("%0".to_string(), lease);
+            write_state_unlocked(&state).expect("seed state");
+
+            heartbeat("%0").expect("heartbeat");
+
+            let s = read_state_unlocked().expect("read back");
+            assert!(
+                s["%0"].heartbeat_at > 1000,
+                "heartbeat should have been updated"
+            );
+        });
+    }
+
+    #[test]
+    fn ensure_idle_panes_capacity_exceeded_returns_err() {
+        with_temp_home(|| {
+            // Fill all MAX_PANES slots with Busy leases.
+            let mut state: PaneState = HashMap::new();
+            for i in 0..MAX_PANES {
+                let pid = format!("%{i}");
+                state.insert(pid.clone(), make_busy(&pid, "@0", None));
+            }
+            write_state_unlocked(&state).expect("seed state");
+
+            // Acquiring the lock before calling the internal helper so we can
+            // test the logic without real tmux.
+            let lock = open_lock_file().expect("open lock");
+            lock.lock_exclusive().expect("flock");
+            let result = ensure_idle_panes_locked(1);
+            lock.unlock().expect("unlock");
+
+            let err = result.expect_err("should be Err");
+            let cap = err.downcast_ref::<CapacityError>().expect("CapacityError");
+            assert_eq!(cap.max_panes, MAX_PANES);
+            assert_eq!(cap.requested, 1);
+        });
+    }
+
+    #[test]
+    fn ensure_idle_panes_noop_when_enough_idle() {
+        with_temp_home(|| {
+            let mut state: PaneState = HashMap::new();
+            state.insert("%0".to_string(), make_idle("%0", "@0"));
+            state.insert("%1".to_string(), make_idle("%1", "@0"));
+            write_state_unlocked(&state).expect("seed state");
+
+            let lock = open_lock_file().expect("open lock");
+            lock.lock_exclusive().expect("flock");
+            // 2 idle panes, need 2 → no-op, no tmux calls.
+            let result = ensure_idle_panes_locked(2);
+            lock.unlock().expect("unlock");
+
+            result.expect("should succeed without calling tmux");
+        });
+    }
+}

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -27,6 +27,9 @@ use std::fs::{File, OpenOptions};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
 use anyhow::{Context, Result};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
@@ -151,11 +154,11 @@ fn open_lock_file() -> Result<File> {
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("creating directory {}", dir.display()))?;
     let path = lock_path()?;
-    OpenOptions::new()
-        .create(true)
-        .truncate(false)
-        .write(true)
-        .open(&path)
+    let mut opts = OpenOptions::new();
+    opts.create(true).truncate(false).write(true);
+    #[cfg(unix)]
+    opts.mode(0o600);
+    opts.open(&path)
         .with_context(|| format!("opening lock file {}", path.display()))
 }
 
@@ -170,7 +173,13 @@ fn read_state_unlocked() -> Result<PaneState> {
     }
     let contents =
         std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
-    serde_json::from_str(&contents).context("parsing tmux-state.json")
+    if contents.trim().is_empty() {
+        return Ok(PaneState::new());
+    }
+    // Tolerate corrupt JSON: reset to empty state rather than hard-erroring.
+    // A corrupt file is treated the same as a missing one — the panes will
+    // be re-discovered on the next `ensure_idle_panes` call.
+    Ok(serde_json::from_str(&contents).unwrap_or_default())
 }
 
 fn write_state_unlocked(state: &PaneState) -> Result<()> {
@@ -180,7 +189,14 @@ fn write_state_unlocked(state: &PaneState) -> Result<()> {
             .with_context(|| format!("creating directory {}", parent.display()))?;
     }
     let contents = serde_json::to_string_pretty(state)?;
-    std::fs::write(&path, contents).with_context(|| format!("writing {}", path.display()))
+
+    // Atomic write: write to a temp file then rename so readers never see a
+    // partially-written file.
+    let tmp_path = path.with_extension("tmp");
+    std::fs::write(&tmp_path, &contents)
+        .with_context(|| format!("writing tmp {}", tmp_path.display()))?;
+    std::fs::rename(&tmp_path, &path)
+        .with_context(|| format!("renaming {} → {}", tmp_path.display(), path.display()))
 }
 
 // ---------------------------------------------------------------------------
@@ -204,6 +220,7 @@ pub fn read_state() -> Result<PaneState> {
 ///
 /// Returns the `pane_id` of the acquired pane.  If `worktree` is provided it
 /// is checked against all currently Busy panes for uniqueness.
+#[allow(dead_code)]
 pub fn acquire_first_idle(
     task_id: &str,
     session_id: &str,
@@ -365,9 +382,9 @@ pub fn heartbeat(pane_id: &str) -> Result<()> {
 
 /// Rename a tmux pane's title.
 ///
-/// Uses `tmux select-pane -t <pane_id> -T <title>`.  Silently succeeds when
-/// tmux is not running (non-zero exit is returned as `Err` but callers may
-/// choose to ignore it).
+/// Uses `tmux select-pane -t <pane_id> -T <title>`.  Returns `Err` when tmux
+/// is not running or returns a non-zero exit code.  Callers may choose to
+/// ignore the error in non-tmux environments.
 pub fn rename_pane(pane_id: &str, title: &str) -> Result<()> {
     let output = std::process::Command::new("tmux")
         .args(["select-pane", "-t", pane_id, "-T", title])
@@ -385,6 +402,9 @@ pub fn rename_pane(pane_id: &str, title: &str) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 /// Ensure at least `needed` Idle panes exist.
+///
+/// Prefer [`ensure_and_acquire_idle`] for single-request use to avoid a
+/// TOCTOU race.  This function is retained for bulk pre-warming use cases.
 ///
 /// If the current number of Idle panes is insufficient, this function splits
 /// existing tmux windows to create new panes (up to [`MAX_PANES`] total).
@@ -404,6 +424,7 @@ pub fn rename_pane(pane_id: &str, title: &str) -> Result<()> {
 ///   fails (no `$TMUX` set).
 /// - `anyhow::Error` with `"no tmux window available to split"` when all
 ///   split attempts fail (extremely rare).
+#[allow(dead_code)]
 pub fn ensure_idle_panes(needed: usize) -> Result<()> {
     if needed == 0 {
         return Ok(());
@@ -505,6 +526,32 @@ fn ensure_idle_panes_locked(needed: usize) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Atomically ensure at least `needed` Idle panes exist **and** acquire the
+/// first idle pane for the given task — all within a single `LOCK_EX`.
+///
+/// This eliminates the TOCTOU race between `ensure_idle_panes` and
+/// `acquire_first_idle` when multiple `ClaudeLaunch` requests arrive
+/// concurrently.
+pub fn ensure_and_acquire_idle(
+    task_id: &str,
+    session_id: &str,
+    worktree: Option<&str>,
+) -> Result<String> {
+    let lock = open_lock_file()?;
+    lock.lock_exclusive()
+        .context("acquiring flock for ensure_and_acquire_idle")?;
+
+    // Ensure at least 1 idle pane exists (expand if necessary).
+    ensure_idle_panes_locked(1)?;
+
+    // Acquire the first idle pane.
+    let pane_id = acquire_first_idle_locked(task_id, session_id, worktree)?;
+
+    lock.unlock()
+        .context("releasing flock after ensure_and_acquire_idle")?;
+    Ok(pane_id)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -34,6 +34,8 @@ use anyhow::{Context, Result};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
+use crate::auth::amaebi_home;
+
 /// Maximum total number of panes (Idle + Busy) that the daemon will manage.
 pub const MAX_PANES: usize = 16;
 
@@ -145,23 +147,16 @@ fn now_secs() -> u64 {
         .as_secs()
 }
 
-fn amaebi_dir() -> Result<PathBuf> {
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .context("HOME environment variable not set")?;
-    Ok(PathBuf::from(home).join(".amaebi"))
-}
-
 fn state_path() -> Result<PathBuf> {
-    Ok(amaebi_dir()?.join("tmux-state.json"))
+    Ok(amaebi_home()?.join("tmux-state.json"))
 }
 
 fn lock_path() -> Result<PathBuf> {
-    Ok(amaebi_dir()?.join("tmux-state.lock"))
+    Ok(amaebi_home()?.join("tmux-state.lock"))
 }
 
 fn open_lock_file() -> Result<File> {
-    let dir = amaebi_dir()?;
+    let dir = amaebi_home()?;
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("creating directory {}", dir.display()))?;
     let path = lock_path()?;
@@ -211,7 +206,8 @@ fn write_state_unlocked(state: &PaneState) -> Result<()> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600));
+        std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("setting 0o600 permissions on {}", tmp_path.display()))?;
     }
     std::fs::rename(&tmp_path, &path)
         .with_context(|| format!("renaming {} → {}", tmp_path.display(), path.display()))

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -400,7 +400,12 @@ pub fn release_lease(pane_id: &str) -> Result<()> {
             lease.status = PaneStatus::Idle;
             lease.task_id = None;
             lease.session_id = None;
-            lease.worktree = None;
+            // Intentionally keep `worktree` and `has_claude`: the pane still
+            // has `claude` running in the same directory.  Preserving these
+            // fields allows the scheduler to reuse the pane for a future task
+            // in the same worktree (tier-1: /compact + inject) without a
+            // full relaunch.  They are only cleared when the pane is destroyed
+            // or explicitly reset to a blank shell.
             lease.heartbeat_at = now_secs();
         }
         write_state_unlocked(&state)?;
@@ -1019,6 +1024,30 @@ mod tests {
             let s = read_state_unlocked().expect("read back");
             assert_eq!(s["%0"].effective_status(), PaneStatus::Idle);
             assert!(s["%0"].task_id.is_none());
+        });
+    }
+
+    #[test]
+    fn release_lease_preserves_worktree_and_has_claude() {
+        // worktree and has_claude must survive release so the scheduler can
+        // reuse the pane for a future task in the same worktree (tier-1 reuse).
+        with_temp_home(|| {
+            let mut lease = make_busy("%0", "@0", Some("/repo/wt/task1"));
+            lease.has_claude = true;
+            let mut state: PaneState = HashMap::new();
+            state.insert("%0".to_string(), lease);
+            write_state_unlocked(&state).expect("seed state");
+
+            release_lease("%0").expect("release");
+
+            let s = read_state_unlocked().expect("read back");
+            assert_eq!(s["%0"].effective_status(), PaneStatus::Idle);
+            assert_eq!(
+                s["%0"].worktree.as_deref(),
+                Some("/repo/wt/task1"),
+                "worktree must be preserved so tier-1 reuse can match it"
+            );
+            assert!(s["%0"].has_claude, "has_claude must be preserved");
         });
     }
 

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -597,9 +597,33 @@ pub fn ensure_and_acquire_idle(
         .context("acquiring flock for ensure_and_acquire_idle")?;
 
     let result = (|| {
-        // Ensure at least 1 idle pane exists (expand if necessary).
-        ensure_idle_panes_locked(1)?;
-        // Acquire the first idle pane, preferring ones with Claude already running.
+        // Count panes that can actually serve this request:
+        //   - blank panes (has_claude = false): always usable
+        //   - same-worktree claude panes: reusable via /compact + inject
+        // Panes with claude running in a *different* worktree are skipped by
+        // acquire_first_idle_locked, so they must not count as available here.
+        // If none are available, expand the pool with a new blank pane.
+        let state = read_state_unlocked()?;
+        let available = state
+            .values()
+            .filter(|l| {
+                l.effective_status() == PaneStatus::Idle
+                    && (!l.has_claude || l.worktree.as_deref() == worktree)
+            })
+            .count();
+        if available == 0 {
+            // No usable idle pane exists (all idle panes have claude running in
+            // a different worktree and cannot receive shell commands).  Force
+            // ensure_idle_panes_locked to create a new blank pane by requesting
+            // one more than the current total idle count — it would otherwise
+            // see the existing (unusable) idle panes and skip expansion.
+            let total_idle = state
+                .values()
+                .filter(|l| l.effective_status() == PaneStatus::Idle)
+                .count();
+            ensure_idle_panes_locked(total_idle + 1)?;
+        }
+        // Acquire the first usable idle pane.
         acquire_first_idle_locked(task_id, session_id, worktree)
     })();
 
@@ -942,6 +966,40 @@ mod tests {
                 "must skip has_claude pane with different worktree"
             );
             assert!(!had_claude, "had_claude must be false for blank pane");
+        });
+    }
+
+    #[test]
+    fn ensure_and_acquire_expands_when_only_mismatched_claude_panes_exist() {
+        // All idle panes have claude running in a different worktree — none
+        // are usable for a fresh task.  ensure_and_acquire_idle must attempt
+        // expansion rather than returning "no idle panes available" immediately.
+        with_temp_home(|| {
+            let mut state: PaneState = HashMap::new();
+            let mut pane = make_idle("%0", "@0");
+            pane.has_claude = true;
+            pane.worktree = Some("/repo/wt/other".to_string());
+            state.insert("%0".to_string(), pane);
+            write_state_unlocked(&state).expect("seed state");
+
+            match ensure_and_acquire_idle("t", "s", Some("/repo/wt/task1")) {
+                Ok((pane_id, had_claude)) => {
+                    // tmux is available: expansion succeeded, must have
+                    // acquired a new blank pane (not the mismatched %0).
+                    assert_ne!(pane_id, "%0", "must not acquire mismatched claude pane");
+                    assert!(!had_claude, "new pane must not have had_claude");
+                }
+                Err(e) => {
+                    // No tmux session: expansion was attempted but failed.
+                    // The error must be a tmux failure, NOT "no idle panes
+                    // available" (which would mean we gave up before trying).
+                    let msg = format!("{e:#}");
+                    assert!(
+                        !msg.contains("no idle panes available"),
+                        "should attempt expansion, not short-circuit: {msg}"
+                    );
+                }
+            }
         });
     }
 

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -284,10 +284,15 @@ fn acquire_first_idle_locked(
         }
     }
 
-    // Prefer idle panes that already have `claude` running *in the same
-    // worktree* — those can absorb a new task via direct prompt injection.
-    // A pane running `claude` in a different (or no) worktree cannot be
-    // reused this way; fall back to any idle pane and launch a fresh session.
+    // Priority order for pane selection:
+    //
+    // 1. Idle pane with `claude` running in the *same* worktree → safe to
+    //    inject a prompt directly (after /compact).
+    // 2. Idle pane with no `claude` running (blank shell) → fresh launch.
+    // 3. Idle pane with `claude` running in a *different* worktree → skip.
+    //    Sending shell commands to a pane where claude is already intercepting
+    //    input would deliver them as chat messages, not shell commands.  Leave
+    //    those panes alone and let auto-expansion create a new blank one.
     let pane_id = state
         .values()
         .find(|l| {
@@ -298,7 +303,7 @@ fn acquire_first_idle_locked(
         .or_else(|| {
             state
                 .values()
-                .find(|l| l.effective_status() == PaneStatus::Idle)
+                .find(|l| l.effective_status() == PaneStatus::Idle && !l.has_claude)
         })
         .map(|l| l.pane_id.clone())
         .ok_or_else(|| anyhow::anyhow!("no idle panes available"))?;
@@ -929,13 +934,14 @@ mod tests {
 
             let (pane, had_claude) =
                 acquire_first_idle("t", "s", Some("/repo/wt/task1")).expect("acquire");
-            // Any idle pane is acceptable; the important thing is `had_claude` is false
-            // (i.e. we did not reuse the mismatched pane as a direct-inject target).
-            let _ = pane;
-            assert!(
-                !had_claude,
-                "had_claude must be false when worktree does not match"
+            // Must select the blank pane (%1), not the mismatched claude pane (%0).
+            // Sending shell commands to a pane where claude is running in a different
+            // worktree would deliver them as chat messages, not shell commands.
+            assert_eq!(
+                pane, "%1",
+                "must skip has_claude pane with different worktree"
             );
+            assert!(!had_claude, "had_claude must be false for blank pane");
         });
     }
 

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -293,22 +293,26 @@ fn acquire_first_idle_locked(
     //    Sending shell commands to a pane where claude is already intercepting
     //    input would deliver them as chat messages, not shell commands.  Leave
     //    those panes alone and let auto-expansion create a new blank one.
+    // Use state.iter() so the HashMap key is carried through the selection,
+    // avoiding a second get_mut lookup (and the unwrap it would require).
     let pane_id = state
-        .values()
-        .find(|l| {
+        .iter()
+        .find(|(_, l)| {
             l.effective_status() == PaneStatus::Idle
                 && l.has_claude
                 && l.worktree.as_deref() == worktree
         })
         .or_else(|| {
             state
-                .values()
-                .find(|l| l.effective_status() == PaneStatus::Idle && !l.has_claude)
+                .iter()
+                .find(|(_, l)| l.effective_status() == PaneStatus::Idle && !l.has_claude)
         })
-        .map(|l| l.pane_id.clone())
+        .map(|(k, _)| k.clone())
         .ok_or_else(|| anyhow::anyhow!("no idle panes available"))?;
 
-    let lease = state.get_mut(&pane_id).unwrap();
+    let lease = state
+        .get_mut(&pane_id)
+        .ok_or_else(|| anyhow::anyhow!("pane {pane_id} disappeared after selection"))?;
     // `had_claude` is only true when the pane's stored worktree matches the
     // requested one — only then can we safely inject a prompt directly into
     // the running claude session.  A pane with claude in a *different* worktree

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -284,10 +284,17 @@ fn acquire_first_idle_locked(
         }
     }
 
-    // Prefer idle panes that already have `amaebi chat` running.
+    // Prefer idle panes that already have `claude` running *in the same
+    // worktree* — those can absorb a new task via direct prompt injection.
+    // A pane running `claude` in a different (or no) worktree cannot be
+    // reused this way; fall back to any idle pane and launch a fresh session.
     let pane_id = state
         .values()
-        .find(|l| l.effective_status() == PaneStatus::Idle && l.has_claude)
+        .find(|l| {
+            l.effective_status() == PaneStatus::Idle
+                && l.has_claude
+                && l.worktree.as_deref() == worktree
+        })
         .or_else(|| {
             state
                 .values()
@@ -297,7 +304,11 @@ fn acquire_first_idle_locked(
         .ok_or_else(|| anyhow::anyhow!("no idle panes available"))?;
 
     let lease = state.get_mut(&pane_id).unwrap();
-    let had_claude = lease.has_claude;
+    // `had_claude` is only true when the pane's stored worktree matches the
+    // requested one — only then can we safely inject a prompt directly into
+    // the running claude session.  A pane with claude in a *different* worktree
+    // must be treated as blank (triggers a fresh `cd <wt> && claude` launch).
+    let had_claude = lease.has_claude && lease.worktree.as_deref() == worktree;
     lease.status = PaneStatus::Busy;
     lease.task_id = Some(task_id.to_string());
     lease.session_id = Some(session_id.to_string());
@@ -878,6 +889,53 @@ mod tests {
 
             let err = acquire_first_idle("t2", "s2", Some("/repo/wt/task1"));
             assert!(err.is_err(), "expected Err for duplicate worktree");
+        });
+    }
+
+    #[test]
+    fn acquire_first_idle_prefers_has_claude_pane_with_matching_worktree() {
+        with_temp_home(|| {
+            let mut state: PaneState = HashMap::new();
+            // Pane with claude already running in the target worktree — should be preferred.
+            let mut has_claude_matching = make_idle("%0", "@0");
+            has_claude_matching.has_claude = true;
+            has_claude_matching.worktree = Some("/repo/wt/task1".to_string());
+            // Plain idle pane (no claude).
+            let blank = make_idle("%1", "@0");
+            state.insert("%0".to_string(), has_claude_matching);
+            state.insert("%1".to_string(), blank);
+            write_state_unlocked(&state).expect("seed state");
+
+            let (pane, had_claude) =
+                acquire_first_idle("t", "s", Some("/repo/wt/task1")).expect("acquire");
+            assert_eq!(pane, "%0", "should prefer matching has_claude pane");
+            assert!(had_claude, "had_claude should be true for reused pane");
+        });
+    }
+
+    #[test]
+    fn acquire_first_idle_skips_has_claude_pane_with_different_worktree() {
+        with_temp_home(|| {
+            let mut state: PaneState = HashMap::new();
+            // Pane with claude in a *different* worktree — must not be preferred.
+            let mut has_claude_other = make_idle("%0", "@0");
+            has_claude_other.has_claude = true;
+            has_claude_other.worktree = Some("/repo/wt/other".to_string());
+            // Plain idle pane (no claude, no worktree).
+            let blank = make_idle("%1", "@0");
+            state.insert("%0".to_string(), has_claude_other);
+            state.insert("%1".to_string(), blank);
+            write_state_unlocked(&state).expect("seed state");
+
+            let (pane, had_claude) =
+                acquire_first_idle("t", "s", Some("/repo/wt/task1")).expect("acquire");
+            // Any idle pane is acceptable; the important thing is `had_claude` is false
+            // (i.e. we did not reuse the mismatched pane as a direct-inject target).
+            let _ = pane;
+            assert!(
+                !had_claude,
+                "had_claude must be false when worktree does not match"
+            );
         });
     }
 

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -67,7 +67,7 @@ pub struct PaneLease {
     pub worktree: Option<String>,
     /// Unix timestamp of the last heartbeat (or acquisition time).
     pub heartbeat_at: u64,
-    /// Whether `amaebi chat` has been started in this pane.  Idle panes with
+    /// Whether `claude` has been started in this pane.  Idle panes with
     /// `has_claude = true` are preferred over blank panes when assigning tasks:
     /// the scheduler injects just the prompt rather than launching a new session.
     #[serde(default)]
@@ -245,9 +245,9 @@ pub fn acquire_first_idle(
 }
 
 /// Returns `(pane_id, had_claude)` where `had_claude` indicates whether
-/// `amaebi chat` was already running in the pane.  Callers use this to decide
+/// `claude` was already running in the pane.  Callers use this to decide
 /// whether to inject only the prompt (`had_claude = true`) or to launch a
-/// fresh `amaebi chat <description>` (`had_claude = false`).
+/// fresh `claude` session (`had_claude = false`).
 ///
 /// Priority: idle panes with `has_claude = true` are preferred so that
 /// existing Claude sessions absorb new tasks before blank panes are used.
@@ -552,9 +552,9 @@ fn ensure_idle_panes_locked(needed: usize) -> Result<()> {
 /// the given task — all within a single `LOCK_EX`.
 ///
 /// Returns `(pane_id, had_claude)`.  `had_claude = true` means the pane
-/// already had `amaebi chat` running; the caller should inject just the
+/// already had `claude` running; the caller should inject just the
 /// prompt.  `had_claude = false` means the pane is blank; the caller should
-/// launch `amaebi chat <description>`.
+/// launch `claude`.
 ///
 /// This eliminates the TOCTOU race between `ensure_idle_panes` and
 /// `acquire_first_idle` when multiple `ClaudeLaunch` requests arrive
@@ -580,9 +580,9 @@ pub fn ensure_and_acquire_idle(
     result
 }
 
-/// Mark a pane as having an active `amaebi chat` session.
+/// Mark a pane as having an active `claude` session.
 ///
-/// Called after successfully injecting `amaebi chat` into a blank pane so
+/// Called after successfully launching `claude` into a blank pane so
 /// that future task assignments can inject prompts directly instead of
 /// launching a new session.
 pub fn mark_claude_started(pane_id: &str) -> Result<()> {

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -67,6 +67,11 @@ pub struct PaneLease {
     pub worktree: Option<String>,
     /// Unix timestamp of the last heartbeat (or acquisition time).
     pub heartbeat_at: u64,
+    /// Whether `amaebi chat` has been started in this pane.  Idle panes with
+    /// `has_claude = true` are preferred over blank panes when assigning tasks:
+    /// the scheduler injects just the prompt rather than launching a new session.
+    #[serde(default)]
+    pub has_claude: bool,
 }
 
 impl PaneLease {
@@ -79,6 +84,7 @@ impl PaneLease {
             session_id: None,
             worktree: None,
             heartbeat_at: now_secs(),
+            has_claude: false,
         }
     }
 
@@ -218,14 +224,15 @@ pub fn read_state() -> Result<PaneState> {
 
 /// Acquire a lease on the **first available idle pane** for the given task.
 ///
-/// Returns the `pane_id` of the acquired pane.  If `worktree` is provided it
-/// is checked against all currently Busy panes for uniqueness.
+/// Returns `(pane_id, had_claude)`.  If `worktree` is provided it is checked
+/// against all currently Busy panes for uniqueness.  Prefer
+/// [`ensure_and_acquire_idle`] for production use to avoid TOCTOU races.
 #[allow(dead_code)]
 pub fn acquire_first_idle(
     task_id: &str,
     session_id: &str,
     worktree: Option<&str>,
-) -> Result<String> {
+) -> Result<(String, bool)> {
     let lock = open_lock_file()?;
     lock.lock_exclusive()
         .context("acquiring flock for acquire_first_idle")?;
@@ -237,11 +244,18 @@ pub fn acquire_first_idle(
     result
 }
 
+/// Returns `(pane_id, had_claude)` where `had_claude` indicates whether
+/// `amaebi chat` was already running in the pane.  Callers use this to decide
+/// whether to inject only the prompt (`had_claude = true`) or to launch a
+/// fresh `amaebi chat <description>` (`had_claude = false`).
+///
+/// Priority: idle panes with `has_claude = true` are preferred so that
+/// existing Claude sessions absorb new tasks before blank panes are used.
 fn acquire_first_idle_locked(
     task_id: &str,
     session_id: &str,
     worktree: Option<&str>,
-) -> Result<String> {
+) -> Result<(String, bool)> {
     let mut state = read_state_unlocked()?;
 
     // Worktree uniqueness check.
@@ -258,14 +272,20 @@ fn acquire_first_idle_locked(
         }
     }
 
-    // Find first idle pane.
+    // Prefer idle panes that already have `amaebi chat` running.
     let pane_id = state
         .values()
-        .find(|l| l.effective_status() == PaneStatus::Idle)
+        .find(|l| l.effective_status() == PaneStatus::Idle && l.has_claude)
+        .or_else(|| {
+            state
+                .values()
+                .find(|l| l.effective_status() == PaneStatus::Idle)
+        })
         .map(|l| l.pane_id.clone())
         .ok_or_else(|| anyhow::anyhow!("no idle panes available"))?;
 
     let lease = state.get_mut(&pane_id).unwrap();
+    let had_claude = lease.has_claude;
     lease.status = PaneStatus::Busy;
     lease.task_id = Some(task_id.to_string());
     lease.session_id = Some(session_id.to_string());
@@ -273,7 +293,7 @@ fn acquire_first_idle_locked(
     lease.heartbeat_at = now_secs();
 
     write_state_unlocked(&state)?;
-    Ok(pane_id)
+    Ok((pane_id, had_claude))
 }
 
 /// Acquire a lease on a **specific pane** by ID.
@@ -528,8 +548,13 @@ fn ensure_idle_panes_locked(needed: usize) -> Result<()> {
     Ok(())
 }
 
-/// Atomically ensure at least `needed` Idle panes exist **and** acquire the
-/// first idle pane for the given task — all within a single `LOCK_EX`.
+/// Atomically ensure at least one idle pane exists **and** acquire it for
+/// the given task — all within a single `LOCK_EX`.
+///
+/// Returns `(pane_id, had_claude)`.  `had_claude = true` means the pane
+/// already had `amaebi chat` running; the caller should inject just the
+/// prompt.  `had_claude = false` means the pane is blank; the caller should
+/// launch `amaebi chat <description>`.
 ///
 /// This eliminates the TOCTOU race between `ensure_idle_panes` and
 /// `acquire_first_idle` when multiple `ClaudeLaunch` requests arrive
@@ -538,7 +563,7 @@ pub fn ensure_and_acquire_idle(
     task_id: &str,
     session_id: &str,
     worktree: Option<&str>,
-) -> Result<String> {
+) -> Result<(String, bool)> {
     let lock = open_lock_file()?;
     lock.lock_exclusive()
         .context("acquiring flock for ensure_and_acquire_idle")?;
@@ -546,12 +571,35 @@ pub fn ensure_and_acquire_idle(
     let result = (|| {
         // Ensure at least 1 idle pane exists (expand if necessary).
         ensure_idle_panes_locked(1)?;
-        // Acquire the first idle pane.
+        // Acquire the first idle pane, preferring ones with Claude already running.
         acquire_first_idle_locked(task_id, session_id, worktree)
     })();
 
     lock.unlock()
         .context("releasing flock after ensure_and_acquire_idle")?;
+    result
+}
+
+/// Mark a pane as having an active `amaebi chat` session.
+///
+/// Called after successfully injecting `amaebi chat` into a blank pane so
+/// that future task assignments can inject prompts directly instead of
+/// launching a new session.
+pub fn mark_claude_started(pane_id: &str) -> Result<()> {
+    let lock = open_lock_file()?;
+    lock.lock_exclusive()
+        .context("acquiring flock for mark_claude_started")?;
+
+    let result = (|| {
+        let mut state = read_state_unlocked()?;
+        if let Some(lease) = state.get_mut(pane_id) {
+            lease.has_claude = true;
+        }
+        write_state_unlocked(&state)
+    })();
+
+    lock.unlock()
+        .context("releasing flock after mark_claude_started")?;
     result
 }
 
@@ -626,6 +674,7 @@ mod tests {
             session_id: Some("sess-1".to_string()),
             worktree: worktree.map(str::to_string),
             heartbeat_at: now_secs(),
+            has_claude: false,
         }
     }
 
@@ -774,7 +823,8 @@ mod tests {
             state.insert("%1".to_string(), make_idle("%1", "@0"));
             write_state_unlocked(&state).expect("seed state");
 
-            let pane = acquire_first_idle("t", "s", None).expect("acquire first idle");
+            let (pane, _had_claude) =
+                acquire_first_idle("t", "s", None).expect("acquire first idle");
             assert_eq!(pane, "%1");
         });
     }

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -994,6 +994,13 @@ mod tests {
         // worktree=None, None==None must NOT suppress expansion.
         // acquire_first_idle_locked requires worktree.is_some() for tier-1
         // reuse, so that pane is not selectable — expansion must be attempted.
+        //
+        // Skip inside a live tmux session: ensure_and_acquire_idle calls
+        // tmux split-window when expanding, which would create real panes.
+        if std::env::var("TMUX").is_ok() {
+            eprintln!("skipping: live tmux session detected (run via scripts/test.sh --docker)");
+            return;
+        }
         {
             let _guard = crate::test_utils::with_temp_home();
             let mut state: PaneState = HashMap::new();
@@ -1026,6 +1033,13 @@ mod tests {
         // All idle panes have claude running in a different worktree — none
         // are usable for a fresh task.  ensure_and_acquire_idle must attempt
         // expansion rather than returning "no idle panes available" immediately.
+        //
+        // Skip inside a live tmux session: ensure_and_acquire_idle calls
+        // tmux split-window when expanding, which would create real panes.
+        if std::env::var("TMUX").is_ok() {
+            eprintln!("skipping: live tmux session detected (run via scripts/test.sh --docker)");
+            return;
+        }
         {
             let _guard = crate::test_utils::with_temp_home();
             let mut state: PaneState = HashMap::new();
@@ -1037,15 +1051,10 @@ mod tests {
 
             match ensure_and_acquire_idle("t", "s", Some("/repo/wt/task1")) {
                 Ok((pane_id, had_claude)) => {
-                    // tmux is available: expansion succeeded, must have
-                    // acquired a new blank pane (not the mismatched %0).
                     assert_ne!(pane_id, "%0", "must not acquire mismatched claude pane");
                     assert!(!had_claude, "new pane must not have had_claude");
                 }
                 Err(e) => {
-                    // No tmux session: expansion was attempted but failed.
-                    // The error must be a tmux failure, NOT "no idle panes
-                    // available" (which would mean we gave up before trying).
                     let msg = format!("{e:#}");
                     assert!(
                         !msg.contains("no idle panes available"),

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -110,6 +110,7 @@ impl ToolExecutor for LocalExecutor {
             "tmux_send_keys" => tmux_send_keys(args).await,
             "tmux_wait" => tmux_wait(args).await,
             "wait_for_file" => wait_for_file(args).await,
+            "tmux_rename_pane" => tmux_rename_pane(args).await,
             "read_file" => read_file(args).await,
             "edit_file" => edit_file(args).await,
             "spawn_agent" => match &self.spawn_ctx {
@@ -258,16 +259,10 @@ async fn tmux_send_keys(args: serde_json::Value) -> Result<String> {
 /// Instead of the LLM calling `tmux_capture_pane` in a loop (burning one LLM
 /// turn per poll), a single `tmux_wait` call blocks until the command running
 /// in the pane appears to have finished.
-///
-/// The function observes `idle_secs` of unchanged output before returning, so
-/// it always waits at least `idle_secs` regardless of the initial pane state.
-/// On timeout an error is returned so callers can distinguish it from a real
-/// pane output.
 async fn tmux_wait(args: serde_json::Value) -> Result<String> {
     let target = args["target"].as_str().unwrap_or("%0");
     let idle_secs = args["idle_secs"].as_u64().unwrap_or(3);
     let timeout_secs = args["timeout_secs"].as_u64().unwrap_or(600).min(86_400);
-    // Clamp poll interval to at least 1 s to avoid busy-polling tmux.
     let poll_secs = args["poll_interval_secs"].as_u64().unwrap_or(2).max(1);
 
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
@@ -275,16 +270,12 @@ async fn tmux_wait(args: serde_json::Value) -> Result<String> {
     let mut stable_since = tokio::time::Instant::now();
 
     loop {
-        // Check the hard deadline at the top of every iteration so we never
-        // start a new capture call after time has already expired.
         if tokio::time::Instant::now() >= deadline {
             anyhow::bail!(
                 "tmux_wait: timed out after {timeout_secs}s waiting for pane '{target}' to become idle"
             );
         }
 
-        // Wrap the capture call with timeout_at so a hung tmux process cannot
-        // block past the deadline.
         let capture_fut = Command::new("tmux")
             .args(["capture-pane", "-t", target, "-p"])
             .output();
@@ -312,7 +303,6 @@ async fn tmux_wait(args: serde_json::Value) -> Result<String> {
             return Ok(last_content);
         }
 
-        // Sleep at most until the deadline to keep the timeout accurate.
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         let sleep_dur = std::time::Duration::from_secs(poll_secs).min(remaining);
         tokio::time::sleep(sleep_dur).await;
@@ -320,21 +310,16 @@ async fn tmux_wait(args: serde_json::Value) -> Result<String> {
 }
 
 /// Block until `path` exists on the filesystem, then return `"found"`.
-///
-/// Useful for scripts that drop a sentinel file on completion, avoiding the
-/// need for the LLM to call `tmux_capture_pane` in a polling loop.
 async fn wait_for_file(args: serde_json::Value) -> Result<String> {
     let path = args["path"]
         .as_str()
         .context("wait_for_file: missing string argument 'path'")?;
-    // Cap timeout at 24 h to avoid Instant overflow with very large values.
     let timeout_secs = args["timeout_secs"].as_u64().unwrap_or(300).min(86_400);
     let poll_ms = args["poll_interval_ms"].as_u64().unwrap_or(500);
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
     loop {
         match tokio::fs::metadata(path).await {
             Ok(m) if m.is_file() => return Ok("found".to_owned()),
-            // A directory at the sentinel path is not the expected file — keep polling.
             Ok(_) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => {
@@ -351,6 +336,29 @@ async fn wait_for_file(args: serde_json::Value) -> Result<String> {
         }
         tokio::time::sleep(std::time::Duration::from_millis(poll_ms).min(remaining)).await;
     }
+}
+
+/// Rename a tmux pane by setting its title.
+async fn tmux_rename_pane(args: serde_json::Value) -> Result<String> {
+    let target = args["target"]
+        .as_str()
+        .context("tmux_rename_pane: missing string argument 'target'")?;
+    let title = args["title"]
+        .as_str()
+        .context("tmux_rename_pane: missing string argument 'title'")?;
+
+    let output = Command::new("tmux")
+        .args(["select-pane", "-t", target, "-T", title])
+        .output()
+        .await
+        .context("spawning tmux select-pane")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("tmux select-pane -T failed: {stderr}");
+    }
+
+    Ok(format!("renamed pane {target} to \"{title}\""))
 }
 
 /// Read the full contents of a file.
@@ -785,6 +793,28 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                         }
                     },
                     "required": ["path"]
+                }
+            }
+        }),
+        serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "tmux_rename_pane",
+                "description": "Set the title of a tmux pane using 'tmux select-pane -T'. \
+                                Useful for labelling panes with the current task.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "type": "string",
+                            "description": "tmux target pane (e.g. '%3'). Required."
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "New pane title to display."
+                        }
+                    },
+                    "required": ["target", "title"]
                 }
             }
         }),


### PR DESCRIPTION
## Summary

- Adds `src/pane_lease.rs`: flock-protected pane lease system with auto-expansion via `tmux split-window`, lease TTL (24h crash-recovery safety net), worktree uniqueness enforcement, and `CapacityError` when `MAX_PANES=16` would be exceeded
- Adds `/claude [--worktree <path>] [--no-enter] "task" ...` command in `client.rs`; sends `Request::ClaudeLaunch` to daemon which assigns panes using three-tier priority:
  1. Idle pane with `claude` running in the **same worktree** → send `/compact` to summarise prior context, then inject the description
  2. Idle pane with **no claude** running (blank shell) → `cd <worktree> && claude --dangerously-skip-permissions`, then inject the description
  3. Idle pane with `claude` running in a **different worktree** → skipped entirely; the pool is expanded with a new blank pane instead (sending shell commands to such a pane would deliver them as chat messages to the running claude session)
- **Auto-creates a git worktree** at `~/.amaebi/worktrees/<repo>/<task_id>-<uuid8>` when `--worktree` is not specified. A short UUID suffix (matching the `agent-{uuid8}` pattern Claude Code uses) guarantees uniqueness across runs — repeated invocations with the same task description never collide on branch name or directory path. Worktrees are centralised under `~/.amaebi/` alongside other amaebi state (no repo pollution, no `.gitignore` entry needed). Falls back gracefully (no worktree) if the cwd is not inside a git repository.
- `TaskSpec` carries `client_cwd` so the daemon runs `git -C <client_cwd>` for worktree creation and uses the client's directory (not the daemon's startup cwd) as the session UUID base
- `tmux send-keys` uses `-l --` to send descriptions as literal text; strings like `"Enter"` or `"C-c"` are typed out rather than interpreted as key names
- `release_lease` preserves `worktree` and `has_claude` so tier-1 reuse (same-worktree pane) works correctly after a task completes
- `task_id` is validated in the daemon (allow only `[A-Za-z0-9._-]`, reject path separators and `..`) before use in paths and branch names
- `/claude --worktree <path>` with multiple task descriptions returns a parse error (a single path cannot be shared across parallel tasks)
- `task_id` gets a `-{idx}` suffix for tasks beyond the first in a single invocation to prevent within-invocation collisions
- Renames acquired panes to `cc-{N}` (tmux pane numeric index, e.g. `cc-5`) for compact visibility
- Adds `TaskSpec`, `Request::ClaudeLaunch`, `Response::PaneAssigned`, `Response::CapacityError` to IPC layer
- Adds `tmux_rename_pane` LLM tool to `tools.rs`
- Unknown `--*` flags in `/claude` now return a parse error

## Test plan

- [x] `cargo test` — all tests pass (20 new pane_lease unit tests + ipc round-trip tests)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings