### PR TITLE
feat(daemon): fold old tool results to save context

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1177,11 +1177,11 @@ const FOLD_TRIGGER_FRACTION: f64 = 0.5;
 ///
 /// This mirrors Claude Code's behaviour of replacing previously-read file
 /// contents with a compact reference once the context grows large.  Only
-/// results with content longer than `min_chars` are folded; short results
+/// results longer than `MIN_FOLD_CHARS` (200) are folded; short results
 /// (e.g. `"ok"`) are left as-is because they add negligible cost.
 ///
-/// The tool name is resolved by looking up the matching assistant
-/// `tool_calls` entry whose `id` equals the result's `tool_call_id`.
+/// The tool name and a human-readable label (e.g. the file path for
+/// `read_file`) are resolved from the matching assistant `tool_calls` entry.
 fn fold_old_tool_results(messages: &mut [copilot::Message], keep_recent: usize) {
     use std::collections::HashMap;
 
@@ -1196,23 +1196,30 @@ fn fold_old_tool_results(messages: &mut [copilot::Message], keep_recent: usize) 
                 let args: serde_json::Value =
                     serde_json::from_str(&tc.function.arguments).unwrap_or_default();
                 let label = match tc.function.name.as_str() {
-                    "read_file" | "edit_file" | "write_file" | "wait_for_file" => args
+                    "read_file" | "edit_file" | "wait_for_file" => args
                         .get("path")
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .to_string(),
                     "shell_command" => {
                         let cmd = args.get("command").and_then(|v| v.as_str()).unwrap_or("");
-                        if cmd.len() > 60 {
-                            format!("{}…", &cmd[..60])
+                        // Use char-aware truncation to avoid splitting multi-byte sequences.
+                        if cmd.chars().count() > 60 {
+                            format!("{}…", cmd.chars().take(60).collect::<String>())
                         } else {
                             cmd.to_string()
                         }
                     }
-                    "tmux_capture_pane" | "tmux_send_keys" | "tmux_wait" => args
+                    "tmux_capture_pane" | "tmux_wait" => args
                         .get("target")
                         .and_then(|v| v.as_str())
                         .unwrap_or("%0")
+                        .to_string(),
+                    // tmux_send_keys: the meaningful argument is the keys sent, not the target.
+                    "tmux_send_keys" => args
+                        .get("keys")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
                         .to_string(),
                     _ => String::new(),
                 };

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1240,6 +1240,19 @@ fn fold_old_tool_results(messages: &mut [copilot::Message], keep_recent: usize) 
     let fold_until = indices.len().saturating_sub(keep_recent);
     for &idx in &indices[..fold_until] {
         let msg = &mut messages[idx];
+
+        // spawn_agent results are already summaries written by the subagent —
+        // folding them would discard useful context rather than save tokens.
+        let tool_name_for_check = msg
+            .tool_call_id
+            .as_deref()
+            .and_then(|id| call_info.get(id))
+            .map(|(n, _)| n.as_str())
+            .unwrap_or("");
+        if tool_name_for_check == "spawn_agent" {
+            continue;
+        }
+
         let char_count = msg
             .content
             .as_deref()
@@ -3517,5 +3530,24 @@ mod tests {
             folded.contains("collapsed"),
             "must be marked collapsed: {folded}"
         );
+    }
+
+    #[test]
+    fn fold_never_collapses_spawn_agent_results() {
+        // spawn_agent results are already summaries; folding them discards context.
+        let summary = "x".repeat(500); // large enough to trigger folding normally
+        let mut msgs = Vec::new();
+        msgs.extend(make_tool_turn("id1", "spawn_agent", &summary));
+        msgs.extend(make_tool_turn("id2", "spawn_agent", &summary));
+        msgs.extend(make_tool_turn("id3", "spawn_agent", &summary));
+        fold_old_tool_results(&mut msgs, 1);
+        // All spawn_agent results must remain untouched regardless of age.
+        for msg in msgs.iter().filter(|m| m.role == "tool") {
+            assert_eq!(
+                msg.content.as_deref().unwrap(),
+                summary,
+                "spawn_agent result must not be folded"
+            );
+        }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1185,12 +1185,38 @@ const FOLD_TRIGGER_FRACTION: f64 = 0.5;
 fn fold_old_tool_results(messages: &mut [copilot::Message], keep_recent: usize) {
     use std::collections::HashMap;
 
-    // Build id → tool_name from all assistant messages.
-    let mut call_names: HashMap<String, String> = HashMap::new();
+    // Build id → (tool_name, label) from all assistant messages.
+    // `label` extracts the most useful argument for each tool so the folded
+    // reference reads e.g. `[read_file: src/daemon.rs — 8432 chars, collapsed]`
+    // instead of the opaque `[read_file result: 8432 chars]`.
+    let mut call_info: HashMap<String, (String, String)> = HashMap::new();
     for msg in messages.iter() {
         if msg.role == "assistant" {
             for tc in &msg.tool_calls {
-                call_names.insert(tc.id.clone(), tc.function.name.clone());
+                let args: serde_json::Value =
+                    serde_json::from_str(&tc.function.arguments).unwrap_or_default();
+                let label = match tc.function.name.as_str() {
+                    "read_file" | "edit_file" | "write_file" | "wait_for_file" => args
+                        .get("path")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    "shell_command" => {
+                        let cmd = args.get("command").and_then(|v| v.as_str()).unwrap_or("");
+                        if cmd.len() > 60 {
+                            format!("{}…", &cmd[..60])
+                        } else {
+                            cmd.to_string()
+                        }
+                    }
+                    "tmux_capture_pane" | "tmux_send_keys" | "tmux_wait" => args
+                        .get("target")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("%0")
+                        .to_string(),
+                    _ => String::new(),
+                };
+                call_info.insert(tc.id.clone(), (tc.function.name.clone(), label));
             }
         }
     }
@@ -1216,15 +1242,17 @@ fn fold_old_tool_results(messages: &mut [copilot::Message], keep_recent: usize) 
         if char_count <= MIN_FOLD_CHARS {
             continue;
         }
-        let tool_name = msg
+        let (tool_name, label) = msg
             .tool_call_id
             .as_deref()
-            .and_then(|id| call_names.get(id))
-            .map(|s| s.as_str())
-            .unwrap_or("unknown_tool");
-        msg.content = Some(format!(
-            "[{tool_name} result: {char_count} chars — collapsed to save context]"
-        ));
+            .and_then(|id| call_info.get(id))
+            .map(|(n, l)| (n.as_str(), l.as_str()))
+            .unwrap_or(("unknown_tool", ""));
+        msg.content = Some(if label.is_empty() {
+            format!("[{tool_name} — {char_count} chars, collapsed]")
+        } else {
+            format!("[{tool_name}: {label} — {char_count} chars, collapsed]")
+        });
     }
 }
 
@@ -3420,7 +3448,7 @@ mod tests {
         // First tool result (index 1) should be collapsed.
         let first_result = msgs[1].content.as_deref().unwrap();
         assert!(
-            first_result.contains("collapsed to save context"),
+            first_result.contains("collapsed"),
             "old result should be folded: {first_result}"
         );
         assert!(
@@ -3448,5 +3476,39 @@ mod tests {
                 "short result must not be folded"
             );
         }
+    }
+
+    #[test]
+    fn fold_includes_path_label_for_read_file() {
+        let large = "x".repeat(500);
+        // Build a turn with a real path argument.
+        let msgs_turn = vec![
+            copilot::Message::assistant(
+                None,
+                vec![crate::copilot::ApiToolCall {
+                    id: "id1".into(),
+                    kind: "function".into(),
+                    function: crate::copilot::ApiToolCallFunction {
+                        name: "read_file".into(),
+                        arguments: r#"{"path":"src/daemon.rs"}"#.into(),
+                    },
+                }],
+            ),
+            copilot::Message::tool_result("id1", &large),
+        ];
+        // Add a second turn so the first is eligible for folding (keep_recent=1).
+        let msgs_turn2 = make_tool_turn("id2", "read_file", &large);
+        let mut msgs = msgs_turn;
+        msgs.extend(msgs_turn2);
+        fold_old_tool_results(&mut msgs, 1);
+        let folded = msgs[1].content.as_deref().unwrap();
+        assert!(
+            folded.contains("src/daemon.rs"),
+            "folded reference must include file path: {folded}"
+        );
+        assert!(
+            folded.contains("collapsed"),
+            "must be marked collapsed: {folded}"
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1161,6 +1161,74 @@ fn truncate_chars(s: &str, max: usize) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Tool-result folding
+// ---------------------------------------------------------------------------
+
+/// Number of the most-recent tool-result messages to keep at full fidelity.
+/// All earlier ones are collapsed to a one-line reference.
+const FOLD_KEEP_RECENT: usize = 6;
+
+/// Threshold (as a fraction of the compaction token budget) above which
+/// `fold_old_tool_results` is triggered inside the agentic loop.
+const FOLD_TRIGGER_FRACTION: f64 = 0.5;
+
+/// Collapse older tool-result messages to one-line references, keeping the
+/// most-recent `keep_recent` results at full fidelity.
+///
+/// This mirrors Claude Code's behaviour of replacing previously-read file
+/// contents with a compact reference once the context grows large.  Only
+/// results with content longer than `min_chars` are folded; short results
+/// (e.g. `"ok"`) are left as-is because they add negligible cost.
+///
+/// The tool name is resolved by looking up the matching assistant
+/// `tool_calls` entry whose `id` equals the result's `tool_call_id`.
+fn fold_old_tool_results(messages: &mut [copilot::Message], keep_recent: usize) {
+    use std::collections::HashMap;
+
+    // Build id → tool_name from all assistant messages.
+    let mut call_names: HashMap<String, String> = HashMap::new();
+    for msg in messages.iter() {
+        if msg.role == "assistant" {
+            for tc in &msg.tool_calls {
+                call_names.insert(tc.id.clone(), tc.function.name.clone());
+            }
+        }
+    }
+
+    // Collect indices of all tool-result messages.
+    let indices: Vec<usize> = messages
+        .iter()
+        .enumerate()
+        .filter(|(_, m)| m.role == "tool")
+        .map(|(i, _)| i)
+        .collect();
+
+    // Only fold the oldest ones; leave the last `keep_recent` intact.
+    let fold_until = indices.len().saturating_sub(keep_recent);
+    for &idx in &indices[..fold_until] {
+        let msg = &mut messages[idx];
+        let char_count = msg
+            .content
+            .as_deref()
+            .map(|c| c.chars().count())
+            .unwrap_or(0);
+        const MIN_FOLD_CHARS: usize = 200;
+        if char_count <= MIN_FOLD_CHARS {
+            continue;
+        }
+        let tool_name = msg
+            .tool_call_id
+            .as_deref()
+            .and_then(|id| call_names.get(id))
+            .map(|s| s.as_str())
+            .unwrap_or("unknown_tool");
+        msg.content = Some(format!(
+            "[{tool_name} result: {char_count} chars — collapsed to save context]"
+        ));
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Memory helpers — canonical DB access for daemon and ACP agent
 // ---------------------------------------------------------------------------
 
@@ -2233,6 +2301,18 @@ where
 
                 // Steers that arrived during tool execution are drained at
                 // the top of the next loop iteration, before the model call.
+
+                // Fold old tool results once we're past half the token budget so
+                // accumulated file reads / shell outputs don't crowd the context.
+                let fold_threshold =
+                    (compaction_threshold_tokens(model) as f64 * FOLD_TRIGGER_FRACTION) as usize;
+                if count_message_tokens(&messages) > fold_threshold {
+                    fold_old_tool_results(&mut messages, FOLD_KEEP_RECENT);
+                    tracing::debug!(
+                        fold_keep_recent = FOLD_KEEP_RECENT,
+                        "folded old tool results to save context"
+                    );
+                }
             }
 
             FinishReason::Other(ref reason) => {
@@ -3296,5 +3376,77 @@ mod tests {
             compact_model("bedrock/us.anthropic.claude-opus-4-6-v1:0"),
             format!("bedrock/{}", crate::provider::DEFAULT_MODEL),
         );
+    }
+
+    // ---- fold_old_tool_results -------------------------------------------
+
+    fn make_tool_turn(call_id: &str, tool_name: &str, result: &str) -> Vec<copilot::Message> {
+        vec![
+            copilot::Message::assistant(
+                None,
+                vec![crate::copilot::ApiToolCall {
+                    id: call_id.into(),
+                    kind: "function".into(),
+                    function: crate::copilot::ApiToolCallFunction {
+                        name: tool_name.into(),
+                        arguments: "{}".into(),
+                    },
+                }],
+            ),
+            copilot::Message::tool_result(call_id, result),
+        ]
+    }
+
+    #[test]
+    fn fold_does_not_touch_recent_results() {
+        let large = "x".repeat(500);
+        let mut msgs = Vec::new();
+        // Only one tool turn → it is "recent", must not be folded.
+        msgs.extend(make_tool_turn("id1", "read_file", &large));
+        fold_old_tool_results(&mut msgs, 2);
+        let content = msgs.last().unwrap().content.as_deref().unwrap();
+        assert_eq!(content, large, "recent result must not be folded");
+    }
+
+    #[test]
+    fn fold_collapses_old_large_results() {
+        let large = "x".repeat(500);
+        let mut msgs = Vec::new();
+        // 3 turns; with keep_recent=2, the first must be folded.
+        msgs.extend(make_tool_turn("id1", "read_file", &large));
+        msgs.extend(make_tool_turn("id2", "shell_command", &large));
+        msgs.extend(make_tool_turn("id3", "tmux_capture_pane", &large));
+        fold_old_tool_results(&mut msgs, 2);
+        // First tool result (index 1) should be collapsed.
+        let first_result = msgs[1].content.as_deref().unwrap();
+        assert!(
+            first_result.contains("collapsed to save context"),
+            "old result should be folded: {first_result}"
+        );
+        assert!(
+            first_result.contains("read_file"),
+            "folded text should include tool name: {first_result}"
+        );
+        // Last two must be intact.
+        assert_eq!(msgs[3].content.as_deref().unwrap(), large);
+        assert_eq!(msgs[5].content.as_deref().unwrap(), large);
+    }
+
+    #[test]
+    fn fold_skips_short_results() {
+        let short = "ok";
+        let mut msgs = Vec::new();
+        msgs.extend(make_tool_turn("id1", "shell_command", short));
+        msgs.extend(make_tool_turn("id2", "shell_command", short));
+        msgs.extend(make_tool_turn("id3", "shell_command", short));
+        fold_old_tool_results(&mut msgs, 1);
+        // Short results should never be collapsed regardless of age.
+        for msg in msgs.iter().filter(|m| m.role == "tool") {
+            assert_eq!(
+                msg.content.as_deref().unwrap(),
+                short,
+                "short result must not be folded"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Mirrors Claude Code's behavior of collapsing previously-read file contents into one-line references once the context grows large.

**How it works:**
- After each tool-call batch in the agentic loop, if total token count exceeds **50% of the compaction threshold**, `fold_old_tool_results` is called
- Tool-result messages older than the most-recent **6** are replaced with a one-line reference: `[read_file result: 8432 chars — collapsed to save context]`
- Short results (≤ 200 chars, e.g. `"ok"`) are never folded
- Tool names are resolved by matching `tool_call_id` to the preceding assistant `tool_calls` list

**New constants:**
- `FOLD_KEEP_RECENT = 6` — how many recent tool results to keep at full fidelity
- `FOLD_TRIGGER_FRACTION = 0.5` — fraction of compaction threshold that triggers folding

## Test plan
- [x] `cargo test` — 3 new unit tests: recent-results preserved, old large results folded, short results skipped
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)