### PR TITLE
feat(tools): add wait_for_file tool for sentinel-file based completion detection

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -309,7 +309,9 @@ async fn wait_for_file(args: serde_json::Value) -> Result<String> {
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
     loop {
         match tokio::fs::metadata(path).await {
-            Ok(_) => return Ok("found".to_owned()),
+            Ok(m) if m.is_file() => return Ok("found".to_owned()),
+            // A directory at the sentinel path is not the expected file — keep polling.
+            Ok(_) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => {
                 return Err(anyhow::anyhow!(
@@ -1405,20 +1407,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wait_for_file_errors_on_permission_denied() {
-        // Create a directory where metadata checks return PermissionDenied
-        // by using a path whose *parent* is a file (so stat errors differently).
-        // On Linux we can also test with /proc/1/mem which is always EACCES.
+    async fn wait_for_file_does_not_match_directory() {
+        // If a directory exists at the sentinel path it should NOT be treated as
+        // "found" — wait_for_file expects a regular file.
+        let tmp = TempDir::new().unwrap();
+        let dir_path = tmp.path().join("subdir");
+        std::fs::create_dir(&dir_path).unwrap();
+        // With a zero timeout the call must time out rather than return "found".
         let result = wait_for_file(serde_json::json!({
-            "path": "/proc/1/mem/sentinel",
-            "timeout_secs": 1,
+            "path": dir_path.to_str().unwrap(),
+            "timeout_secs": 0,
             "poll_interval_ms": 10
         }))
-        .await;
-        // Either an error (permission denied propagated) or timeout is acceptable
-        // depending on how the kernel reports the path. The key assertion is that
-        // we don't silently poll until timeout on an accessible path that exists.
-        // We just check it doesn't panic.
-        let _ = result;
+        .await
+        .unwrap();
+        assert!(
+            result.starts_with("timeout:"),
+            "directory must not match: {result}"
+        );
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -303,12 +303,19 @@ async fn wait_for_file(args: serde_json::Value) -> Result<String> {
     let path = args["path"]
         .as_str()
         .context("wait_for_file: missing string argument 'path'")?;
-    let timeout_secs = args["timeout_secs"].as_u64().unwrap_or(300);
+    // Cap timeout at 24 h to avoid Instant overflow with very large values.
+    let timeout_secs = args["timeout_secs"].as_u64().unwrap_or(300).min(86_400);
     let poll_ms = args["poll_interval_ms"].as_u64().unwrap_or(500);
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
     loop {
-        if tokio::fs::metadata(path).await.is_ok() {
-            return Ok("found".to_owned());
+        match tokio::fs::metadata(path).await {
+            Ok(_) => return Ok("found".to_owned()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "wait_for_file: error checking '{path}': {e}"
+                ))
+            }
         }
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
@@ -1365,5 +1372,53 @@ mod tests {
         assert!(result.is_err());
         let msg = format!("{}", result.unwrap_err());
         assert!(msg.contains("unknown tool"), "got: {msg}");
+    }
+
+    // ---- wait_for_file --------------------------------------------------
+
+    #[tokio::test]
+    async fn wait_for_file_returns_found_immediately() {
+        let tmp = TempDir::new().unwrap();
+        let sentinel = tmp.path().join("done.txt");
+        std::fs::write(&sentinel, "").unwrap();
+        let result = wait_for_file(serde_json::json!({
+            "path": sentinel.to_str().unwrap(),
+            "timeout_secs": 5
+        }))
+        .await
+        .unwrap();
+        assert_eq!(result, "found");
+    }
+
+    #[tokio::test]
+    async fn wait_for_file_times_out_when_file_absent() {
+        let tmp = TempDir::new().unwrap();
+        let sentinel = tmp.path().join("never.txt");
+        let result = wait_for_file(serde_json::json!({
+            "path": sentinel.to_str().unwrap(),
+            "timeout_secs": 0,
+            "poll_interval_ms": 10
+        }))
+        .await
+        .unwrap();
+        assert!(result.starts_with("timeout:"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn wait_for_file_errors_on_permission_denied() {
+        // Create a directory where metadata checks return PermissionDenied
+        // by using a path whose *parent* is a file (so stat errors differently).
+        // On Linux we can also test with /proc/1/mem which is always EACCES.
+        let result = wait_for_file(serde_json::json!({
+            "path": "/proc/1/mem/sentinel",
+            "timeout_secs": 1,
+            "poll_interval_ms": 10
+        }))
+        .await;
+        // Either an error (permission denied propagated) or timeout is acceptable
+        // depending on how the kernel reports the path. The key assertion is that
+        // we don't silently poll until timeout on an accessible path that exists.
+        // We just check it doesn't panic.
+        let _ = result;
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -109,6 +109,7 @@ impl ToolExecutor for LocalExecutor {
             "tmux_capture_pane" => tmux_capture_pane(args).await,
             "tmux_send_keys" => tmux_send_keys(args).await,
             "tmux_wait" => tmux_wait(args).await,
+            "wait_for_file" => wait_for_file(args).await,
             "read_file" => read_file(args).await,
             "edit_file" => edit_file(args).await,
             "spawn_agent" => match &self.spawn_ctx {
@@ -291,6 +292,31 @@ async fn tmux_wait(args: serde_json::Value) -> Result<String> {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         let sleep_dur = std::time::Duration::from_secs(poll_secs).min(remaining);
         tokio::time::sleep(sleep_dur).await;
+    }
+}
+
+/// Block until `path` exists on the filesystem, then return `"found"`.
+///
+/// Useful for scripts that drop a sentinel file on completion, avoiding the
+/// need for the LLM to call `tmux_capture_pane` in a polling loop.
+async fn wait_for_file(args: serde_json::Value) -> Result<String> {
+    let path = args["path"]
+        .as_str()
+        .context("wait_for_file: missing string argument 'path'")?;
+    let timeout_secs = args["timeout_secs"].as_u64().unwrap_or(300);
+    let poll_ms = args["poll_interval_ms"].as_u64().unwrap_or(500);
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+    loop {
+        if tokio::fs::metadata(path).await.is_ok() {
+            return Ok("found".to_owned());
+        }
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Ok(format!(
+                "timeout: '{path}' did not appear within {timeout_secs}s"
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(poll_ms).min(remaining)).await;
     }
 }
 
@@ -694,6 +720,34 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
         serde_json::json!({
             "type": "function",
             "function": {
+                "name": "wait_for_file",
+                "description": "Block until a file appears at the given path, then return \"found\". \
+                                Returns a timeout message if the file does not appear within timeout_secs. \
+                                Use this instead of polling tmux_capture_pane when a script can write \
+                                a sentinel file on completion.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Absolute or relative path of the file to wait for."
+                        },
+                        "timeout_secs": {
+                            "type": "integer",
+                            "description": "Maximum seconds to wait before returning timeout message. Default: 300."
+                        },
+                        "poll_interval_ms": {
+                            "type": "integer",
+                            "description": "How often to check for the file, in milliseconds. Default: 500."
+                        }
+                    },
+                    "required": ["path"]
+                }
+            }
+        }),
+        serde_json::json!({
+            "type": "function",
+            "function": {
                 "name": "read_file",
                 "description": "Read the full contents of a file on disk.",
                 "parameters": {
@@ -828,6 +882,7 @@ mod tests {
             "tmux_capture_pane",
             "tmux_send_keys",
             "tmux_wait",
+            "wait_for_file",
             "read_file",
             "edit_file",
             "spawn_agent",


### PR DESCRIPTION
## Summary
- New `wait_for_file` tool: blocks internally until a file appears at the given path, then returns `"found"`
- Avoids repeated `tmux_capture_pane` LLM polling — scripts drop a sentinel file on completion, the supervisor makes one tool call and waits
- Parameters: `path` (required), `timeout_secs` (default 300), `poll_interval_ms` (default 500)

## Test plan
- [x] `cargo test` — all pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)