### PR TITLE
feat(tools): add switch_model tool for autonomous mid-session model switching

### DIFF
--- a/src/agent_server.rs
+++ b/src/agent_server.rs
@@ -277,7 +277,7 @@ impl acp::Agent for AmaebiAgent {
                 true,
             )
             .await
-            .map(|(text, tokens, _messages)| (text, tokens)) // discard messages Vec
+            .map(|(text, tokens, _messages, _model)| (text, tokens)) // discard messages Vec
             .map_err(|e| format!("{e:#}"));
             let _ = result_tx.send(outcome);
             // Dropping write_half closes the pipe, signalling EOF to the reader.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1834,6 +1834,8 @@ where
     let mut tools_were_used = false;
     let mut conclusion_nudge_sent = false;
     let mut last_prompt_tokens: usize;
+    // Mutable so switch_model tool calls can change the model mid-session.
+    let mut current_model = model.to_string();
 
     // Per-run scratch directory for large tool outputs (unix only).
     // Intentionally not cleaned up on exit — see comment near ScratchDirGuard
@@ -1888,10 +1890,10 @@ where
         // Token management and auth-error retry are handled inside invoke_model.
         let resp = invoke_model(
             state,
-            model,
+            &current_model,
             &messages,
             &schemas,
-            response_max_tokens(model),
+            response_max_tokens(&current_model),
             writer,
         )
         .await?;
@@ -2209,6 +2211,7 @@ where
                     let results =
                         futures_util::future::join_all(tool_calls_snapshot.iter().map(|tc| {
                             let scratch_dir = scratch_dir.clone();
+                            let current_model = current_model.clone();
                             async move {
                                 let args = match tc.parse_args() {
                                     Ok(v) => v,
@@ -2223,14 +2226,14 @@ where
                                 };
                                 tracing::debug!(
                                     tool = %tc.name,
-                                    model = %model,
+                                    model = %current_model,
                                     "executing tool"
                                 );
                                 match state.executor.execute(&tc.name, args).await {
                                     Ok(output) => {
                                         tracing::debug!(
                                             tool = %tc.name,
-                                            model = %model,
+                                            model = %current_model,
                                             output_len = output.len(),
                                             "tool succeeded"
                                         );
@@ -2284,7 +2287,7 @@ where
                             break;
                         }
 
-                        tracing::debug!(tool = %tc.name, model = %model, "executing tool");
+                        tracing::debug!(tool = %tc.name, model = %current_model, "executing tool");
 
                         // Parse args once; reused for dedup, tool_detail, and execution.
                         let args = match tc.parse_args() {
@@ -2308,9 +2311,6 @@ where
                                 if let Some(key) = file_cache_key(&path).await {
                                     if let Some((cached_key, cached_id)) = read_cache.get(&path) {
                                         if *cached_key == key {
-                                            // Emit a ToolUse frame so the UI shows
-                                            // the tool was called (with "unchanged"
-                                            // detail to distinguish from a real read).
                                             write_frame(
                                                 writer,
                                                 &Response::ToolUse {
@@ -2357,6 +2357,11 @@ where
                                 .and_then(|v| v.as_str())
                                 .unwrap_or_default()
                                 .to_string(),
+                            "switch_model" => args
+                                .get("model")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string(),
                             _ => String::new(),
                         };
                         write_frame(
@@ -2367,6 +2372,39 @@ where
                             },
                         )
                         .await?;
+
+                        // switch_model is handled here, not by the executor.
+                        if tc.name == "switch_model" {
+                            let result = match args["model"].as_str() {
+                                None => "error: switch_model: missing 'model' argument".to_string(),
+                                Some(new_model) if new_model.trim().is_empty() => {
+                                    "error: switch_model: 'model' must not be empty".to_string()
+                                }
+                                Some(new_model) => {
+                                    let old = std::mem::replace(
+                                        &mut current_model,
+                                        new_model.to_string(),
+                                    );
+                                    tracing::info!(
+                                        old = %old,
+                                        new = %current_model,
+                                        "model switched by LLM"
+                                    );
+                                    write_frame(
+                                        writer,
+                                        &Response::Text {
+                                            chunk: format!(
+                                                "[model switched: {old} → {current_model}]\n"
+                                            ),
+                                        },
+                                    )
+                                    .await?;
+                                    format!("Model switched to {current_model}")
+                                }
+                            };
+                            messages.push(Message::tool_result(&tc.id, result));
+                            continue;
+                        }
 
                         // Extract the read_file path before args is consumed by execute.
                         let read_path: Option<std::path::PathBuf> = if tc.name == "read_file" {
@@ -2379,7 +2417,7 @@ where
                             Ok(output) => {
                                 tracing::debug!(
                                     tool = %tc.name,
-                                    model = %model,
+                                    model = %current_model,
                                     output_len = output.len(),
                                     "tool succeeded"
                                 );

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -487,6 +487,10 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
     // Tracks the session_id so context is reset when the client switches sessions.
     let mut carried_messages: Option<Vec<Message>> = None;
     let mut carried_session_id: Option<String> = None;
+    // Carries the effective model across Chat turns: updated when switch_model
+    // is called inside run_agentic_loop so the new model persists for the
+    // remainder of the session, not just the current agentic loop invocation.
+    let mut carried_model: Option<String> = None;
     // Count of unsolicited frames received while an agentic loop was running.
     // Flushed as error responses after the loop releases the writer lock.
     let mut pending_unsolicited: u32 = 0;
@@ -600,7 +604,7 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                     match run_agentic_loop(&state, &model, messages, &mut sink, &mut steer_rx, true)
                         .await
                     {
-                        Ok((final_text, _, _)) => {
+                        Ok((final_text, _, _, _)) => {
                             store_conversation(
                                 &state,
                                 &sid,
@@ -665,6 +669,7 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                     &mut conn_state,
                     &mut carried_messages,
                     &mut carried_session_id,
+                    &mut carried_model,
                     &mut chat_session_guard,
                     prompt,
                     tmux_pane,
@@ -723,7 +728,7 @@ async fn drive_agentic_loop(
     expected_sid: &str,
     messages: Vec<Message>,
     model: &str,
-) -> Option<anyhow::Result<(String, usize, Vec<Message>)>> {
+) -> Option<anyhow::Result<(String, usize, Vec<Message>, String)>> {
     let (steer_tx, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(16);
     let writer_loop = Arc::clone(writer);
     let state_loop = Arc::clone(state);
@@ -898,7 +903,7 @@ async fn handle_resume_request(
     };
     flush_pending_unsolicited(writer, conn_state.pending_unsolicited).await;
     match result {
-        Ok((response_text, _, _)) => {
+        Ok((response_text, _, _, _)) => {
             store_conversation(
                 state,
                 &session_id,
@@ -937,6 +942,7 @@ async fn handle_chat_request(
     conn_state: &mut ConnState<'_>,
     carried_messages: &mut Option<Vec<Message>>,
     carried_session_id: &mut Option<String>,
+    carried_model: &mut Option<String>,
     chat_session_guard: &mut Option<ActiveSessionGuard>,
     prompt: String,
     tmux_pane: Option<String>,
@@ -1038,16 +1044,18 @@ async fn handle_chat_request(
     };
 
     let pre_send_tokens = count_message_tokens(&messages);
-    let threshold = compaction_threshold_tokens(&model);
+    // If a switch_model call updated the model in a previous turn, use it.
+    let effective_model = carried_model.take().unwrap_or(model);
+    let threshold = compaction_threshold_tokens(&effective_model);
     let Some(loop_result) =
-        drive_agentic_loop(state, writer, conn_state, &sid, messages, &model).await
+        drive_agentic_loop(state, writer, conn_state, &sid, messages, &effective_model).await
     else {
         return Ok(ConnAction::Break);
     };
     flush_pending_unsolicited(writer, conn_state.pending_unsolicited).await;
 
     match loop_result {
-        Ok((response_text, prompt_tokens, final_messages)) => {
+        Ok((response_text, prompt_tokens, final_messages, final_model)) => {
             store_conversation(
                 state,
                 &sid,
@@ -1075,7 +1083,7 @@ async fn handle_chat_request(
                     tokio::spawn(compact_session(
                         Arc::clone(state),
                         sid.clone(),
-                        compact_model(&model),
+                        compact_model(&effective_model),
                         HOT_TAIL_PAIRS * 2,
                     ));
                 }
@@ -1084,6 +1092,8 @@ async fn handle_chat_request(
             drop(w);
             *carried_messages = Some(final_messages);
             *carried_session_id = Some(sid.clone());
+            // Persist the final model so the next turn starts with it.
+            *carried_model = Some(final_model);
         }
         Err(e) => {
             tracing::error!(error = %e, "agentic loop error");
@@ -1097,6 +1107,7 @@ async fn handle_chat_request(
             .await;
             *carried_messages = None;
             *carried_session_id = None;
+            *carried_model = None;
         }
     }
     Ok(ConnAction::Continue)
@@ -1168,6 +1179,25 @@ fn truncate_chars(s: &str, max: usize) -> String {
 /// preview, severing its ability to read files larger than the preview window.
 fn should_persist_tool_output(tool_name: &str) -> bool {
     tool_name != "read_file"
+}
+
+/// Validate and normalise the `model` argument from a `switch_model` tool call.
+///
+/// Returns `Ok(trimmed_model)` on success, or `Err(error_message)` if the
+/// argument is missing or blank.  Trimming ensures leading/trailing whitespace
+/// does not silently change provider routing behaviour.
+fn parse_switch_model_arg(raw: Option<&str>) -> Result<String, String> {
+    match raw {
+        None => Err("error: switch_model: missing 'model' argument".to_string()),
+        Some(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                Err("error: switch_model: 'model' must not be empty".to_string())
+            } else {
+                Ok(trimmed.to_string())
+            }
+        }
+    }
 }
 
 /// Write `content` to `scratch_dir/{uuid}.txt` and return a stub message
@@ -1825,7 +1855,7 @@ pub(crate) async fn run_agentic_loop<W>(
     writer: &mut W,
     steer_rx: &mut tokio::sync::mpsc::Receiver<Option<String>>,
     include_spawn_agent: bool,
-) -> Result<(String, usize, Vec<Message>)>
+) -> Result<(String, usize, Vec<Message>, String)>
 where
     W: AsyncWriteExt + Unpin,
 {
@@ -2375,16 +2405,11 @@ where
 
                         // switch_model is handled here, not by the executor.
                         if tc.name == "switch_model" {
-                            let result = match args["model"].as_str() {
-                                None => "error: switch_model: missing 'model' argument".to_string(),
-                                Some(new_model) if new_model.trim().is_empty() => {
-                                    "error: switch_model: 'model' must not be empty".to_string()
-                                }
-                                Some(new_model) => {
-                                    let old = std::mem::replace(
-                                        &mut current_model,
-                                        new_model.to_string(),
-                                    );
+                            let result = match parse_switch_model_arg(args["model"].as_str()) {
+                                Err(e) => e,
+                                Ok(new_model) => {
+                                    let old =
+                                        std::mem::replace(&mut current_model, new_model.clone());
                                     tracing::info!(
                                         old = %old,
                                         new = %current_model,
@@ -2506,7 +2531,7 @@ where
         }
     }
 
-    Ok((final_text, last_prompt_tokens, messages))
+    Ok((final_text, last_prompt_tokens, messages, current_model))
 }
 
 // ---------------------------------------------------------------------------
@@ -2784,7 +2809,7 @@ async fn run_cron_job(state: Arc<DaemonState>, job: &cron::CronJob) {
     let result = run_agentic_loop(&state, &model, messages, &mut sink, &mut steer_rx, true).await;
 
     let (output, run_ok) = match result {
-        Ok((final_text, _, _)) => {
+        Ok((final_text, _, _, _)) => {
             store_conversation(&state, &session_id, &job.description, &final_text).await;
             (final_text, true)
         }
@@ -3697,34 +3722,39 @@ mod tests {
         );
     }
 
-    // ---- switch_model validation -------------------------------------------
+    // ---- switch_model validation (via parse_switch_model_arg helper) -------
+
+    #[test]
+    fn switch_model_rejects_missing_arg() {
+        assert!(parse_switch_model_arg(None).is_err());
+    }
 
     #[test]
     fn switch_model_rejects_empty_string() {
-        let model = "";
-        assert!(model.trim().is_empty(), "empty string must be rejected");
+        assert!(parse_switch_model_arg(Some("")).is_err());
     }
 
     #[test]
     fn switch_model_rejects_whitespace_only() {
-        let model = "   ";
-        assert!(
-            model.trim().is_empty(),
-            "whitespace-only string must be rejected by the guard"
-        );
+        assert!(parse_switch_model_arg(Some("   ")).is_err());
     }
 
     #[test]
     fn switch_model_accepts_valid_model_name() {
-        for valid in [
+        for raw in [
             "claude-sonnet-4.6",
             "bedrock/claude-opus-4.6",
             "copilot/gpt-4o",
         ] {
-            assert!(
-                !valid.trim().is_empty(),
-                "valid model name must pass the guard: {valid}"
-            );
+            let result = parse_switch_model_arg(Some(raw));
+            assert!(result.is_ok(), "valid model must be accepted: {raw}");
+            assert_eq!(result.unwrap(), raw);
         }
+    }
+
+    #[test]
+    fn switch_model_trims_whitespace() {
+        let result = parse_switch_model_arg(Some("  claude-opus-4.6  "));
+        assert_eq!(result.unwrap(), "claude-opus-4.6");
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3696,4 +3696,35 @@ mod tests {
             "after file change, dedup must NOT produce a stub (cache key differs)"
         );
     }
+
+    // ---- switch_model validation -------------------------------------------
+
+    #[test]
+    fn switch_model_rejects_empty_string() {
+        let model = "";
+        assert!(model.trim().is_empty(), "empty string must be rejected");
+    }
+
+    #[test]
+    fn switch_model_rejects_whitespace_only() {
+        let model = "   ";
+        assert!(
+            model.trim().is_empty(),
+            "whitespace-only string must be rejected by the guard"
+        );
+    }
+
+    #[test]
+    fn switch_model_accepts_valid_model_name() {
+        for valid in [
+            "claude-sonnet-4.6",
+            "bedrock/claude-opus-4.6",
+            "copilot/gpt-4o",
+        ] {
+            assert!(
+                !valid.trim().is_empty(),
+                "valid model name must pass the guard: {valid}"
+            );
+        }
+    }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -590,7 +590,7 @@ async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<Stri
 
     // Fix 5: child agents do not get spawn_agent in their tool schema to
     // prevent unbounded recursion at the schema level.
-    let (final_text, _, _) = crate::daemon::run_agentic_loop(
+    let (final_text, _, _, _) = crate::daemon::run_agentic_loop(
         &child_state,
         &model,
         messages,
@@ -885,7 +885,7 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                         "description": (format!(
                             "Model to switch to. Supports provider/model format \
                              (e.g. bedrock/claude-opus-4.6, copilot/gpt-4o). \
-                             Current default: {}.",
+                             Project default: {}.",
                             crate::provider::DEFAULT_MODEL
                         ))
                     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -864,6 +864,37 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
             }
         }));
     }
+
+    // switch_model is always available (not gated on include_spawn_agent).
+    // The tool has no executor implementation — it is intercepted and handled
+    // directly inside run_agentic_loop before the executor is called.
+    schemas.push(serde_json::json!({
+        "type": "function",
+        "function": {
+            "name": "switch_model",
+            "description": "Switch the AI model used for the remainder of this session. \
+                            Use a more capable model (e.g. claude-opus-4.6) for tasks \
+                            requiring deep reasoning or planning; switch back to a faster \
+                            model (e.g. claude-sonnet-4.6) for routine work like reading \
+                            files or running commands.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "model": {
+                        "type": "string",
+                        "description": (format!(
+                            "Model to switch to. Supports provider/model format \
+                             (e.g. bedrock/claude-opus-4.6, copilot/gpt-4o). \
+                             Current default: {}.",
+                            crate::provider::DEFAULT_MODEL
+                        ))
+                    }
+                },
+                "required": ["model"]
+            }
+        }
+    }));
+
     schemas
 }
 
@@ -895,6 +926,7 @@ mod tests {
             "read_file",
             "edit_file",
             "spawn_agent",
+            "switch_model",
         ] {
             assert!(names.contains(&name), "missing tool: {name}");
         }
@@ -1424,6 +1456,41 @@ mod tests {
         assert!(
             result.starts_with("timeout:"),
             "directory must not match: {result}"
+        );
+    }
+
+    // ---- switch_model schema -----------------------------------------------
+
+    #[test]
+    fn switch_model_schema_present_in_all_modes() {
+        // switch_model must always be available, regardless of include_spawn_agent.
+        for include in [true, false] {
+            let schemas = tool_schemas(include);
+            let names: Vec<&str> = schemas
+                .iter()
+                .map(|s| s["function"]["name"].as_str().unwrap())
+                .collect();
+            assert!(
+                names.contains(&"switch_model"),
+                "switch_model must be present when include_spawn_agent={include}"
+            );
+        }
+    }
+
+    #[test]
+    fn switch_model_schema_has_required_model_param() {
+        let schemas = tool_schemas(true);
+        let schema = schemas
+            .iter()
+            .find(|s| s["function"]["name"] == "switch_model")
+            .expect("switch_model schema must exist");
+        let required = schema["function"]["parameters"]["required"]
+            .as_array()
+            .expect("required must be an array");
+        let required_names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(
+            required_names.contains(&"model"),
+            "switch_model must require 'model': {required_names:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Adds a \`switch_model\` tool so the LLM can autonomously change models mid-session
- Use case: upgrade to \`claude-opus-4.6\` for reasoning-heavy tasks; switch back to \`claude-sonnet-4.6\` for routine work (file reads, shell commands) — all within the same conversation context
- The tool is intercepted inside \`run_agentic_loop\` before reaching the executor (no executor impl needed); \`current_model\` local variable replaces the immutable \`model\` parameter
- Switch is announced to the user as a \`[model switched: old → new]\` text frame
- Supports all existing provider/model formats (\`bedrock/claude-opus-4.6\`, \`copilot/gpt-4o\`, etc.)

## Test plan

- [x] \`switch_model_schema_present_in_all_modes\`: schema visible regardless of \`include_spawn_agent\`
- [x] \`switch_model_schema_has_required_model_param\`: \`model\` is in \`required\` array
- [x] \`cargo test && cargo fmt --check && cargo clippy -- -D warnings\` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)