### PR TITLE
feat(daemon): replace 8K truncation with /tmp persistence and read_file dedup

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1237,9 +1237,9 @@ async fn write_tool_output_file(path: &std::path::Path, content: String) -> std:
 /// the string literal — changes to the wording only need to be made once.
 fn file_unchanged_stub(cached_tool_use_id: &str) -> String {
     format!(
-        "[File unchanged since last read \
+        "[File metadata (mtime, size) unchanged since last read \
          (see tool_result for call {cached_tool_use_id}) \
-         — content still current]"
+         — re-reading is skipped]"
     )
 }
 
@@ -1268,11 +1268,18 @@ struct ScratchDirGuard(std::path::PathBuf);
 impl Drop for ScratchDirGuard {
     fn drop(&mut self) {
         let path = self.0.clone();
-        // Spawn a thread so we don't block the Tokio runtime on drop.
+        // Prefer Tokio's bounded blocking pool; fall back to a raw thread only
+        // when no runtime is available (e.g. during shutdown or in tests).
         // Best-effort: /tmp is ephemeral so lingering files on failure are fine.
-        std::thread::spawn(move || {
-            let _ = std::fs::remove_dir_all(&path);
-        });
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn_blocking(move || {
+                let _ = std::fs::remove_dir_all(&path);
+            });
+        } else {
+            std::thread::spawn(move || {
+                let _ = std::fs::remove_dir_all(&path);
+            });
+        }
     }
 }
 
@@ -2374,8 +2381,8 @@ where
                                     output_len = output.len(),
                                     "tool succeeded"
                                 );
-                                if tc.name == "read_file" {
-                                    // Update dedup cache after a fresh read.
+                                if !should_persist_tool_output(&tc.name) {
+                                    // Update dedup cache after a fresh read_file.
                                     if let Some(path) = read_path {
                                         if let Some(key) = file_cache_key(&path).await {
                                             read_cache.insert(path, (key, tc.id.clone()));

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1173,23 +1173,20 @@ fn should_persist_tool_output(tool_name: &str) -> bool {
 /// Write `content` to `scratch_dir/{uuid}.txt` and return a stub message
 /// containing a preview (up to 2 000 Unicode scalar values) and the file path.
 ///
-/// The filename is a fresh UUID v4, guaranteeing uniqueness even when multiple
-/// tool IDs sanitise to the same string.  The file is created with mode 0600
-/// (unix) so that tool outputs, which may include secrets, are not world-readable.
-/// The blocking open+write runs in `spawn_blocking` to avoid stalling the Tokio
-/// runtime.
+/// The filename is a fresh UUID v4, guaranteeing uniqueness across concurrent
+/// tool calls.  The file is created with mode 0600 (unix) so that tool outputs,
+/// which may include secrets, are not world-readable.  The blocking open+write
+/// runs in `spawn_blocking` to avoid stalling the Tokio runtime.
 ///
 /// If the write fails (e.g. /tmp not writable) the stub is returned inline with
 /// an explicit note that persistence failed, so the model knows the full output
 /// is unavailable rather than silently receiving a truncated fragment.
 ///
-/// Note: individual files can be large (up to the LARGE_TOOL_RESULT_CHARS threshold).
-/// The scratch directory is cleaned up when the agentic loop exits via ScratchDirGuard.
-async fn persist_large_result(
-    _tool_use_id: &str,
-    content: String,
-    scratch_dir: &std::path::Path,
-) -> String {
+/// Note: persistence is triggered when an output *exceeds* `LARGE_TOOL_RESULT_CHARS`;
+/// the written file contains the full output and may therefore be larger than that
+/// threshold.  The scratch directory is cleaned up when the loop exits via
+/// `ScratchDirGuard`.
+async fn persist_large_result(content: String, scratch_dir: &std::path::Path) -> String {
     // Use a UUID filename to guarantee uniqueness regardless of tool_use_id content.
     let path = scratch_dir.join(format!("{}.txt", uuid::Uuid::new_v4()));
     let total = content.len(); // byte count — O(1), good enough for display
@@ -1265,8 +1262,8 @@ async fn file_cache_key(path: &std::path::Path) -> Option<(u128, u64)> {
 /// `drop` uses synchronous `remove_dir_all` because `Drop` cannot be async.
 /// This is intentional: /tmp is a local filesystem so the latency is negligible
 /// even for large files, and the call happens only at loop exit (not on the hot
-/// path).  The number of persisted files is bounded by the number of tool calls
-/// in a single session, each at most LARGE_TOOL_RESULT_CHARS bytes.
+/// path).  Each file is the full output of one tool call (no upper bound enforced
+/// beyond system memory); the file count is bounded by the session's tool-call count.
 struct ScratchDirGuard(std::path::PathBuf);
 
 impl Drop for ScratchDirGuard {
@@ -2220,7 +2217,7 @@ where
                                             .nth(LARGE_TOOL_RESULT_CHARS)
                                             .is_some()
                                         {
-                                            persist_large_result(&tc.id, output, &scratch_dir).await
+                                            persist_large_result(output, &scratch_dir).await
                                         } else {
                                             output
                                         }
@@ -2276,6 +2273,17 @@ where
                                         if let Some((cached_key, cached_id)) = read_cache.get(&path)
                                         {
                                             if *cached_key == key {
+                                                // Emit a ToolUse frame so the UI shows
+                                                // the tool was called (with "unchanged"
+                                                // detail to distinguish from a real read).
+                                                write_frame(
+                                                    writer,
+                                                    &Response::ToolUse {
+                                                        name: tc.name.clone(),
+                                                        detail: format!("{path_str} (unchanged)"),
+                                                    },
+                                                )
+                                                .await?;
                                                 messages.push(Message::tool_result(
                                                     &tc.id,
                                                     file_unchanged_stub(cached_id),
@@ -2367,13 +2375,18 @@ where
                                             read_cache.insert(path, (key, tc.id.clone()));
                                         }
                                     }
-                                    output // no size limit for read_file
+                                    // read_file is injected in full: it is the model's
+                                    // only path to complete file content.  Capping it
+                                    // would leave the model with a truncated view and
+                                    // no way to retrieve the rest.  The dedup cache
+                                    // above avoids re-injecting unchanged files.
+                                    output
                                 } else if output
                                     .char_indices()
                                     .nth(LARGE_TOOL_RESULT_CHARS)
                                     .is_some()
                                 {
-                                    persist_large_result(&tc.id, output, &scratch_dir).await
+                                    persist_large_result(output, &scratch_dir).await
                                 } else {
                                     output
                                 }
@@ -3498,7 +3511,7 @@ mod tests {
     async fn large_tool_output_persisted_to_tmp() {
         let dir = tempfile::TempDir::new().unwrap();
         let big_output = "x".repeat(51_000);
-        let result = persist_large_result("tool-use-id-abc", big_output, dir.path()).await;
+        let result = persist_large_result(big_output, dir.path()).await;
         // Stub must contain a path inside the scratch dir and a Preview section.
         assert!(
             result.contains(dir.path().to_str().unwrap()),
@@ -3535,7 +3548,7 @@ mod tests {
         // The exemption itself is enforced by should_persist_tool_output (tested below).
         let dir = tempfile::TempDir::new().unwrap();
         let big_output = "x".repeat(51_000);
-        let stub = persist_large_result("id", big_output, dir.path()).await;
+        let stub = persist_large_result(big_output, dir.path()).await;
         assert!(
             stub.len() < 10_000,
             "persist_large_result must produce a short stub: len={}",

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1170,35 +1170,28 @@ fn should_persist_tool_output(tool_name: &str) -> bool {
     tool_name != "read_file"
 }
 
-/// Write `content` to `scratch_dir/{safe_id}.txt` and return a stub message
+/// Write `content` to `scratch_dir/{uuid}.txt` and return a stub message
 /// containing a preview (up to 2 000 Unicode scalar values) and the file path.
 ///
-/// `tool_use_id` is sanitised: alphanumerics and `-` are kept as-is; all other
-/// characters (including `/`, `..`, spaces) are replaced with `_` to prevent
-/// path traversal.  The file is created with mode 0600 (unix) so that tool
-/// outputs, which may include secrets, are not world-readable.  The blocking
-/// open+write runs in `spawn_blocking` to avoid stalling the Tokio runtime.
+/// The filename is a fresh UUID v4, guaranteeing uniqueness even when multiple
+/// tool IDs sanitise to the same string.  The file is created with mode 0600
+/// (unix) so that tool outputs, which may include secrets, are not world-readable.
+/// The blocking open+write runs in `spawn_blocking` to avoid stalling the Tokio
+/// runtime.
 ///
 /// If the write fails (e.g. /tmp not writable) the stub is returned inline with
 /// an explicit note that persistence failed, so the model knows the full output
 /// is unavailable rather than silently receiving a truncated fragment.
+///
+/// Note: individual files can be large (up to the LARGE_TOOL_RESULT_CHARS threshold).
+/// The scratch directory is cleaned up when the agentic loop exits via ScratchDirGuard.
 async fn persist_large_result(
-    tool_use_id: &str,
+    _tool_use_id: &str,
     content: String,
     scratch_dir: &std::path::Path,
 ) -> String {
-    // Sanitise: keep only alphanumerics and '-'; replace everything else with '_'.
-    let safe_id: String = tool_use_id
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    let path = scratch_dir.join(format!("{safe_id}.txt"));
+    // Use a UUID filename to guarantee uniqueness regardless of tool_use_id content.
+    let path = scratch_dir.join(format!("{}.txt", uuid::Uuid::new_v4()));
     let total = content.len(); // byte count — O(1), good enough for display
     let preview: String = content.chars().take(2_000).collect();
 
@@ -1241,6 +1234,18 @@ async fn write_tool_output_file(path: &std::path::Path, content: String) -> std:
     }
 }
 
+/// Format the "file unchanged" stub returned by the read_file dedup check.
+///
+/// Centralised so that tests can assert on the same format without duplicating
+/// the string literal — changes to the wording only need to be made once.
+fn file_unchanged_stub(cached_tool_use_id: &str) -> String {
+    format!(
+        "[File unchanged since last read \
+         (see tool_result for call {cached_tool_use_id}) \
+         — content still current]"
+    )
+}
+
 /// Return `(mtime_nanos, size_bytes)` for `path`, or `None` if metadata is
 /// unavailable.  Using both fields reduces false cache-hits on filesystems with
 /// coarse mtime granularity (e.g. FAT32 at 2-second resolution) where content
@@ -1256,11 +1261,17 @@ async fn file_cache_key(path: &std::path::Path) -> Option<(u128, u64)> {
 }
 
 /// RAII guard that removes a directory tree on drop (best-effort).
+///
+/// `drop` uses synchronous `remove_dir_all` because `Drop` cannot be async.
+/// This is intentional: /tmp is a local filesystem so the latency is negligible
+/// even for large files, and the call happens only at loop exit (not on the hot
+/// path).  The number of persisted files is bounded by the number of tool calls
+/// in a single session, each at most LARGE_TOOL_RESULT_CHARS bytes.
 struct ScratchDirGuard(std::path::PathBuf);
 
 impl Drop for ScratchDirGuard {
     fn drop(&mut self) {
-        // Best-effort sync removal; /tmp is ephemeral so failure is acceptable.
+        // Best-effort; /tmp is ephemeral so lingering files on failure are fine.
         let _ = std::fs::remove_dir_all(&self.0);
     }
 }
@@ -1833,7 +1844,8 @@ where
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
-        let _ = std::fs::set_permissions(&scratch_dir, std::fs::Permissions::from_mode(0o700));
+        let _ =
+            tokio::fs::set_permissions(&scratch_dir, std::fs::Permissions::from_mode(0o700)).await;
     }
     let _scratch_guard = ScratchDirGuard(scratch_dir.clone());
 
@@ -2264,12 +2276,10 @@ where
                                         if let Some((cached_key, cached_id)) = read_cache.get(&path)
                                         {
                                             if *cached_key == key {
-                                                let stub = format!(
-                                                    "[File unchanged since last read \
-                                                     (see tool_result for call {cached_id}) \
-                                                     — content still current]"
-                                                );
-                                                messages.push(Message::tool_result(&tc.id, stub));
+                                                messages.push(Message::tool_result(
+                                                    &tc.id,
+                                                    file_unchanged_stub(cached_id),
+                                                ));
                                                 continue;
                                             }
                                         }
@@ -3489,10 +3499,14 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let big_output = "x".repeat(51_000);
         let result = persist_large_result("tool-use-id-abc", big_output, dir.path()).await;
-        // Must reference the file name and contain a Preview section.
+        // Stub must contain a path inside the scratch dir and a Preview section.
         assert!(
-            result.contains("tool-use-id-abc.txt"),
-            "result must contain the file name: {result}"
+            result.contains(dir.path().to_str().unwrap()),
+            "result must contain the scratch dir path: {result}"
+        );
+        assert!(
+            result.contains(".txt"),
+            "result must reference a .txt file: {result}"
         );
         assert!(
             result.contains("Preview:"),
@@ -3504,9 +3518,13 @@ mod tests {
             "stub must be much shorter than 51K chars, got {} chars",
             result.len()
         );
-        // The file itself must exist and contain the full content.
-        let file_path = dir.path().join("tool-use-id-abc.txt");
-        let written = std::fs::read_to_string(&file_path).unwrap();
+        // The file must exist in the scratch dir and contain the full content.
+        let files: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(files.len(), 1, "exactly one file must be written");
+        let written = std::fs::read_to_string(files[0].path()).unwrap();
         assert_eq!(written.len(), 51_000);
     }
 
@@ -3563,24 +3581,15 @@ mod tests {
             .expect("metadata must be available");
         let stub = if let Some((cached_key, cached_id)) = read_cache.get(&file_path) {
             if *cached_key == key2 {
-                format!(
-                    "[File unchanged since last read (see tool_result for call {cached_id}) \
-                     — content still current]"
-                )
+                file_unchanged_stub(cached_id)
             } else {
                 "NOT_STUB".to_string()
             }
         } else {
             "NOT_STUB".to_string()
         };
-        assert!(
-            stub.contains("File unchanged since last read"),
-            "second read must return unchanged stub: {stub}"
-        );
-        assert!(
-            stub.contains("first-call-id"),
-            "stub must reference the first call id: {stub}"
-        );
+        let expected = file_unchanged_stub("first-call-id");
+        assert_eq!(stub, expected, "second read must return unchanged stub");
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1160,13 +1160,25 @@ fn truncate_chars(s: &str, max: usize) -> String {
     out
 }
 
+/// Returns `true` if large outputs from `tool_name` should be persisted to /tmp
+/// rather than injected inline into the model context.
+///
+/// `read_file` is always injected fully: it is the model's only path to access
+/// complete file content.  Persisting it would restrict the model to a 2 KB
+/// preview, severing its ability to read files larger than the preview window.
+fn should_persist_tool_output(tool_name: &str) -> bool {
+    tool_name != "read_file"
+}
+
 /// Write `content` to `scratch_dir/{safe_id}.txt` and return a stub message
 /// containing a 2 KB preview and the path.  Falls back to inline truncation if
 /// the write fails (e.g. /tmp not writable).
 ///
 /// `tool_use_id` is sanitised to alphanumerics and `-` before use as a filename
 /// to prevent path traversal.  The file is created with mode 0600 (unix) so
-/// that tool outputs, which may include secrets, are not world-readable.
+/// that tool outputs, which may include secrets, are not world-readable.  The
+/// blocking open+write is moved to `spawn_blocking` to avoid stalling the Tokio
+/// runtime thread on large outputs.
 async fn persist_large_result(
     tool_use_id: &str,
     content: &str,
@@ -1186,26 +1198,8 @@ async fn persist_large_result(
     let path = scratch_dir.join(format!("{safe_id}.txt"));
     let total = content.len(); // byte count — O(1), good enough for display
     let preview: String = content.chars().take(2_000).collect();
-    let write_ok = async {
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt as _;
-            // Create with mode 0600; fail if the file already exists.
-            let file = std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .mode(0o600)
-                .open(&path)?;
-            use std::io::Write as _;
-            { file }.write_all(content.as_bytes())?;
-            Ok::<_, std::io::Error>(())
-        }
-        #[cfg(not(unix))]
-        {
-            tokio::fs::write(&path, content).await
-        }
-    }
-    .await;
+
+    let write_ok = write_tool_output_file(&path, content).await;
 
     if write_ok.is_ok() {
         format!(
@@ -1217,16 +1211,45 @@ async fn persist_large_result(
     }
 }
 
-/// Return the modification time of `path` as nanoseconds since Unix epoch,
-/// or 0 if metadata is unavailable or the clock predates the epoch.
-async fn file_mtime_nanos(path: &std::path::Path) -> u128 {
-    tokio::fs::metadata(path)
+/// Write `content` to `path` with mode 0600 (unix) using `spawn_blocking` to
+/// avoid stalling the async runtime.  Falls back to a plain async write on
+/// non-unix platforms.
+async fn write_tool_output_file(path: &std::path::Path, content: &str) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        let path = path.to_owned();
+        let content = content.to_owned();
+        tokio::task::spawn_blocking(move || {
+            use std::io::Write as _;
+            use std::os::unix::fs::OpenOptionsExt as _;
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&path)?;
+            file.write_all(content.as_bytes())
+        })
         .await
+        .map_err(std::io::Error::other)?
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::fs::write(path, content).await
+    }
+}
+
+/// Return `(mtime_nanos, size_bytes)` for `path`, or `None` if metadata is
+/// unavailable.  Using both fields reduces false cache-hits on filesystems with
+/// coarse mtime granularity (e.g. FAT32 at 2-second resolution) where content
+/// can change without the mtime advancing.
+async fn file_cache_key(path: &std::path::Path) -> Option<(u128, u64)> {
+    let meta = tokio::fs::metadata(path).await.ok()?;
+    let mtime = meta
+        .modified()
         .ok()
-        .and_then(|m| m.modified().ok())
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_nanos())
-        .unwrap_or(0)
+        .map(|d| d.as_nanos())?;
+    Some((mtime, meta.len()))
 }
 
 /// RAII guard that removes a directory tree on drop (best-effort).
@@ -1811,8 +1834,10 @@ where
     }
     let _scratch_guard = ScratchDirGuard(scratch_dir.clone());
 
-    // read_file dedup cache: path → (mtime_nanos, tool_use_id of last read)
-    let mut read_cache: std::collections::HashMap<std::path::PathBuf, (u128, String)> =
+    // read_file dedup cache: path → ((mtime_nanos, size_bytes), tool_use_id of last read).
+    // Both mtime and size are stored to reduce false hits on filesystems with
+    // coarse mtime granularity where content can change without mtime advancing.
+    let mut read_cache: std::collections::HashMap<std::path::PathBuf, ((u128, u64), String)> =
         Default::default();
 
     loop {
@@ -2173,7 +2198,7 @@ where
                                             output_len = output.len(),
                                             "tool succeeded"
                                         );
-                                        if tc.name == "read_file" {
+                                        if !should_persist_tool_output(&tc.name) {
                                             output
                                         } else if output
                                             .char_indices()
@@ -2227,16 +2252,16 @@ where
                         tracing::debug!(tool = %tc.name, "executing tool");
 
                         // read_file dedup: skip re-read if file is unchanged.
+                        // Both mtime and size are compared to reduce false hits on
+                        // filesystems with coarse mtime resolution (e.g. FAT32).
                         if tc.name == "read_file" {
                             if let Ok(args) = tc.parse_args() {
                                 if let Some(path_str) = args["path"].as_str() {
                                     let path = std::path::PathBuf::from(path_str);
-                                    let mtime = file_mtime_nanos(&path).await;
-                                    if mtime != 0 {
-                                        if let Some((cached_mtime, cached_id)) =
-                                            read_cache.get(&path)
+                                    if let Some(key) = file_cache_key(&path).await {
+                                        if let Some((cached_key, cached_id)) = read_cache.get(&path)
                                         {
-                                            if *cached_mtime == mtime {
+                                            if *cached_key == key {
                                                 let stub = format!(
                                                     "[File unchanged since last read \
                                                      (see tool_result for call {cached_id}) \
@@ -2326,9 +2351,8 @@ where
                                 if tc.name == "read_file" {
                                     // Update dedup cache after a fresh read.
                                     if let Some(path) = read_path {
-                                        let mtime = file_mtime_nanos(&path).await;
-                                        if mtime != 0 {
-                                            read_cache.insert(path, (mtime, tc.id.clone()));
+                                        if let Some(key) = file_cache_key(&path).await {
+                                            read_cache.insert(path, (key, tc.id.clone()));
                                         }
                                     }
                                     output // no size limit for read_file
@@ -3484,31 +3508,17 @@ mod tests {
         assert_eq!(written.len(), 51_000);
     }
 
-    #[tokio::test]
-    async fn read_file_not_truncated_by_persist() {
-        // Verify that persist_large_result is NOT called for read_file outputs,
-        // i.e. read_file content passes through at full size.  We confirm this
-        // by calling persist_large_result with a 51K string and ensuring its
-        // output (the stub) is much shorter — proving the loop would need to
-        // *skip* this call to preserve the full content for read_file.
-        let big_output = "x".repeat(51_000);
-        assert!(
-            big_output.chars().count() > LARGE_TOOL_RESULT_CHARS,
-            "test pre-condition: 51k > LARGE_TOOL_RESULT_CHARS"
-        );
-        let dir = tempfile::TempDir::new().unwrap();
-        let stub = persist_large_result("read-file-test-id", &big_output, dir.path()).await;
-        // The stub is much shorter than 51K — confirming that any code path
-        // that calls persist_large_result for read_file would lose content.
-        // The loop guards against this with the `tc.name == "read_file"` check.
-        assert!(
-            stub.len() < 10_000,
-            "persist_large_result must produce a short stub, not the full content"
-        );
-        assert!(
-            stub.contains("Preview:"),
-            "stub must contain a preview section"
-        );
+    #[test]
+    fn read_file_exempt_from_persistence() {
+        // should_persist_tool_output drives the read_file exemption in the loop.
+        // If this fails, the loop would call persist_large_result for read_file
+        // outputs, replacing full content with a 2KB stub and breaking the model's
+        // only path to read complete files.
+        assert!(!should_persist_tool_output("read_file"));
+        assert!(should_persist_tool_output("shell_command"));
+        assert!(should_persist_tool_output("tmux_capture_pane"));
+        assert!(should_persist_tool_output("tmux_wait"));
+        assert!(should_persist_tool_output("spawn_agent"));
     }
 
     #[tokio::test]
@@ -3517,18 +3527,21 @@ mod tests {
         let file_path = dir.path().join("test_file.txt");
         std::fs::write(&file_path, "hello world content").unwrap();
 
-        let mut read_cache: std::collections::HashMap<std::path::PathBuf, (u128, String)> =
+        let mut read_cache: std::collections::HashMap<std::path::PathBuf, ((u128, u64), String)> =
             Default::default();
 
-        // First read: capture mtime via the shared helper and populate cache.
-        let mtime = file_mtime_nanos(&file_path).await;
-        assert!(mtime != 0);
-        read_cache.insert(file_path.clone(), (mtime, "first-call-id".to_string()));
+        // First read: capture cache key and populate cache.
+        let key = file_cache_key(&file_path)
+            .await
+            .expect("metadata must be available");
+        read_cache.insert(file_path.clone(), (key, "first-call-id".to_string()));
 
-        // Second read with same mtime → dedup should produce a stub.
-        let mtime2 = file_mtime_nanos(&file_path).await;
-        let stub = if let Some((cached_mtime, cached_id)) = read_cache.get(&file_path) {
-            if *cached_mtime == mtime2 {
+        // Second read with same key → dedup should produce a stub.
+        let key2 = file_cache_key(&file_path)
+            .await
+            .expect("metadata must be available");
+        let stub = if let Some((cached_key, cached_id)) = read_cache.get(&file_path) {
+            if *cached_key == key2 {
                 format!(
                     "[File unchanged since last read (see tool_result for call {cached_id}) \
                      — content still current]"
@@ -3555,31 +3568,36 @@ mod tests {
         let file_path = dir.path().join("test_file2.txt");
         std::fs::write(&file_path, "original content").unwrap();
 
-        let mtime1 = file_mtime_nanos(&file_path).await;
+        let key1 = file_cache_key(&file_path)
+            .await
+            .expect("metadata must be available");
 
-        let mut read_cache: std::collections::HashMap<std::path::PathBuf, (u128, String)> =
+        let mut read_cache: std::collections::HashMap<std::path::PathBuf, ((u128, u64), String)> =
             Default::default();
-        read_cache.insert(file_path.clone(), (mtime1, "first-call-id".to_string()));
+        read_cache.insert(file_path.clone(), (key1, "first-call-id".to_string()));
 
-        // Modify the file to change its mtime.
+        // Modify the file to change its mtime and/or size.
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        std::fs::write(&file_path, "modified content").unwrap();
+        std::fs::write(&file_path, "modified content — longer now").unwrap();
 
-        let mtime2 = file_mtime_nanos(&file_path).await;
+        let key2 = file_cache_key(&file_path)
+            .await
+            .expect("metadata must be available");
 
-        // If filesystem has coarse mtime resolution, skip rather than fail.
-        if mtime1 == mtime2 {
+        // If both mtime and size are identical (coarse-resolution filesystem),
+        // the cache would not correctly detect the change — skip rather than fail.
+        if key1 == key2 {
             return;
         }
 
-        let is_stub = if let Some((cached_mtime, _cached_id)) = read_cache.get(&file_path) {
-            *cached_mtime == mtime2
+        let is_stub = if let Some((cached_key, _cached_id)) = read_cache.get(&file_path) {
+            *cached_key == key2
         } else {
             false
         };
         assert!(
             !is_stub,
-            "after file change, dedup must NOT produce a stub (mtimes differ)"
+            "after file change, dedup must NOT produce a stub (cache key differs)"
         );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1171,17 +1171,20 @@ fn should_persist_tool_output(tool_name: &str) -> bool {
 }
 
 /// Write `content` to `scratch_dir/{safe_id}.txt` and return a stub message
-/// containing a 2 KB preview and the path.  Falls back to inline truncation if
-/// the write fails (e.g. /tmp not writable).
+/// containing a preview (up to 2 000 Unicode scalar values) and the file path.
 ///
-/// `tool_use_id` is sanitised to alphanumerics and `-` before use as a filename
-/// to prevent path traversal.  The file is created with mode 0600 (unix) so
-/// that tool outputs, which may include secrets, are not world-readable.  The
-/// blocking open+write is moved to `spawn_blocking` to avoid stalling the Tokio
-/// runtime thread on large outputs.
+/// `tool_use_id` is sanitised: alphanumerics and `-` are kept as-is; all other
+/// characters (including `/`, `..`, spaces) are replaced with `_` to prevent
+/// path traversal.  The file is created with mode 0600 (unix) so that tool
+/// outputs, which may include secrets, are not world-readable.  The blocking
+/// open+write runs in `spawn_blocking` to avoid stalling the Tokio runtime.
+///
+/// If the write fails (e.g. /tmp not writable) the stub is returned inline with
+/// an explicit note that persistence failed, so the model knows the full output
+/// is unavailable rather than silently receiving a truncated fragment.
 async fn persist_large_result(
     tool_use_id: &str,
-    content: &str,
+    content: String,
     scratch_dir: &std::path::Path,
 ) -> String {
     // Sanitise: keep only alphanumerics and '-'; replace everything else with '_'.
@@ -1199,26 +1202,26 @@ async fn persist_large_result(
     let total = content.len(); // byte count — O(1), good enough for display
     let preview: String = content.chars().take(2_000).collect();
 
-    let write_ok = write_tool_output_file(&path, content).await;
-
-    if write_ok.is_ok() {
-        format!(
+    match write_tool_output_file(&path, content).await {
+        Ok(()) => format!(
             "[output truncated: {total} bytes → {path}\n\nPreview:\n{preview}\n...]",
             path = path.display()
-        )
-    } else {
-        truncate_chars(content, 2_000)
+        ),
+        Err(e) => format!(
+            "[output truncated: {total} bytes — could not persist to /tmp ({e}). \
+             Preview:\n{preview}\n...]"
+        ),
     }
 }
 
 /// Write `content` to `path` with mode 0600 (unix) using `spawn_blocking` to
 /// avoid stalling the async runtime.  Falls back to a plain async write on
-/// non-unix platforms.
-async fn write_tool_output_file(path: &std::path::Path, content: &str) -> std::io::Result<()> {
+/// non-unix platforms.  Takes ownership of `content` so the caller avoids an
+/// extra clone for large outputs.
+async fn write_tool_output_file(path: &std::path::Path, content: String) -> std::io::Result<()> {
     #[cfg(unix)]
     {
         let path = path.to_owned();
-        let content = content.to_owned();
         tokio::task::spawn_blocking(move || {
             use std::io::Write as _;
             use std::os::unix::fs::OpenOptionsExt as _;
@@ -2205,8 +2208,7 @@ where
                                             .nth(LARGE_TOOL_RESULT_CHARS)
                                             .is_some()
                                         {
-                                            persist_large_result(&tc.id, &output, &scratch_dir)
-                                                .await
+                                            persist_large_result(&tc.id, output, &scratch_dir).await
                                         } else {
                                             output
                                         }
@@ -2361,7 +2363,7 @@ where
                                     .nth(LARGE_TOOL_RESULT_CHARS)
                                     .is_some()
                                 {
-                                    persist_large_result(&tc.id, &output, &scratch_dir).await
+                                    persist_large_result(&tc.id, output, &scratch_dir).await
                                 } else {
                                     output
                                 }
@@ -3486,8 +3488,8 @@ mod tests {
     async fn large_tool_output_persisted_to_tmp() {
         let dir = tempfile::TempDir::new().unwrap();
         let big_output = "x".repeat(51_000);
-        let result = persist_large_result("tool-use-id-abc", &big_output, dir.path()).await;
-        // Must reference /tmp path (or our temp dir path) and contain Preview.
+        let result = persist_large_result("tool-use-id-abc", big_output, dir.path()).await;
+        // Must reference the file name and contain a Preview section.
         assert!(
             result.contains("tool-use-id-abc.txt"),
             "result must contain the file name: {result}"
@@ -3496,7 +3498,7 @@ mod tests {
             result.contains("Preview:"),
             "result must contain a preview header: {result}"
         );
-        // Must NOT contain the full 51K content inline.
+        // Stub must be much shorter than the original 51K content.
         assert!(
             result.len() < 10_000,
             "stub must be much shorter than 51K chars, got {} chars",
@@ -3508,12 +3510,31 @@ mod tests {
         assert_eq!(written.len(), 51_000);
     }
 
+    #[tokio::test]
+    async fn read_file_not_truncated_by_persist() {
+        // Validate that persist_large_result produces a short stub — confirming
+        // that the loop MUST skip it for read_file to preserve full content.
+        // The exemption itself is enforced by should_persist_tool_output (tested below).
+        let dir = tempfile::TempDir::new().unwrap();
+        let big_output = "x".repeat(51_000);
+        let stub = persist_large_result("id", big_output, dir.path()).await;
+        assert!(
+            stub.len() < 10_000,
+            "persist_large_result must produce a short stub: len={}",
+            stub.len()
+        );
+        assert!(
+            stub.contains("Preview:"),
+            "stub must contain a preview section"
+        );
+    }
+
     #[test]
     fn read_file_exempt_from_persistence() {
         // should_persist_tool_output drives the read_file exemption in the loop.
-        // If this fails, the loop would call persist_large_result for read_file
-        // outputs, replacing full content with a 2KB stub and breaking the model's
-        // only path to read complete files.
+        // If this returns true for read_file, the loop would call persist_large_result
+        // and replace full file content with a stub, breaking the model's only path
+        // to read complete files.
         assert!(!should_persist_tool_output("read_file"));
         assert!(should_persist_tool_output("shell_command"));
         assert!(should_persist_tool_output("tmux_capture_pane"));

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1173,62 +1173,74 @@ fn should_persist_tool_output(tool_name: &str) -> bool {
 /// Write `content` to `scratch_dir/{uuid}.txt` and return a stub message
 /// containing a preview (up to 2 000 Unicode scalar values) and the file path.
 ///
-/// The filename is a fresh UUID v4, guaranteeing uniqueness across concurrent
-/// tool calls.  The file is created with mode 0600 (unix) so that tool outputs,
-/// which may include secrets, are not world-readable.  The blocking open+write
-/// runs in `spawn_blocking` to avoid stalling the Tokio runtime.
+/// **Unix only**: the file is created with mode 0600 so that tool outputs,
+/// which may include secrets, are not world-readable.  On non-unix platforms
+/// this function always returns an inline fallback stub (no disk write) because
+/// equivalent permission hardening is not available.
 ///
-/// If the write fails (e.g. /tmp not writable) the stub is returned inline with
-/// an explicit note that persistence failed, so the model knows the full output
-/// is unavailable rather than silently receiving a truncated fragment.
+/// The filename is a fresh UUID v4, guaranteeing uniqueness across concurrent
+/// tool calls.  The blocking open+write runs in `spawn_blocking` to avoid
+/// stalling the Tokio runtime.
+///
+/// If the write fails the stub is returned inline with an explicit note so the
+/// model knows the full output is unavailable.
 ///
 /// Note: persistence is triggered when an output *exceeds* `LARGE_TOOL_RESULT_CHARS`;
-/// the written file contains the full output and may therefore be larger than that
-/// threshold.  The scratch directory is cleaned up when the loop exits via
-/// `ScratchDirGuard`.
+/// files contain the full output and may therefore be larger than that threshold.
+/// Files are intentionally **not** deleted when the loop exits: stubs in
+/// `carried_messages` reference these paths across Chat turns, and deleting them
+/// would cause `read_file` calls on those paths to fail with NotFound.  /tmp is
+/// cleaned by the OS on reboot.
 async fn persist_large_result(content: String, scratch_dir: &std::path::Path) -> String {
-    // Use a UUID filename to guarantee uniqueness regardless of tool_use_id content.
-    let path = scratch_dir.join(format!("{}.txt", uuid::Uuid::new_v4()));
     let total = content.len(); // byte count — O(1), good enough for display
     let preview: String = content.chars().take(2_000).collect();
 
-    match write_tool_output_file(&path, content).await {
-        Ok(()) => format!(
-            "[output truncated: {total} bytes → {path}\n\nPreview:\n{preview}\n...]",
-            path = path.display()
-        ),
-        Err(e) => format!(
-            "[output truncated: {total} bytes — could not persist to /tmp ({e}). \
+    // Unix: write with mode 0600 and return a path stub.
+    #[cfg(unix)]
+    let result = {
+        let path = scratch_dir.join(format!("{}.txt", uuid::Uuid::new_v4()));
+        match write_tool_output_file(&path, content).await {
+            Ok(()) => format!(
+                "[output truncated: {total} bytes → {path}\n\nPreview:\n{preview}\n...]",
+                path = path.display()
+            ),
+            Err(e) => format!(
+                "[output truncated: {total} bytes — could not persist to /tmp ({e}). \
+                 Preview:\n{preview}\n...]"
+            ),
+        }
+    };
+
+    // Non-unix: no 0600-equivalent permission guarantee, return inline.
+    #[cfg(not(unix))]
+    let result = {
+        let _ = scratch_dir;
+        format!(
+            "[output truncated: {total} bytes — persistence unavailable on this platform. \
              Preview:\n{preview}\n...]"
-        ),
-    }
+        )
+    };
+
+    result
 }
 
-/// Write `content` to `path` with mode 0600 (unix) using `spawn_blocking` to
-/// avoid stalling the async runtime.  Falls back to a plain async write on
-/// non-unix platforms.  Takes ownership of `content` so the caller avoids an
-/// extra clone for large outputs.
+/// Write `content` to `path` with mode 0600 using `spawn_blocking`.
+/// Only compiled on unix; callers on other platforms skip the write entirely.
+#[cfg(unix)]
 async fn write_tool_output_file(path: &std::path::Path, content: String) -> std::io::Result<()> {
-    #[cfg(unix)]
-    {
-        let path = path.to_owned();
-        tokio::task::spawn_blocking(move || {
-            use std::io::Write as _;
-            use std::os::unix::fs::OpenOptionsExt as _;
-            let mut file = std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .mode(0o600)
-                .open(&path)?;
-            file.write_all(content.as_bytes())
-        })
-        .await
-        .map_err(std::io::Error::other)?
-    }
-    #[cfg(not(unix))]
-    {
-        tokio::fs::write(path, content).await
-    }
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || {
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)?;
+        file.write_all(content.as_bytes())
+    })
+    .await
+    .map_err(std::io::Error::other)?
 }
 
 /// Format the "file unchanged" stub returned by the read_file dedup check.
@@ -1257,31 +1269,12 @@ async fn file_cache_key(path: &std::path::Path) -> Option<(u128, u64)> {
     Some((mtime, meta.len()))
 }
 
-/// RAII guard that removes a directory tree when dropped (best-effort).
-///
-/// Deletion is performed on a background thread so the Tokio worker is never
-/// blocked, even when many large files were persisted.  Each file holds one full
-/// tool-call output (no enforced upper bound beyond system memory); the file
-/// count is bounded by the session's tool-call count.
-struct ScratchDirGuard(std::path::PathBuf);
-
-impl Drop for ScratchDirGuard {
-    fn drop(&mut self) {
-        let path = self.0.clone();
-        // Prefer Tokio's bounded blocking pool; fall back to a raw thread only
-        // when no runtime is available (e.g. during shutdown or in tests).
-        // Best-effort: /tmp is ephemeral so lingering files on failure are fine.
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            handle.spawn_blocking(move || {
-                let _ = std::fs::remove_dir_all(&path);
-            });
-        } else {
-            std::thread::spawn(move || {
-                let _ = std::fs::remove_dir_all(&path);
-            });
-        }
-    }
-}
+// Note: there is intentionally no ScratchDirGuard / cleanup for the per-run
+// scratch directory.  Stubs written into tool_result messages reference paths
+// under this directory, and those messages are carried across Chat turns in
+// carried_messages.  Deleting the directory when run_agentic_loop returns would
+// cause read_file calls on those paths to fail with NotFound on the next turn.
+// The directory is left in /tmp for the OS to clean up on reboot.
 
 // ---------------------------------------------------------------------------
 // Memory helpers — canonical DB access for daemon and ACP agent
@@ -1842,33 +1835,35 @@ where
     let mut conclusion_nudge_sent = false;
     let mut last_prompt_tokens: usize;
 
-    // Per-run scratch directory for large tool outputs.  Cleaned up via RAII
-    // on all exit paths (normal return and early `?` returns).
-    let run_id = uuid::Uuid::new_v4().to_string();
-    let scratch_dir = std::path::PathBuf::from(format!("/tmp/amaebi-tool-results/{run_id}"));
-    if let Err(e) = tokio::fs::create_dir_all(&scratch_dir).await {
-        tracing::warn!(
-            path = %scratch_dir.display(),
-            error = %e,
-            "failed to create tool-output scratch dir; large outputs will be truncated inline"
-        );
-    }
-    // Restrict to 0700 so persisted tool outputs are not world-readable.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt as _;
-        if let Err(e) =
-            tokio::fs::set_permissions(&scratch_dir, std::fs::Permissions::from_mode(0o700)).await
+    // Per-run scratch directory for large tool outputs (unix only).
+    // Intentionally not cleaned up on exit — see comment near ScratchDirGuard
+    // for rationale.  /tmp is cleaned by the OS on reboot.
+    let scratch_dir = {
+        #[cfg(unix)]
         {
-            tracing::warn!(
-                path = %scratch_dir.display(),
-                error = %e,
-                "failed to set scratch dir permissions to 0700"
-            );
+            use std::os::unix::fs::PermissionsExt as _;
+            let run_id = uuid::Uuid::new_v4().to_string();
+            let dir = std::path::PathBuf::from(format!("/tmp/amaebi-tool-results/{run_id}"));
+            if let Err(e) = tokio::fs::create_dir_all(&dir).await {
+                tracing::warn!(
+                    path = %dir.display(),
+                    error = %e,
+                    "failed to create tool-output scratch dir; large outputs will be truncated inline"
+                );
+            } else if let Err(e) =
+                tokio::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).await
+            {
+                tracing::warn!(
+                    path = %dir.display(),
+                    error = %e,
+                    "failed to set scratch dir permissions to 0700"
+                );
+            }
+            dir
         }
-    }
-    let _scratch_guard = ScratchDirGuard(scratch_dir.clone());
-
+        #[cfg(not(unix))]
+        std::path::PathBuf::new() // unused placeholder; persist_large_result is no-op on non-unix
+    };
     // read_file dedup cache: path → ((mtime_nanos, size_bytes), tool_use_id of last read).
     // Both mtime and size are stored to reduce false hits on filesystems with
     // coarse mtime granularity where content can change without mtime advancing.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1160,20 +1160,56 @@ fn truncate_chars(s: &str, max: usize) -> String {
     out
 }
 
-/// Write `content` to `scratch_dir/{tool_use_id}.txt` and return a stub message
+/// Write `content` to `scratch_dir/{safe_id}.txt` and return a stub message
 /// containing a 2 KB preview and the path.  Falls back to inline truncation if
 /// the write fails (e.g. /tmp not writable).
+///
+/// `tool_use_id` is sanitised to alphanumerics and `-` before use as a filename
+/// to prevent path traversal.  The file is created with mode 0600 (unix) so
+/// that tool outputs, which may include secrets, are not world-readable.
 async fn persist_large_result(
     tool_use_id: &str,
     content: &str,
     scratch_dir: &std::path::Path,
 ) -> String {
-    let path = scratch_dir.join(format!("{tool_use_id}.txt"));
-    let total = content.chars().count();
+    // Sanitise: keep only alphanumerics and '-'; replace everything else with '_'.
+    let safe_id: String = tool_use_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let path = scratch_dir.join(format!("{safe_id}.txt"));
+    let total = content.len(); // byte count — O(1), good enough for display
     let preview: String = content.chars().take(2_000).collect();
-    if tokio::fs::write(&path, content).await.is_ok() {
+    let write_ok = async {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            // Create with mode 0600; fail if the file already exists.
+            let file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&path)?;
+            use std::io::Write as _;
+            { file }.write_all(content.as_bytes())?;
+            Ok::<_, std::io::Error>(())
+        }
+        #[cfg(not(unix))]
+        {
+            tokio::fs::write(&path, content).await
+        }
+    }
+    .await;
+
+    if write_ok.is_ok() {
         format!(
-            "[output truncated: {total} chars → {path}\n\nPreview:\n{preview}\n...]",
+            "[output truncated: {total} bytes → {path}\n\nPreview:\n{preview}\n...]",
             path = path.display()
         )
     } else {
@@ -1183,13 +1219,24 @@ async fn persist_large_result(
 
 /// Return the modification time of `path` as nanoseconds since Unix epoch,
 /// or 0 if metadata is unavailable or the clock predates the epoch.
-fn file_mtime_nanos(path: &std::path::Path) -> u128 {
-    std::fs::metadata(path)
+async fn file_mtime_nanos(path: &std::path::Path) -> u128 {
+    tokio::fs::metadata(path)
+        .await
         .ok()
         .and_then(|m| m.modified().ok())
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_nanos())
         .unwrap_or(0)
+}
+
+/// RAII guard that removes a directory tree on drop (best-effort).
+struct ScratchDirGuard(std::path::PathBuf);
+
+impl Drop for ScratchDirGuard {
+    fn drop(&mut self) {
+        // Best-effort sync removal; /tmp is ephemeral so failure is acceptable.
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1751,10 +1798,18 @@ where
     let mut conclusion_nudge_sent = false;
     let mut last_prompt_tokens: usize;
 
-    // Per-run scratch directory for large tool outputs.
+    // Per-run scratch directory for large tool outputs.  Cleaned up via RAII
+    // on all exit paths (normal return and early `?` returns).
     let run_id = uuid::Uuid::new_v4().to_string();
     let scratch_dir = std::path::PathBuf::from(format!("/tmp/amaebi-tool-results/{run_id}"));
     tokio::fs::create_dir_all(&scratch_dir).await.ok();
+    // Set directory permissions to 0700 so tool outputs are not world-readable.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let _ = std::fs::set_permissions(&scratch_dir, std::fs::Permissions::from_mode(0o700));
+    }
+    let _scratch_guard = ScratchDirGuard(scratch_dir.clone());
 
     // read_file dedup cache: path → (mtime_nanos, tool_use_id of last read)
     let mut read_cache: std::collections::HashMap<std::path::PathBuf, (u128, String)> =
@@ -2176,7 +2231,7 @@ where
                             if let Ok(args) = tc.parse_args() {
                                 if let Some(path_str) = args["path"].as_str() {
                                     let path = std::path::PathBuf::from(path_str);
-                                    let mtime = file_mtime_nanos(&path);
+                                    let mtime = file_mtime_nanos(&path).await;
                                     if mtime != 0 {
                                         if let Some((cached_mtime, cached_id)) =
                                             read_cache.get(&path)
@@ -2271,7 +2326,7 @@ where
                                 if tc.name == "read_file" {
                                     // Update dedup cache after a fresh read.
                                     if let Some(path) = read_path {
-                                        let mtime = file_mtime_nanos(&path);
+                                        let mtime = file_mtime_nanos(&path).await;
                                         if mtime != 0 {
                                             read_cache.insert(path, (mtime, tc.id.clone()));
                                         }
@@ -2349,7 +2404,6 @@ where
         }
     }
 
-    tokio::fs::remove_dir_all(&scratch_dir).await.ok();
     Ok((final_text, last_prompt_tokens, messages))
 }
 
@@ -3432,15 +3486,29 @@ mod tests {
 
     #[tokio::test]
     async fn read_file_not_truncated_by_persist() {
+        // Verify that persist_large_result is NOT called for read_file outputs,
+        // i.e. read_file content passes through at full size.  We confirm this
+        // by calling persist_large_result with a 51K string and ensuring its
+        // output (the stub) is much shorter — proving the loop would need to
+        // *skip* this call to preserve the full content for read_file.
         let big_output = "x".repeat(51_000);
-        // The loop returns `output` directly for read_file; no truncation.
-        // Verify the constant boundary holds and the output is not trimmed.
         assert!(
             big_output.chars().count() > LARGE_TOOL_RESULT_CHARS,
             "test pre-condition: 51k > LARGE_TOOL_RESULT_CHARS"
         );
-        let result = big_output.clone();
-        assert_eq!(result.chars().count(), 51_000);
+        let dir = tempfile::TempDir::new().unwrap();
+        let stub = persist_large_result("read-file-test-id", &big_output, dir.path()).await;
+        // The stub is much shorter than 51K — confirming that any code path
+        // that calls persist_large_result for read_file would lose content.
+        // The loop guards against this with the `tc.name == "read_file"` check.
+        assert!(
+            stub.len() < 10_000,
+            "persist_large_result must produce a short stub, not the full content"
+        );
+        assert!(
+            stub.contains("Preview:"),
+            "stub must contain a preview section"
+        );
     }
 
     #[tokio::test]
@@ -3453,12 +3521,12 @@ mod tests {
             Default::default();
 
         // First read: capture mtime via the shared helper and populate cache.
-        let mtime = file_mtime_nanos(&file_path);
+        let mtime = file_mtime_nanos(&file_path).await;
         assert!(mtime != 0);
         read_cache.insert(file_path.clone(), (mtime, "first-call-id".to_string()));
 
         // Second read with same mtime → dedup should produce a stub.
-        let mtime2 = file_mtime_nanos(&file_path);
+        let mtime2 = file_mtime_nanos(&file_path).await;
         let stub = if let Some((cached_mtime, cached_id)) = read_cache.get(&file_path) {
             if *cached_mtime == mtime2 {
                 format!(
@@ -3487,17 +3555,17 @@ mod tests {
         let file_path = dir.path().join("test_file2.txt");
         std::fs::write(&file_path, "original content").unwrap();
 
-        let mtime1 = file_mtime_nanos(&file_path);
+        let mtime1 = file_mtime_nanos(&file_path).await;
 
         let mut read_cache: std::collections::HashMap<std::path::PathBuf, (u128, String)> =
             Default::default();
         read_cache.insert(file_path.clone(), (mtime1, "first-call-id".to_string()));
 
         // Modify the file to change its mtime.
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         std::fs::write(&file_path, "modified content").unwrap();
 
-        let mtime2 = file_mtime_nanos(&file_path);
+        let mtime2 = file_mtime_nanos(&file_path).await;
 
         // If filesystem has coarse mtime resolution, skip rather than fail.
         if mtime1 == mtime2 {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1257,19 +1257,22 @@ async fn file_cache_key(path: &std::path::Path) -> Option<(u128, u64)> {
     Some((mtime, meta.len()))
 }
 
-/// RAII guard that removes a directory tree on drop (best-effort).
+/// RAII guard that removes a directory tree when dropped (best-effort).
 ///
-/// `drop` uses synchronous `remove_dir_all` because `Drop` cannot be async.
-/// This is intentional: /tmp is a local filesystem so the latency is negligible
-/// even for large files, and the call happens only at loop exit (not on the hot
-/// path).  Each file is the full output of one tool call (no upper bound enforced
-/// beyond system memory); the file count is bounded by the session's tool-call count.
+/// Deletion is performed on a background thread so the Tokio worker is never
+/// blocked, even when many large files were persisted.  Each file holds one full
+/// tool-call output (no enforced upper bound beyond system memory); the file
+/// count is bounded by the session's tool-call count.
 struct ScratchDirGuard(std::path::PathBuf);
 
 impl Drop for ScratchDirGuard {
     fn drop(&mut self) {
-        // Best-effort; /tmp is ephemeral so lingering files on failure are fine.
-        let _ = std::fs::remove_dir_all(&self.0);
+        let path = self.0.clone();
+        // Spawn a thread so we don't block the Tokio runtime on drop.
+        // Best-effort: /tmp is ephemeral so lingering files on failure are fine.
+        std::thread::spawn(move || {
+            let _ = std::fs::remove_dir_all(&path);
+        });
     }
 }
 
@@ -1836,13 +1839,26 @@ where
     // on all exit paths (normal return and early `?` returns).
     let run_id = uuid::Uuid::new_v4().to_string();
     let scratch_dir = std::path::PathBuf::from(format!("/tmp/amaebi-tool-results/{run_id}"));
-    tokio::fs::create_dir_all(&scratch_dir).await.ok();
-    // Set directory permissions to 0700 so tool outputs are not world-readable.
+    if let Err(e) = tokio::fs::create_dir_all(&scratch_dir).await {
+        tracing::warn!(
+            path = %scratch_dir.display(),
+            error = %e,
+            "failed to create tool-output scratch dir; large outputs will be truncated inline"
+        );
+    }
+    // Restrict to 0700 so persisted tool outputs are not world-readable.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
-        let _ =
-            tokio::fs::set_permissions(&scratch_dir, std::fs::Permissions::from_mode(0o700)).await;
+        if let Err(e) =
+            tokio::fs::set_permissions(&scratch_dir, std::fs::Permissions::from_mode(0o700)).await
+        {
+            tracing::warn!(
+                path = %scratch_dir.display(),
+                error = %e,
+                "failed to set scratch dir permissions to 0700"
+            );
+        }
     }
     let _scratch_guard = ScratchDirGuard(scratch_dir.clone());
 
@@ -2262,87 +2278,7 @@ where
 
                         tracing::debug!(tool = %tc.name, "executing tool");
 
-                        // read_file dedup: skip re-read if file is unchanged.
-                        // Both mtime and size are compared to reduce false hits on
-                        // filesystems with coarse mtime resolution (e.g. FAT32).
-                        if tc.name == "read_file" {
-                            if let Ok(args) = tc.parse_args() {
-                                if let Some(path_str) = args["path"].as_str() {
-                                    let path = std::path::PathBuf::from(path_str);
-                                    if let Some(key) = file_cache_key(&path).await {
-                                        if let Some((cached_key, cached_id)) = read_cache.get(&path)
-                                        {
-                                            if *cached_key == key {
-                                                // Emit a ToolUse frame so the UI shows
-                                                // the tool was called (with "unchanged"
-                                                // detail to distinguish from a real read).
-                                                write_frame(
-                                                    writer,
-                                                    &Response::ToolUse {
-                                                        name: tc.name.clone(),
-                                                        detail: format!("{path_str} (unchanged)"),
-                                                    },
-                                                )
-                                                .await?;
-                                                messages.push(Message::tool_result(
-                                                    &tc.id,
-                                                    file_unchanged_stub(cached_id),
-                                                ));
-                                                continue;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        let tool_detail = {
-                            let args: serde_json::Value = serde_json::from_str(&tc.arguments)
-                                .unwrap_or(serde_json::Value::Null);
-                            match tc.name.as_str() {
-                                "shell_command" => args
-                                    .get("command")
-                                    .and_then(|v| v.as_str())
-                                    .map(|s| {
-                                        if s.len() > 80 {
-                                            format!("{}…", &s[..80])
-                                        } else {
-                                            s.to_string()
-                                        }
-                                    })
-                                    .unwrap_or_default(),
-                                "read_file" => args
-                                    .get("path")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or_default()
-                                    .to_string(),
-                                "edit_file" => args
-                                    .get("path")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or_default()
-                                    .to_string(),
-                                "tmux_send_keys" => args
-                                    .get("keys")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or_default()
-                                    .to_string(),
-                                "tmux_capture_pane" => args
-                                    .get("target")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or_default()
-                                    .to_string(),
-                                _ => String::new(),
-                            }
-                        };
-                        write_frame(
-                            writer,
-                            &Response::ToolUse {
-                                name: tc.name.clone(),
-                                detail: tool_detail,
-                            },
-                        )
-                        .await?;
-
+                        // Parse args once; reused for dedup, tool_detail, and execution.
                         let args = match tc.parse_args() {
                             Ok(v) => v,
                             Err(e) => {
@@ -2354,6 +2290,76 @@ where
                                 continue;
                             }
                         };
+
+                        // read_file dedup: skip re-read if file is unchanged.
+                        // Both mtime and size are compared to reduce false hits on
+                        // filesystems with coarse mtime resolution (e.g. FAT32).
+                        if tc.name == "read_file" {
+                            if let Some(path_str) = args["path"].as_str() {
+                                let path = std::path::PathBuf::from(path_str);
+                                if let Some(key) = file_cache_key(&path).await {
+                                    if let Some((cached_key, cached_id)) = read_cache.get(&path) {
+                                        if *cached_key == key {
+                                            // Emit a ToolUse frame so the UI shows
+                                            // the tool was called (with "unchanged"
+                                            // detail to distinguish from a real read).
+                                            write_frame(
+                                                writer,
+                                                &Response::ToolUse {
+                                                    name: tc.name.clone(),
+                                                    detail: format!("{path_str} (unchanged)"),
+                                                },
+                                            )
+                                            .await?;
+                                            messages.push(Message::tool_result(
+                                                &tc.id,
+                                                file_unchanged_stub(cached_id),
+                                            ));
+                                            continue;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        let tool_detail = match tc.name.as_str() {
+                            "shell_command" => args
+                                .get("command")
+                                .and_then(|v| v.as_str())
+                                .map(|s| {
+                                    if s.len() > 80 {
+                                        format!("{}…", &s[..80])
+                                    } else {
+                                        s.to_string()
+                                    }
+                                })
+                                .unwrap_or_default(),
+                            "read_file" | "edit_file" => args
+                                .get("path")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string(),
+                            "tmux_send_keys" => args
+                                .get("keys")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string(),
+                            "tmux_capture_pane" => args
+                                .get("target")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string(),
+                            _ => String::new(),
+                        };
+                        write_frame(
+                            writer,
+                            &Response::ToolUse {
+                                name: tc.name.clone(),
+                                detail: tool_detail,
+                            },
+                        )
+                        .await?;
+
                         // Extract the read_file path before args is consumed by execute.
                         let read_path: Option<std::path::PathBuf> = if tc.name == "read_file" {
                             args["path"].as_str().map(std::path::PathBuf::from)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1160,6 +1160,38 @@ fn truncate_chars(s: &str, max: usize) -> String {
     out
 }
 
+/// Write `content` to `scratch_dir/{tool_use_id}.txt` and return a stub message
+/// containing a 2 KB preview and the path.  Falls back to inline truncation if
+/// the write fails (e.g. /tmp not writable).
+async fn persist_large_result(
+    tool_use_id: &str,
+    content: &str,
+    scratch_dir: &std::path::Path,
+) -> String {
+    let path = scratch_dir.join(format!("{tool_use_id}.txt"));
+    let total = content.chars().count();
+    let preview: String = content.chars().take(2_000).collect();
+    if tokio::fs::write(&path, content).await.is_ok() {
+        format!(
+            "[output truncated: {total} chars → {path}\n\nPreview:\n{preview}\n...]",
+            path = path.display()
+        )
+    } else {
+        truncate_chars(content, 2_000)
+    }
+}
+
+/// Return the modification time of `path` as nanoseconds since Unix epoch,
+/// or 0 if metadata is unavailable or the clock predates the epoch.
+fn file_mtime_nanos(path: &std::path::Path) -> u128 {
+    std::fs::metadata(path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}
+
 // ---------------------------------------------------------------------------
 // Memory helpers — canonical DB access for daemon and ACP agent
 // ---------------------------------------------------------------------------
@@ -1686,10 +1718,9 @@ where
 /// outputs from blowing the model's context window after extended use.
 const MAX_HISTORY_CHARS: usize = 4_000;
 
-/// Maximum number of Unicode scalar values kept from a single tool-call
-/// output within the current agentic loop iteration.  Large file reads and
-/// shell command outputs are truncated before being fed back to the model.
-const MAX_TOOL_OUTPUT_CHARS: usize = 8_000;
+/// Tool outputs larger than this (chars) are written to /tmp and replaced with a stub.
+/// Matches Claude Code's DEFAULT_MAX_RESULT_SIZE_CHARS. read_file is exempt (always full).
+const LARGE_TOOL_RESULT_CHARS: usize = 50_000;
 
 /// Drive the conversation until Copilot responds with `finish_reason: stop`
 /// (or an error).  Executes tool calls and feeds results back in a loop.
@@ -1719,6 +1750,15 @@ where
     let mut tools_were_used = false;
     let mut conclusion_nudge_sent = false;
     let mut last_prompt_tokens: usize;
+
+    // Per-run scratch directory for large tool outputs.
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let scratch_dir = std::path::PathBuf::from(format!("/tmp/amaebi-tool-results/{run_id}"));
+    tokio::fs::create_dir_all(&scratch_dir).await.ok();
+
+    // read_file dedup cache: path → (mtime_nanos, tool_use_id of last read)
+    let mut read_cache: std::collections::HashMap<std::path::PathBuf, (u128, String)> =
+        Default::default();
 
     loop {
         // Drain any steering corrections that arrived since the last model
@@ -2056,36 +2096,49 @@ where
                     // Steer interrupts are not checked here — they only apply
                     // to the sequential path where we can abort cleanly before
                     // the next tool runs.
-                    let results = futures_util::future::join_all(tool_calls_snapshot.iter().map(
-                        |tc| async move {
-                            let args = match tc.parse_args() {
-                                Ok(v) => v,
-                                Err(e) => {
-                                    tracing::warn!(
-                                        tool = %tc.name,
-                                        error = %e,
-                                        "bad tool arguments"
-                                    );
-                                    return format!("argument error: {e:#}");
-                                }
-                            };
-                            match state.executor.execute(&tc.name, args).await {
-                                Ok(output) => {
-                                    tracing::debug!(
-                                        tool = %tc.name,
-                                        output_len = output.len(),
-                                        "tool succeeded"
-                                    );
-                                    truncate_chars(&output, MAX_TOOL_OUTPUT_CHARS)
-                                }
-                                Err(e) => {
-                                    tracing::warn!(tool = %tc.name, error = %e, "tool failed");
-                                    format!("error: {e:#}")
+                    let results =
+                        futures_util::future::join_all(tool_calls_snapshot.iter().map(|tc| {
+                            let scratch_dir = scratch_dir.clone();
+                            async move {
+                                let args = match tc.parse_args() {
+                                    Ok(v) => v,
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            tool = %tc.name,
+                                            error = %e,
+                                            "bad tool arguments"
+                                        );
+                                        return format!("argument error: {e:#}");
+                                    }
+                                };
+                                match state.executor.execute(&tc.name, args).await {
+                                    Ok(output) => {
+                                        tracing::debug!(
+                                            tool = %tc.name,
+                                            output_len = output.len(),
+                                            "tool succeeded"
+                                        );
+                                        if tc.name == "read_file" {
+                                            output
+                                        } else if output
+                                            .char_indices()
+                                            .nth(LARGE_TOOL_RESULT_CHARS)
+                                            .is_some()
+                                        {
+                                            persist_large_result(&tc.id, &output, &scratch_dir)
+                                                .await
+                                        } else {
+                                            output
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(tool = %tc.name, error = %e, "tool failed");
+                                        format!("error: {e:#}")
+                                    }
                                 }
                             }
-                        },
-                    ))
-                    .await;
+                        }))
+                        .await;
 
                     for (tc, result) in tool_calls_snapshot.iter().zip(results) {
                         messages.push(Message::tool_result(&tc.id, result));
@@ -2117,6 +2170,31 @@ where
                         }
 
                         tracing::debug!(tool = %tc.name, "executing tool");
+
+                        // read_file dedup: skip re-read if file is unchanged.
+                        if tc.name == "read_file" {
+                            if let Ok(args) = tc.parse_args() {
+                                if let Some(path_str) = args["path"].as_str() {
+                                    let path = std::path::PathBuf::from(path_str);
+                                    let mtime = file_mtime_nanos(&path);
+                                    if mtime != 0 {
+                                        if let Some((cached_mtime, cached_id)) =
+                                            read_cache.get(&path)
+                                        {
+                                            if *cached_mtime == mtime {
+                                                let stub = format!(
+                                                    "[File unchanged since last read \
+                                                     (see tool_result for call {cached_id}) \
+                                                     — content still current]"
+                                                );
+                                                messages.push(Message::tool_result(&tc.id, stub));
+                                                continue;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
 
                         let tool_detail = {
                             let args: serde_json::Value = serde_json::from_str(&tc.arguments)
@@ -2176,6 +2254,12 @@ where
                                 continue;
                             }
                         };
+                        // Extract the read_file path before args is consumed by execute.
+                        let read_path: Option<std::path::PathBuf> = if tc.name == "read_file" {
+                            args["path"].as_str().map(std::path::PathBuf::from)
+                        } else {
+                            None
+                        };
 
                         let result = match state.executor.execute(&tc.name, args).await {
                             Ok(output) => {
@@ -2184,7 +2268,24 @@ where
                                     output_len = output.len(),
                                     "tool succeeded"
                                 );
-                                truncate_chars(&output, MAX_TOOL_OUTPUT_CHARS)
+                                if tc.name == "read_file" {
+                                    // Update dedup cache after a fresh read.
+                                    if let Some(path) = read_path {
+                                        let mtime = file_mtime_nanos(&path);
+                                        if mtime != 0 {
+                                            read_cache.insert(path, (mtime, tc.id.clone()));
+                                        }
+                                    }
+                                    output // no size limit for read_file
+                                } else if output
+                                    .char_indices()
+                                    .nth(LARGE_TOOL_RESULT_CHARS)
+                                    .is_some()
+                                {
+                                    persist_large_result(&tc.id, &output, &scratch_dir).await
+                                } else {
+                                    output
+                                }
                             }
                             Err(e) => {
                                 tracing::warn!(tool = %tc.name, error = %e, "tool failed");
@@ -2248,6 +2349,7 @@ where
         }
     }
 
+    tokio::fs::remove_dir_all(&scratch_dir).await.ok();
     Ok((final_text, last_prompt_tokens, messages))
 }
 
@@ -3295,6 +3397,121 @@ mod tests {
         assert_eq!(
             compact_model("bedrock/us.anthropic.claude-opus-4-6-v1:0"),
             format!("bedrock/{}", crate::provider::DEFAULT_MODEL),
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // persist_large_result tests
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn large_tool_output_persisted_to_tmp() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let big_output = "x".repeat(51_000);
+        let result = persist_large_result("tool-use-id-abc", &big_output, dir.path()).await;
+        // Must reference /tmp path (or our temp dir path) and contain Preview.
+        assert!(
+            result.contains("tool-use-id-abc.txt"),
+            "result must contain the file name: {result}"
+        );
+        assert!(
+            result.contains("Preview:"),
+            "result must contain a preview header: {result}"
+        );
+        // Must NOT contain the full 51K content inline.
+        assert!(
+            result.len() < 10_000,
+            "stub must be much shorter than 51K chars, got {} chars",
+            result.len()
+        );
+        // The file itself must exist and contain the full content.
+        let file_path = dir.path().join("tool-use-id-abc.txt");
+        let written = std::fs::read_to_string(&file_path).unwrap();
+        assert_eq!(written.len(), 51_000);
+    }
+
+    #[tokio::test]
+    async fn read_file_not_truncated_by_persist() {
+        let big_output = "x".repeat(51_000);
+        // The loop returns `output` directly for read_file; no truncation.
+        // Verify the constant boundary holds and the output is not trimmed.
+        assert!(
+            big_output.chars().count() > LARGE_TOOL_RESULT_CHARS,
+            "test pre-condition: 51k > LARGE_TOOL_RESULT_CHARS"
+        );
+        let result = big_output.clone();
+        assert_eq!(result.chars().count(), 51_000);
+    }
+
+    #[tokio::test]
+    async fn read_file_dedup_returns_stub_when_unchanged() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file_path = dir.path().join("test_file.txt");
+        std::fs::write(&file_path, "hello world content").unwrap();
+
+        let mut read_cache: std::collections::HashMap<std::path::PathBuf, (u128, String)> =
+            Default::default();
+
+        // First read: capture mtime via the shared helper and populate cache.
+        let mtime = file_mtime_nanos(&file_path);
+        assert!(mtime != 0);
+        read_cache.insert(file_path.clone(), (mtime, "first-call-id".to_string()));
+
+        // Second read with same mtime → dedup should produce a stub.
+        let mtime2 = file_mtime_nanos(&file_path);
+        let stub = if let Some((cached_mtime, cached_id)) = read_cache.get(&file_path) {
+            if *cached_mtime == mtime2 {
+                format!(
+                    "[File unchanged since last read (see tool_result for call {cached_id}) \
+                     — content still current]"
+                )
+            } else {
+                "NOT_STUB".to_string()
+            }
+        } else {
+            "NOT_STUB".to_string()
+        };
+        assert!(
+            stub.contains("File unchanged since last read"),
+            "second read must return unchanged stub: {stub}"
+        );
+        assert!(
+            stub.contains("first-call-id"),
+            "stub must reference the first call id: {stub}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_file_dedup_re_reads_when_changed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file_path = dir.path().join("test_file2.txt");
+        std::fs::write(&file_path, "original content").unwrap();
+
+        let mtime1 = file_mtime_nanos(&file_path);
+
+        let mut read_cache: std::collections::HashMap<std::path::PathBuf, (u128, String)> =
+            Default::default();
+        read_cache.insert(file_path.clone(), (mtime1, "first-call-id".to_string()));
+
+        // Modify the file to change its mtime.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        std::fs::write(&file_path, "modified content").unwrap();
+
+        let mtime2 = file_mtime_nanos(&file_path);
+
+        // If filesystem has coarse mtime resolution, skip rather than fail.
+        if mtime1 == mtime2 {
+            return;
+        }
+
+        let is_stub = if let Some((cached_mtime, _cached_id)) = read_cache.get(&file_path) {
+            *cached_mtime == mtime2
+        } else {
+            false
+        };
+        assert!(
+            !is_stub,
+            "after file change, dedup must NOT produce a stub (mtimes differ)"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Large-output /tmp persistence (Unit 1, unix only)**: non-\`read_file\` tool outputs >50K chars are written to \`/tmp/amaebi-tool-results/{run_id}/{uuid}.txt\` with mode 0600; the model receives a 2000-char preview + file path stub instead of the full content. On non-unix platforms the stub is returned inline (no disk write). \`read_file\` is fully exempt — no size limit. This replaces the previous blunt 8K truncation.
- **Scratch dir lifetime**: the per-run directory is intentionally **not** deleted on loop exit — stubs in \`carried_messages\` reference these paths across Chat turns, and cleanup would cause \`read_file\` calls on those paths to fail. /tmp is cleaned by the OS on reboot.
- **read_file dedup (Unit 2)**: if the same file is read again in the same session with unchanged metadata (mtime + size), the model receives a one-line "metadata unchanged" stub referencing the original call's tool_result. A \`ToolUse\` frame with "(unchanged)" detail is still emitted so the UI shows the call.
- Tool args parsed once per call in the sequential path; reused for dedup, UI detail, and execution.
- \`file_cache_key\` async helper returns \`(mtime_nanos, size_bytes)\` — both fields reduce false hits on coarse-resolution filesystems.
- \`file_unchanged_stub()\` helper centralises the dedup stub format.
- \`should_persist_tool_output()\` encapsulates the exemption policy; used consistently in both parallel and sequential paths.
- \`write_tool_output_file\` takes ownership of the content \`String\` to avoid cloning large outputs; is \`#[cfg(unix)]\` only.
- Scratch dir created with mode 0700; creation/chmod failures logged as warnings.

## Test plan

- [x] \`large_tool_output_persisted_to_tmp\`: 51K output → stub contains path + preview; file written in full
- [x] \`read_file_not_truncated_by_persist\`: \`persist_large_result\` produces short stub
- [x] \`read_file_exempt_from_persistence\`: \`should_persist_tool_output\` returns false for read_file
- [x] \`read_file_dedup_returns_stub_when_unchanged\`: same cache key → stub equals \`file_unchanged_stub()\` output
- [x] \`read_file_dedup_re_reads_when_changed\`: different cache key → cache miss, full content returned
- [x] \`cargo test && cargo fmt --check && cargo clippy -- -D warnings\` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)