### PR TITLE
feat(daemon): add model field to tool execution debug logs

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2221,10 +2221,16 @@ where
                                         return format!("argument error: {e:#}");
                                     }
                                 };
+                                tracing::debug!(
+                                    tool = %tc.name,
+                                    model = %model,
+                                    "executing tool"
+                                );
                                 match state.executor.execute(&tc.name, args).await {
                                     Ok(output) => {
                                         tracing::debug!(
                                             tool = %tc.name,
+                                            model = %model,
                                             output_len = output.len(),
                                             "tool succeeded"
                                         );
@@ -2278,7 +2284,7 @@ where
                             break;
                         }
 
-                        tracing::debug!(tool = %tc.name, "executing tool");
+                        tracing::debug!(tool = %tc.name, model = %model, "executing tool");
 
                         // Parse args once; reused for dedup, tool_detail, and execution.
                         let args = match tc.parse_args() {
@@ -2373,6 +2379,7 @@ where
                             Ok(output) => {
                                 tracing::debug!(
                                     tool = %tc.name,
+                                    model = %model,
                                     output_len = output.len(),
                                     "tool succeeded"
                                 );


### PR DESCRIPTION
## Summary

- Add `model=` field to every `executing tool` and `tool succeeded` DEBUG log line in `run_agentic_loop`
- Covers both the sequential execution path and the parallel `spawn_agent` path
- With this change, logs now show which model was active when each tool ran, making it easy to trace subagent sessions and `switch_model` transitions

**Before:**
```
DEBUG executing tool tool=edit_file
DEBUG tool succeeded tool=edit_file output_len=47
```

**After:**
```
DEBUG executing tool tool=edit_file model="bedrock/claude-opus-4.6[1m]"
DEBUG tool succeeded tool=edit_file model="bedrock/claude-opus-4.6[1m]" output_len=47
```

Since subagents call `run_agentic_loop` with their own model string, their tool logs will naturally show the subagent model — no extra plumbing needed.

## Test plan

- [x] `cargo test` — 34/34 pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)