### PR TITLE
feat(daemon): lower default compaction threshold from 0.85 to 0.75

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -75,7 +75,7 @@ fn response_max_tokens(model: &str) -> usize {
     result
 }
 /// Compact session history when prompt tokens exceed this fraction of available input.
-const COMPACTION_THRESHOLD: f64 = 0.85;
+const COMPACTION_THRESHOLD: f64 = 0.75;
 /// Minimum recent user/assistant *pairs* to keep in the hot tail after a token-budget trim.
 const HOT_TAIL_PAIRS: usize = 3;
 /// How many past-session summaries to prepend to the system message.


### PR DESCRIPTION
## Summary
- Change `COMPACTION_THRESHOLD` from `0.85` to `0.75`, triggering context compaction earlier
- Reduces the size of uncached delta tokens on each turn when conversation history is large
- `AMAEBI_COMPACTION_THRESHOLD` env override still takes precedence

## Test plan
- [x] `cargo test` — 34 pass, existing `compaction_threshold_is_below_context_limit` test still passes
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)