### PR TITLE
revert(tools): remove lines param from tmux_capture_pane

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -188,21 +188,13 @@ async fn shell_command(
     Ok(result)
 }
 
-/// Capture recent lines from a tmux pane's scrollback history.
-///
-/// Uses `tmux capture-pane -S -{lines}` where `-S` receives a negative numeric
-/// argument, starting `lines` lines before the bottom of the pane history and
-/// returning at most `lines` lines. This avoids flooding the LLM with thousands
-/// of lines of build output when only the tail matters.
+/// Capture the visible text of a tmux pane.
 async fn tmux_capture_pane(args: serde_json::Value) -> Result<String> {
+    // Default to the first pane if no target provided.
     let target = args["target"].as_str().unwrap_or("%0");
-    // Clamp to at least 1: lines=0 would produce "-S -0" which disables the
-    // limit and could capture unbounded history.
-    let lines = args["lines"].as_u64().unwrap_or(200).max(1);
-    let start = format!("-{lines}");
 
     let output = Command::new("tmux")
-        .args(["capture-pane", "-t", target, "-p", "-S", &start])
+        .args(["capture-pane", "-t", target, "-p"])
         .output()
         .await
         .context("spawning tmux capture-pane")?;
@@ -662,7 +654,7 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
             "type": "function",
             "function": {
                 "name": "tmux_capture_pane",
-                "description": "Capture and return recent text from a tmux pane.",
+                "description": "Capture and return the current visible text of a tmux pane.",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -670,13 +662,6 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                             "type": "string",
                             "description": "tmux target pane (e.g. '%0', '0:1.0'). \
                                             Defaults to %0."
-                        },
-                        "lines": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "description": "Number of lines of scrollback to capture \
-                                            (minimum: 1, default: 200). Use a smaller value \
-                                            to reduce token usage when only the tail matters."
                         }
                     },
                     "required": []


### PR DESCRIPTION
## Summary

Reverts #91.

The `lines` parameter adds little practical value: pane 4 (117×111) with `-S -200` captures up to 311 lines, but tmux strips trailing whitespace so real output is already just 5–7 KB — dictated by content density, not line count. The parameter adds schema complexity without improving the LLM's access to build output. For cases where complete output matters, the right pattern is \`ninja 2>&1 | tee build.log\` + \`read_file\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)