### PR TITLE
feat(daemon): add AMAEBI_COMPACT_MODEL to decouple compaction from main agent model

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3258,4 +3258,43 @@ mod tests {
     fn gpt_5_mini_requires_responses_api() {
         assert!(requires_responses_api("gpt-5-mini"));
     }
+
+    #[test]
+    #[serial_test::serial]
+    fn compact_model_override_used_verbatim() {
+        std::env::set_var("AMAEBI_COMPACT_MODEL", "custom/provider-model");
+        let result = compact_model("copilot/claude-opus-4-6");
+        std::env::remove_var("AMAEBI_COMPACT_MODEL");
+        assert_eq!(result, "custom/provider-model");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn compact_model_defaults_to_default_model_no_prefix() {
+        std::env::remove_var("AMAEBI_COMPACT_MODEL");
+        assert_eq!(
+            compact_model("claude-opus-4-6"),
+            crate::provider::DEFAULT_MODEL
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn compact_model_preserves_copilot_prefix() {
+        std::env::remove_var("AMAEBI_COMPACT_MODEL");
+        assert_eq!(
+            compact_model("copilot/claude-opus-4-6"),
+            format!("copilot/{}", crate::provider::DEFAULT_MODEL),
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn compact_model_preserves_bedrock_prefix() {
+        std::env::remove_var("AMAEBI_COMPACT_MODEL");
+        assert_eq!(
+            compact_model("bedrock/us.anthropic.claude-opus-4-6-v1:0"),
+            format!("bedrock/{}", crate::provider::DEFAULT_MODEL),
+        );
+    }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -74,6 +74,31 @@ fn response_max_tokens(model: &str) -> usize {
     );
     result
 }
+/// Resolve the model to use for background session compaction.
+///
+/// Defaults to [`crate::provider::DEFAULT_MODEL`] so compaction never
+/// inherits an expensive main-agent model (e.g. opus) unless the caller
+/// explicitly opts in.  The provider prefix of `main_model` is preserved so
+/// compaction stays on the same API backend (e.g. `copilot/` stays Copilot).
+///
+/// Resolution order:
+///   1. `AMAEBI_COMPACT_MODEL` env var (used verbatim)
+///   2. Same provider prefix as `main_model` + `DEFAULT_MODEL` (sonnet)
+fn compact_model(main_model: &str) -> String {
+    if let Ok(override_model) = std::env::var("AMAEBI_COMPACT_MODEL") {
+        return override_model;
+    }
+    // Preserve the provider prefix so compaction uses the same API backend.
+    let prefix = main_model
+        .split_once('/')
+        .map(|(p, _)| p)
+        .filter(|p| matches!(*p, "copilot" | "bedrock"));
+    match prefix {
+        Some(p) => format!("{}/{}", p, crate::provider::DEFAULT_MODEL),
+        None => crate::provider::DEFAULT_MODEL.to_string(),
+    }
+}
+
 /// Compact session history when prompt tokens exceed this fraction of available input.
 const COMPACTION_THRESHOLD: f64 = 0.85;
 /// Minimum recent user/assistant *pairs* to keep in the hot tail after a token-budget trim.
@@ -995,7 +1020,7 @@ async fn handle_chat_request(
                 tokio::spawn(compact_session(
                     Arc::clone(state),
                     old_sid,
-                    model.clone(),
+                    compact_model(&model),
                     0,
                 ));
             }
@@ -1050,7 +1075,7 @@ async fn handle_chat_request(
                     tokio::spawn(compact_session(
                         Arc::clone(state),
                         sid.clone(),
-                        model.clone(),
+                        compact_model(&model),
                         HOT_TAIL_PAIRS * 2,
                     ));
                 }


### PR DESCRIPTION
## Summary
- Add `compact_model()` helper that defaults compaction to `DEFAULT_MODEL` (sonnet-4.6) instead of inheriting the main agent model
- When `AMAEBI_MODEL=claude-opus-4-6`, compaction no longer runs on opus — it uses sonnet by default
- Set `AMAEBI_COMPACT_MODEL=claude-haiku-4.5` (or any `provider/model` string) to override
- Provider prefix is preserved: if main model is `copilot/gpt-4o`, compact model defaults to `copilot/claude-sonnet-4.6`

## Test plan
- [x] `cargo test` — all pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)