### PR TITLE
fix(daemon): truncate shell_command detail on char boundaries (UTF-8 panic)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2364,6 +2364,10 @@ async fn flush_pending_unsolicited(
 const MAX_PROMPT_CHARS: usize = 4_000;
 /// Maximum chars stored for an assistant response in session history.
 const MAX_RESPONSE_CHARS: usize = 8_000;
+/// Maximum Unicode scalars kept in the `shell_command` preview returned by
+/// [`summarise_tool_detail`] before appending `…`.  Kept at module scope so
+/// regression tests can reference it without duplicating the `80` literal.
+const SHELL_DETAIL_MAX_CHARS: usize = 80;
 
 /// Truncate `s` to at most `max` Unicode scalar values (including the marker).
 ///
@@ -2411,17 +2415,21 @@ fn should_persist_tool_output(tool_name: &str) -> bool {
 /// when the original was longer; other tools return their primary argument
 /// verbatim.
 fn summarise_tool_detail(tool_name: &str, args: &serde_json::Value) -> String {
-    const SHELL_MAX_CHARS: usize = 80;
     match tool_name {
         "shell_command" => args
             .get("command")
             .and_then(|v| v.as_str())
             .map(|s| {
-                if s.chars().nth(SHELL_MAX_CHARS).is_some() {
-                    let head: String = s.chars().take(SHELL_MAX_CHARS).collect();
-                    format!("{head}…")
-                } else {
-                    s.to_string()
+                // `char_indices().nth(N)` walks the string once and returns
+                // the byte offset of the (N+1)-th Unicode scalar, which is by
+                // construction a char boundary.  Slicing at that byte offset
+                // is safe and avoids the double-iteration / allocation of the
+                // prior `chars().nth` + `chars().take(N).collect()` approach.
+                // `None` means the string has ≤ SHELL_DETAIL_MAX_CHARS chars
+                // and fits verbatim.
+                match s.char_indices().nth(SHELL_DETAIL_MAX_CHARS) {
+                    Some((byte_idx, _)) => format!("{}…", &s[..byte_idx]),
+                    None => s.to_string(),
                 }
             })
             .unwrap_or_default(),
@@ -5887,13 +5895,13 @@ mod tests {
 
     #[test]
     fn summarise_tool_detail_shell_long_ascii_truncates_with_ellipsis() {
-        let cmd: String = "x".repeat(200);
+        let cmd: String = "x".repeat(SHELL_DETAIL_MAX_CHARS * 2);
         let args = serde_json::json!({ "command": cmd });
         let detail = summarise_tool_detail("shell_command", &args);
-        // 80 chars + `…`; total 81 Unicode scalars.
-        assert_eq!(detail.chars().count(), 81);
+        // SHELL_DETAIL_MAX_CHARS chars + `…`.
+        assert_eq!(detail.chars().count(), SHELL_DETAIL_MAX_CHARS + 1);
         assert!(detail.ends_with('…'));
-        assert!(detail.starts_with(&"x".repeat(80)));
+        assert!(detail.starts_with(&"x".repeat(SHELL_DETAIL_MAX_CHARS)));
     }
 
     #[test]
@@ -5907,20 +5915,20 @@ mod tests {
         let args = serde_json::json!({ "command": cmd });
         // Should return Ok without panicking.
         let detail = summarise_tool_detail("shell_command", &args);
-        // If the input has >80 chars, output should end with '…'; in any case
-        // the first 80 chars must be a valid prefix of the input by char count.
-        if cmd.chars().count() > 80 {
+        // If the input has more than SHELL_DETAIL_MAX_CHARS chars, output
+        // should end with '…'; otherwise it's returned verbatim.
+        if cmd.chars().count() > SHELL_DETAIL_MAX_CHARS {
             assert!(detail.ends_with('…'));
-            assert_eq!(detail.chars().count(), 81);
+            assert_eq!(detail.chars().count(), SHELL_DETAIL_MAX_CHARS + 1);
         } else {
             assert_eq!(detail, cmd);
         }
     }
 
     #[test]
-    fn summarise_tool_detail_shell_exactly_80_chars_not_truncated() {
-        // Boundary: exactly 80 Unicode scalars → return as-is, no ellipsis.
-        let cmd: String = "a".repeat(80);
+    fn summarise_tool_detail_shell_exactly_max_chars_not_truncated() {
+        // Boundary: exactly SHELL_DETAIL_MAX_CHARS scalars → return as-is, no ellipsis.
+        let cmd: String = "a".repeat(SHELL_DETAIL_MAX_CHARS);
         let args = serde_json::json!({ "command": cmd.clone() });
         assert_eq!(summarise_tool_detail("shell_command", &args), cmd);
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2400,6 +2400,55 @@ fn should_persist_tool_output(tool_name: &str) -> bool {
     tool_name != "read_file"
 }
 
+/// Build a short human-readable detail string for a tool call, used in
+/// `Response::ToolUse` frames so the client can render something like
+/// `shell_command: ls -la`.
+///
+/// Must operate on Unicode scalar boundaries: shell commands routinely contain
+/// non-ASCII text (Chinese comments, em-dashes) and a raw byte slice like
+/// `&s[..80]` panics when the truncation index falls inside a multi-byte UTF-8
+/// sequence.  The `shell_command` branch truncates at 80 chars, appending `…`
+/// when the original was longer; other tools return their primary argument
+/// verbatim.
+fn summarise_tool_detail(tool_name: &str, args: &serde_json::Value) -> String {
+    const SHELL_MAX_CHARS: usize = 80;
+    match tool_name {
+        "shell_command" => args
+            .get("command")
+            .and_then(|v| v.as_str())
+            .map(|s| {
+                if s.chars().nth(SHELL_MAX_CHARS).is_some() {
+                    let head: String = s.chars().take(SHELL_MAX_CHARS).collect();
+                    format!("{head}…")
+                } else {
+                    s.to_string()
+                }
+            })
+            .unwrap_or_default(),
+        "read_file" | "edit_file" => args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        "tmux_send_keys" => args
+            .get("keys")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        "tmux_capture_pane" => args
+            .get("target")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        "switch_model" => args
+            .get("model")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        _ => String::new(),
+    }
+}
+
 /// Validate and normalise the `model` argument from a `switch_model` tool call.
 ///
 /// Returns `Ok(trimmed_model)` on success, or `Err(error_message)` if the
@@ -3983,40 +4032,7 @@ where
                             }
                         }
 
-                        let tool_detail = match tc.name.as_str() {
-                            "shell_command" => args
-                                .get("command")
-                                .and_then(|v| v.as_str())
-                                .map(|s| {
-                                    if s.len() > 80 {
-                                        format!("{}…", &s[..80])
-                                    } else {
-                                        s.to_string()
-                                    }
-                                })
-                                .unwrap_or_default(),
-                            "read_file" | "edit_file" => args
-                                .get("path")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            "tmux_send_keys" => args
-                                .get("keys")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            "tmux_capture_pane" => args
-                                .get("target")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            "switch_model" => args
-                                .get("model")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            _ => String::new(),
-                        };
+                        let tool_detail = summarise_tool_detail(&tc.name, &args);
                         write_frame(
                             writer,
                             &Response::ToolUse {
@@ -5857,5 +5873,75 @@ mod tests {
             sanitize_remote_url("ssh://user@host/path"),
             "ssh://***@host/path"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // summarise_tool_detail
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn summarise_tool_detail_shell_short_ascii() {
+        let args = serde_json::json!({ "command": "ls -la" });
+        assert_eq!(summarise_tool_detail("shell_command", &args), "ls -la");
+    }
+
+    #[test]
+    fn summarise_tool_detail_shell_long_ascii_truncates_with_ellipsis() {
+        let cmd: String = "x".repeat(200);
+        let args = serde_json::json!({ "command": cmd });
+        let detail = summarise_tool_detail("shell_command", &args);
+        // 80 chars + `…`; total 81 Unicode scalars.
+        assert_eq!(detail.chars().count(), 81);
+        assert!(detail.ends_with('…'));
+        assert!(detail.starts_with(&"x".repeat(80)));
+    }
+
+    #[test]
+    fn summarise_tool_detail_shell_multibyte_utf8_does_not_panic() {
+        // Regression: previously the branch used `&s[..80]` (byte slice) which
+        // panicked when byte 80 landed inside a multi-byte UTF-8 sequence.
+        // This exact input — mixed ASCII + Chinese + em-dash + newline + path —
+        // was seen in a real Bedrock supervision turn and crashed the daemon.
+        let cmd = "# 看 flash-attention 的 tile_scheduler 怎么 dispatch m_block — \
+                   它是怎么避免 OOB 的\nsed -n '440,480p' /home/yuankuns/path.hpp";
+        let args = serde_json::json!({ "command": cmd });
+        // Should return Ok without panicking.
+        let detail = summarise_tool_detail("shell_command", &args);
+        // If the input has >80 chars, output should end with '…'; in any case
+        // the first 80 chars must be a valid prefix of the input by char count.
+        if cmd.chars().count() > 80 {
+            assert!(detail.ends_with('…'));
+            assert_eq!(detail.chars().count(), 81);
+        } else {
+            assert_eq!(detail, cmd);
+        }
+    }
+
+    #[test]
+    fn summarise_tool_detail_shell_exactly_80_chars_not_truncated() {
+        // Boundary: exactly 80 Unicode scalars → return as-is, no ellipsis.
+        let cmd: String = "a".repeat(80);
+        let args = serde_json::json!({ "command": cmd.clone() });
+        assert_eq!(summarise_tool_detail("shell_command", &args), cmd);
+    }
+
+    #[test]
+    fn summarise_tool_detail_read_file_returns_path() {
+        let args = serde_json::json!({ "path": "/tmp/foo.rs" });
+        assert_eq!(summarise_tool_detail("read_file", &args), "/tmp/foo.rs");
+        assert_eq!(summarise_tool_detail("edit_file", &args), "/tmp/foo.rs");
+    }
+
+    #[test]
+    fn summarise_tool_detail_missing_arg_returns_empty() {
+        let args = serde_json::json!({});
+        assert_eq!(summarise_tool_detail("shell_command", &args), "");
+        assert_eq!(summarise_tool_detail("read_file", &args), "");
+    }
+
+    #[test]
+    fn summarise_tool_detail_unknown_tool_returns_empty() {
+        let args = serde_json::json!({ "command": "ignored" });
+        assert_eq!(summarise_tool_detail("bogus_tool", &args), "");
     }
 }


### PR DESCRIPTION
## Summary

Live daemon crash, reproduced with a shell_command containing mixed ASCII + Chinese + em-dash:

    thread 'tokio-rt-worker' panicked at src/daemon.rs:3201:58:
    byte index 80 is not a char boundary; it is inside '么' (bytes 78..81) of
    \`# 看 flash-attention 的 tile_scheduler 怎么 dispatch m_block — ...\`

The \`Response::ToolUse\` detail builder used \`&s[..80]\` to produce a short command preview. Byte slicing on a \`str\` panics when the cut index lands inside a multi-byte UTF-8 sequence — easy to trigger with any command containing non-ASCII text near byte 80 (Chinese comments, em-dashes, CJK paths, emoji). The whole agentic-loop task panics, the client sees \`agent error: loop panicked\`, and the chat REPL has to restart.

## Fix

- Extract the detail builder into \`summarise_tool_detail(tool_name, args)\` so it's unit-testable.
- Switch the \`shell_command\` branch to char-boundary truncation via \`s.chars().take(80).collect()\` instead of byte slicing.
- Other tools (read_file, edit_file, tmux_send_keys, tmux_capture_pane, switch_model) already returned their primary arg verbatim and were safe.

## Test plan

New unit tests in \`summarise_tool_detail_*\`:
- short ASCII returned verbatim
- long ASCII truncated at 80 chars with trailing \`…\`
- **regression**: the exact multibyte input that crashed the daemon runs without panicking
- exactly 80 chars → not truncated (boundary)
- missing argument → empty string
- unknown tool name → empty string

- [x] \`cargo test\` — 535 unit + 35 integration, all green
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy -- -D warnings\`
- [x] Based on latest master

🤖 Generated with [Claude Code](https://claude.com/claude-code)