### PR TITLE
feat(tools): tmux_send_keys defaults to pressing Enter after text

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -221,12 +221,16 @@ async fn tmux_send_keys(args: serde_json::Value) -> Result<String> {
         .as_str()
         .context("tmux_send_keys: missing string argument 'keys'")?;
     let target = args["target"].as_str().unwrap_or("%0");
+    // Default true: append an Enter keystroke so text is submitted.
+    // Set enter=false to type text without pressing Enter (e.g. partial input).
+    let press_enter = args["enter"].as_bool().unwrap_or(true);
 
-    let output = Command::new("tmux")
-        .args(["send-keys", "-t", target, keys])
-        .output()
-        .await
-        .context("spawning tmux send-keys")?;
+    let mut cmd = Command::new("tmux");
+    cmd.args(["send-keys", "-t", target, keys]);
+    if press_enter {
+        cmd.arg("Enter");
+    }
+    let output = cmd.output().await.context("spawning tmux send-keys")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -687,19 +691,25 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
             "type": "function",
             "function": {
                 "name": "tmux_send_keys",
-                "description": "Send keystrokes to a tmux pane. Use for interactive \
-                                programs (e.g. pressing Enter, Ctrl-C). For background \
-                                tasks prefer shell_command.",
+                "description": "Send keystrokes to a tmux pane and press Enter to submit \
+                                (default). Use for interactive programs (e.g. answering \
+                                prompts, sending messages to another agent). Set enter=false \
+                                to type text without submitting. For background tasks prefer \
+                                shell_command.",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "keys": {
                             "type": "string",
-                            "description": "Keys to send, e.g. 'q', 'Enter', 'C-c'."
+                            "description": "Text or key name to send, e.g. 'hello world', 'C-c', 'q'."
                         },
                         "target": {
                             "type": "string",
                             "description": "tmux target pane. Defaults to %0."
+                        },
+                        "enter": {
+                            "type": "boolean",
+                            "description": "Whether to press Enter after sending keys. Default true."
                         }
                     },
                     "required": ["keys"]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -227,7 +227,9 @@ async fn tmux_send_keys(args: serde_json::Value) -> Result<String> {
 
     let mut cmd = Command::new("tmux");
     cmd.args(["send-keys", "-t", target, keys]);
-    if press_enter {
+    // Avoid a double Enter when the caller explicitly sends the "Enter" key name.
+    // e.g. keys="Enter", enter=true (default) should press Enter once, not twice.
+    if press_enter && keys != "Enter" {
         cmd.arg("Enter");
     }
     let output = cmd.output().await.context("spawning tmux send-keys")?;
@@ -701,7 +703,10 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                     "properties": {
                         "keys": {
                             "type": "string",
-                            "description": "Text or key name to send, e.g. 'hello world', 'C-c', 'q'."
+                            "description": "Text to type or a single tmux key name \
+                                            (e.g. 'hello world', 'q'). \
+                                            For control keys like 'C-c' or 'Escape' set \
+                                            enter=false to avoid an unwanted trailing Enter."
                         },
                         "target": {
                             "type": "string",
@@ -709,7 +714,8 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                         },
                         "enter": {
                             "type": "boolean",
-                            "description": "Whether to press Enter after sending keys. Default true."
+                            "description": "Press Enter after sending keys (default true). \
+                                            Set false for control keys or partial input."
                         }
                     },
                     "required": ["keys"]
@@ -1429,6 +1435,61 @@ mod tests {
         .await
         .unwrap();
         assert!(result.starts_with("timeout:"), "got: {result}");
+    }
+
+    // ---- tmux_send_keys enter parameter ------------------------------------
+
+    #[test]
+    fn tmux_send_keys_schema_has_enter_field() {
+        let schemas = tool_schemas(true);
+        let schema = schemas
+            .iter()
+            .find(|s| s["function"]["name"] == "tmux_send_keys")
+            .expect("tmux_send_keys schema must exist");
+        let props = &schema["function"]["parameters"]["properties"];
+        assert!(
+            !props["enter"].is_null(),
+            "tmux_send_keys schema must expose 'enter' property"
+        );
+        assert_eq!(
+            props["enter"]["type"].as_str(),
+            Some("boolean"),
+            "'enter' property must be boolean"
+        );
+    }
+
+    #[tokio::test]
+    async fn tmux_send_keys_appends_enter_by_default() {
+        // Verify that when enter=true (default) and keys != "Enter",
+        // the "Enter" key is appended as a separate tmux argument.
+        // We call the function with a pane that doesn't exist; the test only
+        // checks argument construction so we assert on the error (pane not found)
+        // rather than needing a real tmux session.
+        let result = tmux_send_keys(serde_json::json!({
+            "keys": "hello",
+            "target": "nonexistent_pane_xyz",
+            "enter": true
+        }))
+        .await;
+        // Expect a tmux error (pane not found), not a panic or argument error.
+        assert!(result.is_err(), "should fail on nonexistent pane");
+    }
+
+    #[tokio::test]
+    async fn tmux_send_keys_no_double_enter_when_keys_is_enter() {
+        // If keys="Enter" and enter=true (default), only one Enter should be sent.
+        // Regression: previously this would send "Enter" Enter — two keystrokes.
+        // We verify by checking that the fn doesn't panic on this input combination.
+        let result = tmux_send_keys(serde_json::json!({
+            "keys": "Enter",
+            "target": "nonexistent_pane_xyz"
+        }))
+        .await;
+        // Expect a tmux error (pane not found), not an argument panic.
+        assert!(
+            result.is_err(),
+            "should fail on nonexistent pane, not panic"
+        );
     }
 
     #[tokio::test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -215,6 +215,25 @@ async fn tmux_capture_pane(args: serde_json::Value) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
+/// Build the argument list for `tmux send-keys`.
+///
+/// Extracted as a pure function so the argument-construction logic can be
+/// unit-tested without requiring a real tmux session.
+fn tmux_send_keys_argv(target: &str, keys: &str, press_enter: bool) -> Vec<String> {
+    let mut args = vec![
+        "send-keys".to_string(),
+        "-t".to_string(),
+        target.to_string(),
+        keys.to_string(),
+    ];
+    // Avoid a double Enter when the caller explicitly sends the "Enter" key name.
+    // e.g. keys="Enter", enter=true (default) presses Enter once, not twice.
+    if press_enter && keys != "Enter" {
+        args.push("Enter".to_string());
+    }
+    args
+}
+
 /// Send keystrokes to a tmux pane (for interactive programs).
 async fn tmux_send_keys(args: serde_json::Value) -> Result<String> {
     let keys = args["keys"]
@@ -222,17 +241,16 @@ async fn tmux_send_keys(args: serde_json::Value) -> Result<String> {
         .context("tmux_send_keys: missing string argument 'keys'")?;
     let target = args["target"].as_str().unwrap_or("%0");
     // Default true: append an Enter keystroke so text is submitted.
-    // Set enter=false to type text without pressing Enter (e.g. partial input).
+    // Set enter=false for single keypresses (q, Escape, C-c, arrow keys, etc.)
+    // to avoid an unintended trailing Enter.
     let press_enter = args["enter"].as_bool().unwrap_or(true);
 
-    let mut cmd = Command::new("tmux");
-    cmd.args(["send-keys", "-t", target, keys]);
-    // Avoid a double Enter when the caller explicitly sends the "Enter" key name.
-    // e.g. keys="Enter", enter=true (default) should press Enter once, not twice.
-    if press_enter && keys != "Enter" {
-        cmd.arg("Enter");
-    }
-    let output = cmd.output().await.context("spawning tmux send-keys")?;
+    let argv = tmux_send_keys_argv(target, keys, press_enter);
+    let output = Command::new("tmux")
+        .args(&argv)
+        .output()
+        .await
+        .context("spawning tmux send-keys")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -703,10 +721,10 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                     "properties": {
                         "keys": {
                             "type": "string",
-                            "description": "Text to type or a single tmux key name \
-                                            (e.g. 'hello world', 'q'). \
-                                            For control keys like 'C-c' or 'Escape' set \
-                                            enter=false to avoid an unwanted trailing Enter."
+                            "description": "Text to type (e.g. 'hello world'). \
+                                            For single keypresses such as 'q', 'Escape', \
+                                            'C-c', or arrow keys, set enter=false to avoid \
+                                            an unintended trailing Enter keystroke."
                         },
                         "target": {
                             "type": "string",
@@ -1458,38 +1476,33 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn tmux_send_keys_appends_enter_by_default() {
-        // Verify that when enter=true (default) and keys != "Enter",
-        // the "Enter" key is appended as a separate tmux argument.
-        // We call the function with a pane that doesn't exist; the test only
-        // checks argument construction so we assert on the error (pane not found)
-        // rather than needing a real tmux session.
-        let result = tmux_send_keys(serde_json::json!({
-            "keys": "hello",
-            "target": "nonexistent_pane_xyz",
-            "enter": true
-        }))
-        .await;
-        // Expect a tmux error (pane not found), not a panic or argument error.
-        assert!(result.is_err(), "should fail on nonexistent pane");
+    #[test]
+    fn tmux_send_keys_argv_appends_enter_by_default() {
+        // Default (press_enter=true) appends "Enter" as a separate arg.
+        let argv = tmux_send_keys_argv("%0", "hello world", true);
+        assert_eq!(argv.last().map(|s| s.as_str()), Some("Enter"));
+        assert!(argv.contains(&"hello world".to_string()));
     }
 
-    #[tokio::test]
-    async fn tmux_send_keys_no_double_enter_when_keys_is_enter() {
-        // If keys="Enter" and enter=true (default), only one Enter should be sent.
-        // Regression: previously this would send "Enter" Enter — two keystrokes.
-        // We verify by checking that the fn doesn't panic on this input combination.
-        let result = tmux_send_keys(serde_json::json!({
-            "keys": "Enter",
-            "target": "nonexistent_pane_xyz"
-        }))
-        .await;
-        // Expect a tmux error (pane not found), not an argument panic.
-        assert!(
-            result.is_err(),
-            "should fail on nonexistent pane, not panic"
-        );
+    #[test]
+    fn tmux_send_keys_argv_no_enter_when_disabled() {
+        let argv = tmux_send_keys_argv("%0", "hello", false);
+        assert!(!argv.contains(&"Enter".to_string()));
+    }
+
+    #[test]
+    fn tmux_send_keys_argv_no_double_enter_when_keys_is_enter() {
+        // keys="Enter" + press_enter=true should produce only one "Enter" in argv.
+        let argv = tmux_send_keys_argv("%0", "Enter", true);
+        let enter_count = argv.iter().filter(|a| a.as_str() == "Enter").count();
+        assert_eq!(enter_count, 1, "must send exactly one Enter: {argv:?}");
+    }
+
+    #[test]
+    fn tmux_send_keys_argv_control_key_no_trailing_enter() {
+        // C-c with enter=false must not append Enter (would confuse the program).
+        let argv = tmux_send_keys_argv("%0", "C-c", false);
+        assert!(!argv.contains(&"Enter".to_string()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- \`tmux_send_keys\` now appends an \`Enter\` keystroke by default (\`enter=true\`)
- Fixes the bug where the LLM sent \`"Enter"\` as literal text instead of a keystroke
- Set \`enter=false\` to type text without submitting (e.g. partial input)
- Schema updated with \`enter: bool\` parameter and clearer description

**Before:** two calls needed — send text, then send \`"Enter"\` separately  
**After:** one call sends text + Enter as proper tmux key sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)