### PR TITLE
fix(tools): document [1m] suffix in switch_model tool description

### DIFF
--- a/src/tools.rs
+++ b/src/tools.rs
@@ -949,6 +949,8 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                         "description": (format!(
                             "Model to switch to. Supports provider/model format \
                              (e.g. bedrock/claude-opus-4.6, copilot/gpt-4o). \
+                             Append [1m] to request 1M-context Bedrock inference \
+                             (e.g. claude-sonnet-4.6[1m], claude-opus-4.6[1m]). \
                              Project default: {}.",
                             crate::provider::DEFAULT_MODEL
                         ))


### PR DESCRIPTION
## Summary

- The `switch_model` tool's `model` parameter description did not mention the `[1m]` suffix for requesting 1M-context Bedrock inference
- When a user typed `/model claude-sonnet-4.6[1m]`, Claude had no basis to know the suffix was valid and could strip it before calling the tool
- Added explicit examples (`claude-sonnet-4.6[1m]`, `claude-opus-4.6[1m]`) to the description

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)