### PR TITLE
feat(tools): add AMAEBI_SUBAGENT_MODEL to decouple sub-agent model from main agent

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -287,13 +287,11 @@ async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<Stri
         )
     })?;
 
-    // Fix 4: inherit the parent's current model when the tool caller does not
-    // specify one explicitly.
     let model = args["model"]
         .as_str()
         .map(|s| s.to_string())
         .unwrap_or_else(|| {
-            std::env::var("AMAEBI_MODEL")
+            std::env::var("AMAEBI_SUBAGENT_MODEL")
                 .unwrap_or_else(|_| crate::provider::DEFAULT_MODEL.to_string())
         });
 
@@ -616,8 +614,7 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                         },
                         "model": {
                             "type": "string",
-                            "description": "LLM model to use (optional; defaults to the AMAEBI_MODEL \
-                                            environment variable, or gpt-4o if unset)."
+                            "description": "LLM model to use (optional; defaults to AMAEBI_SUBAGENT_MODEL env var, or claude-sonnet-4.6 if unset). Supports provider/model format (e.g. bedrock/claude-haiku-4.5)."
                         },
                         "extra_mounts": {
                             "type": "array",

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -251,6 +251,32 @@ async fn read_file(args: serde_json::Value) -> Result<String> {
 /// The child executor is created with `spawn_ctx: None` so it cannot
 /// call `spawn_agent` itself.
 /// TODO: enforce a depth limit for nested agents if needed.
+/// Resolve the default model for a spawned sub-agent.
+///
+/// Mirrors the provider-prefix preservation logic in `compact_model` in
+/// `daemon.rs`: if the parent session uses `copilot/` or `bedrock/` (as
+/// indicated by `AMAEBI_MODEL`), the sub-agent defaults to the same backend
+/// rather than falling back to bare `DEFAULT_MODEL` (Bedrock).
+///
+/// Resolution order:
+///   1. `AMAEBI_SUBAGENT_MODEL` env var (used verbatim)
+///   2. Provider prefix from `AMAEBI_MODEL` + `DEFAULT_MODEL`
+///   3. Bare `DEFAULT_MODEL`
+fn subagent_default_model() -> String {
+    if let Ok(m) = std::env::var("AMAEBI_SUBAGENT_MODEL") {
+        return m;
+    }
+    let parent = std::env::var("AMAEBI_MODEL").unwrap_or_default();
+    let prefix = parent
+        .split_once('/')
+        .map(|(p, _)| p)
+        .filter(|p| matches!(*p, "copilot" | "bedrock"));
+    match prefix {
+        Some(p) => format!("{}/{}", p, crate::provider::DEFAULT_MODEL),
+        None => crate::provider::DEFAULT_MODEL.to_string(),
+    }
+}
+
 async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<String> {
     let task = args["task"]
         .as_str()
@@ -290,10 +316,7 @@ async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<Stri
     let model = args["model"]
         .as_str()
         .map(|s| s.to_string())
-        .unwrap_or_else(|| {
-            std::env::var("AMAEBI_SUBAGENT_MODEL")
-                .unwrap_or_else(|_| crate::provider::DEFAULT_MODEL.to_string())
-        });
+        .unwrap_or_else(subagent_default_model);
 
     let extra_mounts = args["extra_mounts"].as_array().cloned().unwrap_or_default();
     let mut ro_paths: Vec<PathBuf> = vec![];
@@ -392,7 +415,20 @@ async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<Stri
     context_lines.push(task.to_string());
     let full_task = context_lines.join("\n");
 
-    tracing::info!(task = %task, workspace = %workspace.display(), model = %model, "spawn_agent: starting child agent");
+    let model_source = if args["model"].as_str().is_some() {
+        "explicit"
+    } else if std::env::var("AMAEBI_SUBAGENT_MODEL").is_ok() {
+        "AMAEBI_SUBAGENT_MODEL"
+    } else {
+        "default"
+    };
+    tracing::info!(
+        task = %task,
+        workspace = %workspace.display(),
+        model = %model,
+        model_source = %model_source,
+        "spawn_agent: starting child agent"
+    );
 
     // Build the child sandbox using the pre-computed `using_noop` flag.
     let child_sandbox: Box<dyn Sandbox> = if using_noop {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -614,7 +614,12 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                         },
                         "model": {
                             "type": "string",
-                            "description": "LLM model to use (optional; defaults to AMAEBI_SUBAGENT_MODEL env var, or claude-sonnet-4.6 if unset). Supports provider/model format (e.g. bedrock/claude-haiku-4.5)."
+                            "description": (format!(
+                                "LLM model to use (optional; defaults to AMAEBI_SUBAGENT_MODEL \
+                                 env var, or {} if unset). Supports provider/model format \
+                                 (e.g. bedrock/claude-haiku-4.5).",
+                                crate::provider::DEFAULT_MODEL
+                            ))
                         },
                         "extra_mounts": {
                             "type": "array",

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1144,6 +1144,57 @@ mod tests {
         }
     }
 
+    // ---- subagent_default_model -----------------------------------------
+
+    #[test]
+    #[serial_test::serial]
+    fn subagent_default_model_uses_subagent_env_verbatim() {
+        std::env::set_var("AMAEBI_MODEL", "copilot/claude-opus-4-6");
+        std::env::set_var("AMAEBI_SUBAGENT_MODEL", "bedrock/claude-haiku-4.5");
+        let result = subagent_default_model();
+        std::env::remove_var("AMAEBI_MODEL");
+        std::env::remove_var("AMAEBI_SUBAGENT_MODEL");
+        // AMAEBI_SUBAGENT_MODEL wins over AMAEBI_MODEL.
+        assert_eq!(result, "bedrock/claude-haiku-4.5");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn subagent_default_model_does_not_inherit_amaebi_model() {
+        std::env::set_var("AMAEBI_MODEL", "copilot/claude-opus-4-6");
+        std::env::remove_var("AMAEBI_SUBAGENT_MODEL");
+        let result = subagent_default_model();
+        std::env::remove_var("AMAEBI_MODEL");
+        // Must NOT be the parent model — just the prefix + DEFAULT_MODEL.
+        assert_ne!(result, "copilot/claude-opus-4-6");
+        assert_eq!(
+            result,
+            format!("copilot/{}", crate::provider::DEFAULT_MODEL)
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn subagent_default_model_preserves_copilot_prefix() {
+        std::env::set_var("AMAEBI_MODEL", "copilot/gpt-4o");
+        std::env::remove_var("AMAEBI_SUBAGENT_MODEL");
+        let result = subagent_default_model();
+        std::env::remove_var("AMAEBI_MODEL");
+        assert_eq!(
+            result,
+            format!("copilot/{}", crate::provider::DEFAULT_MODEL)
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn subagent_default_model_no_prefix_falls_back_to_default() {
+        std::env::remove_var("AMAEBI_MODEL");
+        std::env::remove_var("AMAEBI_SUBAGENT_MODEL");
+        let result = subagent_default_model();
+        assert_eq!(result, crate::provider::DEFAULT_MODEL);
+    }
+
     // ---- unknown tool ---------------------------------------------------
 
     #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -773,6 +773,7 @@ async fn spawn_agent_runs_task() {
         &[
             ("AMAEBI_SPAWN_SANDBOX", "noop"),
             ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
         ],
     )
     .await
@@ -838,6 +839,7 @@ async fn spawn_agent_child_cannot_spawn() {
         &[
             ("AMAEBI_SPAWN_SANDBOX", "noop"),
             ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
         ],
     )
     .await
@@ -914,6 +916,7 @@ async fn spawn_agent_uses_specified_model() {
         &[
             ("AMAEBI_SPAWN_SANDBOX", "noop"),
             ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
         ],
     )
     .await
@@ -980,6 +983,7 @@ async fn spawn_agent_missing_workspace_returns_error() {
         &[
             ("AMAEBI_SPAWN_SANDBOX", "noop"),
             ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
         ],
     )
     .await
@@ -1070,6 +1074,7 @@ async fn spawn_agent_workspace_passed_to_sandbox() {
         &[
             ("AMAEBI_SPAWN_SANDBOX", "noop"),
             ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
         ],
     )
     .await
@@ -1167,6 +1172,7 @@ async fn spawn_agent_parallel_calls() {
         &[
             ("AMAEBI_SPAWN_SANDBOX", "noop"),
             ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
         ],
     )
     .await
@@ -1265,6 +1271,7 @@ async fn spawn_agent_parallel_timing() {
         &[
             ("AMAEBI_SPAWN_SANDBOX", "noop"),
             ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
         ],
     )
     .await
@@ -1323,7 +1330,10 @@ async fn cron_job_triggers_llm_call() {
     let (socket, mut child, _socket_dir) = start_daemon_at_home_with_env(
         home_dir.path(),
         &server.url(),
-        &[("AMAEBI_MODEL", "copilot/gpt-4o")],
+        &[
+            ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
+        ],
     )
     .await
     .expect("start daemon");
@@ -1402,7 +1412,10 @@ async fn cron_job_result_not_sent_to_chat() {
     let (socket, mut child, _socket_dir) = start_daemon_at_home_with_env(
         home_dir.path(),
         &server.url(),
-        &[("AMAEBI_MODEL", "copilot/gpt-4o")],
+        &[
+            ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
+        ],
     )
     .await
     .expect("start daemon");
@@ -1487,6 +1500,7 @@ async fn cron_job_with_spawn_agent() {
         &[
             ("AMAEBI_SPAWN_SANDBOX", "noop"),
             ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
         ],
     )
     .await
@@ -1691,6 +1705,7 @@ async fn sandbox_noop_child_does_not_expose_credentials() {
         &[
             ("AMAEBI_SPAWN_SANDBOX", "noop"),
             ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
         ],
     )
     .await
@@ -1793,6 +1808,7 @@ async fn subagent_chain_session_remains_usable_after_recursion_block() {
         &[
             ("AMAEBI_SPAWN_SANDBOX", "noop"),
             ("AMAEBI_MODEL", "copilot/gpt-4o"),
+            ("AMAEBI_SUBAGENT_MODEL", "copilot/gpt-4o"),
         ],
     )
     .await


### PR DESCRIPTION
## Summary
- Switch `spawn_agent` model resolution from `AMAEBI_MODEL` → `AMAEBI_SUBAGENT_MODEL`, falling back to `DEFAULT_MODEL` (sonnet-4.6)
- When `AMAEBI_MODEL=claude-opus-4-6`, spawned sub-agents now default to sonnet instead of opus
- Set `AMAEBI_SUBAGENT_MODEL=claude-haiku-4.5` for even cheaper sub-agent work; supports full `provider/model` format
- Remove stale `// Fix 4: inherit the parent's current model` comment (behavior is now the opposite)
- Fix integration tests: add `AMAEBI_SUBAGENT_MODEL=copilot/gpt-4o` alongside `AMAEBI_MODEL` in all spawn_agent test cases

## Test plan
- [x] `cargo test` — 419 unit + 34 integration tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)