### PR TITLE
feat(tools): add lines param to tmux_capture_pane to limit scrollback

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -188,9 +188,10 @@ async fn shell_command(
 
 /// Capture recent lines from a tmux pane's scrollback history.
 ///
-/// Uses `tmux capture-pane -S -N` to start N lines before the bottom of the
-/// pane history, returning at most `lines` lines. This avoids flooding the LLM
-/// with thousands of lines of build output when only the tail matters.
+/// Uses `tmux capture-pane -S -{lines}` where `-S` receives a negative numeric
+/// argument, starting `lines` lines before the bottom of the pane history and
+/// returning at most `lines` lines. This avoids flooding the LLM with thousands
+/// of lines of build output when only the tail matters.
 async fn tmux_capture_pane(args: serde_json::Value) -> Result<String> {
     let target = args["target"].as_str().unwrap_or("%0");
     // Clamp to at least 1: lines=0 would produce "-S -0" which disables the
@@ -535,9 +536,10 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                         },
                         "lines": {
                             "type": "integer",
+                            "minimum": 1,
                             "description": "Number of lines of scrollback to capture \
-                                            (default: 200). Use a smaller value to reduce \
-                                            token usage when only the tail matters."
+                                            (minimum: 1, default: 200). Use a smaller value \
+                                            to reduce token usage when only the tail matters."
                         }
                     },
                     "required": []

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -186,12 +186,16 @@ async fn shell_command(
     Ok(result)
 }
 
-/// Capture the visible text of a tmux pane.
+/// Capture recent lines from a tmux pane's scrollback history.
+///
+/// Uses `tmux capture-pane -S -N` to start N lines before the bottom of the
+/// pane history, returning at most `lines` lines. This avoids flooding the LLM
+/// with thousands of lines of build output when only the tail matters.
 async fn tmux_capture_pane(args: serde_json::Value) -> Result<String> {
     let target = args["target"].as_str().unwrap_or("%0");
-    // Limit scrollback to avoid flooding the LLM with thousands of lines.
-    // -S -N means "start N lines before the bottom of the pane history".
-    let lines = args["lines"].as_u64().unwrap_or(200);
+    // Clamp to at least 1: lines=0 would produce "-S -0" which disables the
+    // limit and could capture unbounded history.
+    let lines = args["lines"].as_u64().unwrap_or(200).max(1);
     let start = format!("-{lines}");
 
     let output = Command::new("tmux")

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -188,11 +188,14 @@ async fn shell_command(
 
 /// Capture the visible text of a tmux pane.
 async fn tmux_capture_pane(args: serde_json::Value) -> Result<String> {
-    // Default to the first pane if no target provided.
     let target = args["target"].as_str().unwrap_or("%0");
+    // Limit scrollback to avoid flooding the LLM with thousands of lines.
+    // -S -N means "start N lines before the bottom of the pane history".
+    let lines = args["lines"].as_u64().unwrap_or(200);
+    let start = format!("-{lines}");
 
     let output = Command::new("tmux")
-        .args(["capture-pane", "-t", target, "-p"])
+        .args(["capture-pane", "-t", target, "-p", "-S", &start])
         .output()
         .await
         .context("spawning tmux capture-pane")?;
@@ -517,7 +520,7 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
             "type": "function",
             "function": {
                 "name": "tmux_capture_pane",
-                "description": "Capture and return the current visible text of a tmux pane.",
+                "description": "Capture and return recent text from a tmux pane.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -525,6 +528,12 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                             "type": "string",
                             "description": "tmux target pane (e.g. '%0', '0:1.0'). \
                                             Defaults to %0."
+                        },
+                        "lines": {
+                            "type": "integer",
+                            "description": "Number of lines of scrollback to capture \
+                                            (default: 200). Use a smaller value to reduce \
+                                            token usage when only the tail matters."
                         }
                     },
                     "required": []


### PR DESCRIPTION
## Summary
- Add optional `lines` parameter to `tmux_capture_pane` (default: 200)
- Uses `tmux capture-pane -S -N` to limit scrollback instead of capturing unbounded history
- Prevents large build outputs (ninja, make, cargo) from flooding LLM context
- LLM can pass a smaller value when only the tail matters

## Before / After
- Before: `tmux capture-pane -t %0 -p` — unbounded, up to `history-limit` lines (default 2000)
- After: `tmux capture-pane -t %0 -p -S -200` — capped at 200 lines by default

## Test plan
- [x] `cargo test` — all pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)