### PR TITLE
feat(chat): add --resume/-r with shared interactive session picker

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,10 +37,20 @@ pub enum Command {
         /// Cannot be combined with --resume.
         #[arg(long, conflicts_with = "resume")]
         detach: bool,
-        /// Resume a prior session by UUID, loading its full chronological history
+        /// Resume a prior session, loading its full chronological history
         /// instead of the normal sliding-window context (last N turns).
+        ///
+        /// Accepts a session UUID (or unique prefix ≥ 4 chars).  If no value
+        /// is given, an interactive picker lists this directory's session
+        /// history (newest first) for you to choose from.
         /// Cannot be combined with --detach.
-        #[arg(long, conflicts_with = "detach")]
+        #[arg(
+            short = 'r',
+            long,
+            conflicts_with = "detach",
+            num_args = 0..=1,
+            default_missing_value = "",
+        )]
         resume: Option<String>,
     },
     /// Start an interactive multi-turn chat session (long connection).
@@ -56,6 +66,18 @@ pub enum Command {
         /// Format: [provider/]model — e.g. bedrock/claude-sonnet-4.6, copilot/gpt-4o.
         #[arg(long)]
         model: Option<String>,
+        /// Resume a prior chat session, loading its full chronological history.
+        ///
+        /// Accepts a session UUID (or unique prefix ≥ 4 chars).  If no value
+        /// is given, an interactive picker lists this directory's session
+        /// history (newest first) for you to choose from.
+        #[arg(
+            short = 'r',
+            long,
+            num_args = 0..=1,
+            default_missing_value = "",
+        )]
+        resume: Option<String>,
     },
     /// Authenticate with GitHub Copilot via the device flow.
     Auth {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,15 +40,19 @@ pub enum Command {
         /// Resume a prior session, loading its full chronological history
         /// instead of the normal sliding-window context (last N turns).
         ///
-        /// Accepts a session UUID (or unique prefix ≥ 4 chars).  If no value
-        /// is given, an interactive picker lists this directory's session
-        /// history (newest first) for you to choose from.
+        /// To pass a UUID you must use `=` syntax (`-r=<uuid>` or
+        /// `--resume=<uuid>`) so the value cannot be confused with the
+        /// required `<PROMPT>` positional.  Bare `-r` / `--resume` opens an
+        /// interactive picker of this directory's session history.
+        ///
+        /// Accepts a session UUID (or unique prefix ≥ 4 chars).
         /// Cannot be combined with --detach.
         #[arg(
             short = 'r',
             long,
             conflicts_with = "detach",
             num_args = 0..=1,
+            require_equals = true,
             default_missing_value = "",
         )]
         resume: Option<String>,
@@ -68,13 +72,17 @@ pub enum Command {
         model: Option<String>,
         /// Resume a prior chat session, loading its full chronological history.
         ///
-        /// Accepts a session UUID (or unique prefix ≥ 4 chars).  If no value
-        /// is given, an interactive picker lists this directory's session
-        /// history (newest first) for you to choose from.
+        /// To pass a UUID you must use `=` syntax (`-r=<uuid>` or
+        /// `--resume=<uuid>`) so the value cannot be confused with the
+        /// optional `[PROMPT]` positional.  Bare `-r` / `--resume` opens an
+        /// interactive picker of this directory's session history.
+        ///
+        /// Accepts a session UUID (or unique prefix ≥ 4 chars).
         #[arg(
             short = 'r',
             long,
             num_args = 0..=1,
+            require_equals = true,
             default_missing_value = "",
         )]
         resume: Option<String>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -897,6 +897,7 @@ pub async fn run_chat_loop(
     socket: PathBuf,
     initial_prompt: Option<String>,
     model: Option<String>,
+    resumed_session_id: Option<String>,
 ) -> Result<()> {
     let mut sigint = signal(SignalKind::interrupt()).context("setting up SIGINT handler")?;
 
@@ -906,14 +907,19 @@ pub async fn run_chat_loop(
 
     let cwd = std::env::current_dir().context("getting current directory")?;
     let cwd_str = cwd.to_string_lossy().into_owned();
-    let cwd_for_session = cwd.clone();
-    let session_id = tokio::task::spawn_blocking(move || session::create_fresh(&cwd_for_session))
-        .await
-        .context("session::create_fresh panicked")?
-        .unwrap_or_else(|e| {
-            tracing::warn!(error = %e, "failed to create fresh session id; using \"global\"");
-            "global".to_string()
-        });
+    let session_id = match resumed_session_id {
+        Some(id) => id,
+        None => {
+            let cwd_for_session = cwd.clone();
+            tokio::task::spawn_blocking(move || session::create_fresh(&cwd_for_session))
+                .await
+                .context("session::create_fresh panicked")?
+                .unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "failed to create fresh session id; using \"global\"");
+                    "global".to_string()
+                })
+        }
+    };
 
     if crate::banner::should_show() {
         crate::banner::print(&model, &session_id, &cwd);

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,13 @@ async fn main() -> Result<()> {
         } => {
             if detach {
                 client::run_detach(socket, prompt, model).await
-            } else if let Some(session_uuid) = resume {
+            } else if resume.is_some() {
+                let cwd = std::env::current_dir().context("getting current directory")?;
+                let resumed = session::resolve_resume(&cwd, resume)?;
+                let Some(session_uuid) = resumed else {
+                    eprintln!("Resume cancelled.");
+                    return Ok(());
+                };
                 match client::run_resume(socket, prompt, model, session_uuid).await {
                     Ok(()) => Ok(()),
                     Err(e) if e.is::<client::Interrupted>() => std::process::exit(130),
@@ -89,11 +95,26 @@ async fn main() -> Result<()> {
             prompt,
             socket,
             model,
-        } => match client::run_chat_loop(socket, prompt, model).await {
-            Ok(()) => Ok(()),
-            Err(e) if e.is::<client::Interrupted>() => std::process::exit(130),
-            Err(e) => Err(e),
-        },
+            resume,
+        } => {
+            let resumed = if resume.is_some() {
+                let cwd = std::env::current_dir().context("getting current directory")?;
+                match session::resolve_resume(&cwd, resume)? {
+                    Some(id) => Some(id),
+                    None => {
+                        eprintln!("Resume cancelled.");
+                        return Ok(());
+                    }
+                }
+            } else {
+                None
+            };
+            match client::run_chat_loop(socket, prompt, model, resumed).await {
+                Ok(()) => Ok(()),
+                Err(e) if e.is::<client::Interrupted>() => std::process::exit(130),
+                Err(e) => Err(e),
+            }
+        }
         cli::Command::Acp { model, socket } => agent_server::run(model, socket).await,
         cli::Command::Models => models::run().await,
         cli::Command::Memory { action, socket } => run_memory(action, socket).await,

--- a/src/session.rs
+++ b/src/session.rs
@@ -355,8 +355,11 @@ pub fn resolve_resume(dir: &Path, arg: Option<String>) -> Result<Option<String>>
     let want_picker = trimmed.is_empty() || trimmed.eq_ignore_ascii_case("list");
 
     if !want_picker {
-        // Direct UUID or unique prefix.
-        let history = list_for_dir(dir)?;
+        // Direct UUID or unique prefix.  `list_for_dir` failures (missing
+        // $HOME, unreadable sessions.json, etc.) are best-effort downgraded
+        // to an empty history so the user can still resume an opaque UUID
+        // when the local index is unavailable.
+        let history = list_for_dir(dir).unwrap_or_default();
         if let Some(rec) = history.iter().find(|r| r.uuid == trimmed) {
             return Ok(Some(rec.uuid.clone()));
         }
@@ -400,7 +403,10 @@ pub fn resolve_resume(dir: &Path, arg: Option<String>) -> Result<Option<String>>
 fn prompt_for_session(history: &[SessionRecord]) -> Result<Option<String>> {
     use std::io::{BufRead, IsTerminal, Write};
 
-    if !std::io::stderr().is_terminal() {
+    // Both stderr (where we draw the prompt) and stdin (where we read the
+    // choice) must be TTYs.  Otherwise the picker could silently consume
+    // piped input as the selection (e.g. `echo foo | amaebi chat -r`).
+    if !std::io::stderr().is_terminal() || !std::io::stdin().is_terminal() {
         anyhow::bail!("--resume without a UUID requires an interactive terminal");
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -335,6 +335,141 @@ pub fn create_fresh(dir: &Path) -> Result<String> {
     Ok(new_id)
 }
 
+/// Interactively resolve a session UUID for the `--resume` flag.
+///
+/// Three cases, driven by the raw value coming off the CLI (which uses
+/// `num_args = 0..=1`, so `--resume` without a value produces `Some("".into())`):
+///
+/// * `arg` is a non-empty, well-formed UUID, or matches an existing record's
+///   UUID prefix uniquely (≥ 4 chars) — returned verbatim / completed.
+/// * `arg` is `None` or an empty / `"list"` string — a numbered picker is
+///   printed to stderr listing this directory's session history (newest first)
+///   and the user's selection is returned.
+/// * The user enters an empty line at the picker — resolves to `Ok(None)`,
+///   letting the caller fall back to starting a fresh session (or aborting).
+///
+/// Returns `Err` when no sessions exist for the directory but a picker was
+/// requested, or when stderr is not a TTY (nothing to prompt on).
+pub fn resolve_resume(dir: &Path, arg: Option<String>) -> Result<Option<String>> {
+    let trimmed = arg.as_deref().map(str::trim).unwrap_or("");
+    let want_picker = trimmed.is_empty() || trimmed.eq_ignore_ascii_case("list");
+
+    if !want_picker {
+        // Direct UUID or unique prefix.
+        let history = list_for_dir(dir)?;
+        if let Some(rec) = history.iter().find(|r| r.uuid == trimmed) {
+            return Ok(Some(rec.uuid.clone()));
+        }
+        if trimmed.len() >= 4 {
+            let matches: Vec<&SessionRecord> = history
+                .iter()
+                .filter(|r| r.uuid.starts_with(trimmed))
+                .collect();
+            if matches.len() == 1 {
+                return Ok(Some(matches[0].uuid.clone()));
+            }
+            if matches.len() > 1 {
+                anyhow::bail!(
+                    "ambiguous session prefix {trimmed:?}: {} matches in {}",
+                    matches.len(),
+                    dir.display()
+                );
+            }
+        }
+        // No historical match: treat the argument as an opaque UUID anyway so
+        // callers can resume a session whose record has been pruned from
+        // sessions.json but whose history still exists in the SQLite memory DB.
+        return Ok(Some(trimmed.to_string()));
+    }
+
+    // Picker path.
+    let history = list_for_dir(dir)?;
+    if history.is_empty() {
+        anyhow::bail!(
+            "no previous sessions in {} — start a new one without --resume",
+            dir.display()
+        );
+    }
+    prompt_for_session(&history)
+}
+
+/// Print a numbered list of `history` to stderr and read a choice from stdin.
+///
+/// Accepts: a 1-based index, a UUID, or a unique UUID prefix (≥ 4 chars).
+/// Returns `Ok(None)` on empty input (user cancelled).
+fn prompt_for_session(history: &[SessionRecord]) -> Result<Option<String>> {
+    use std::io::{BufRead, IsTerminal, Write};
+
+    if !std::io::stderr().is_terminal() {
+        anyhow::bail!("--resume without a UUID requires an interactive terminal");
+    }
+
+    let stderr = std::io::stderr();
+    let mut e = stderr.lock();
+    writeln!(
+        e,
+        "Select a session to resume ({} available):",
+        history.len()
+    )
+    .context("writing picker header")?;
+    for (i, rec) in history.iter().enumerate() {
+        let marker = if i == 0 { " (current)" } else { "" };
+        writeln!(
+            e,
+            "  {:>2}. {}{}",
+            i + 1,
+            &rec.uuid[..rec.uuid.len().min(8)],
+            marker
+        )?;
+        writeln!(
+            e,
+            "        created {}  accessed {}",
+            rec.created_at, rec.last_accessed
+        )?;
+    }
+    write!(e, "Choice [1-{}] (empty to cancel): ", history.len())?;
+    e.flush().context("flushing picker prompt")?;
+    drop(e);
+
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    if stdin
+        .lock()
+        .read_line(&mut line)
+        .context("reading choice")?
+        == 0
+    {
+        return Ok(None);
+    }
+    let choice = line.trim();
+    if choice.is_empty() {
+        return Ok(None);
+    }
+
+    if let Ok(n) = choice.parse::<usize>() {
+        if n >= 1 && n <= history.len() {
+            return Ok(Some(history[n - 1].uuid.clone()));
+        }
+        anyhow::bail!("invalid choice {n}: expected 1..={}", history.len());
+    }
+
+    if let Some(rec) = history.iter().find(|r| r.uuid == choice) {
+        return Ok(Some(rec.uuid.clone()));
+    }
+    if choice.len() >= 4 {
+        let matches: Vec<&SessionRecord> = history
+            .iter()
+            .filter(|r| r.uuid.starts_with(choice))
+            .collect();
+        match matches.len() {
+            1 => return Ok(Some(matches[0].uuid.clone())),
+            0 => anyhow::bail!("no session matches prefix {choice:?}"),
+            _ => anyhow::bail!("ambiguous prefix {choice:?}: {} matches", matches.len()),
+        }
+    }
+    anyhow::bail!("could not interpret choice {choice:?}")
+}
+
 /// Return all session records for `dir`, newest first.
 pub fn list_for_dir(dir: &Path) -> Result<Vec<SessionRecord>> {
     let path = sessions_path()?;
@@ -959,6 +1094,57 @@ mod tests {
         assert_eq!(history.len(), 2);
         assert_eq!(history[0].uuid, new_id);
         assert_eq!(history[1].uuid, old_id);
+    }
+
+    #[test]
+    fn resolve_resume_exact_uuid_passes_through() {
+        let _guard = with_temp_home();
+        let dir = tempdir().unwrap();
+        let id = create_fresh(dir.path()).unwrap();
+        let resolved = resolve_resume(dir.path(), Some(id.clone())).unwrap();
+        assert_eq!(resolved, Some(id));
+    }
+
+    #[test]
+    fn resolve_resume_unique_prefix_completes() {
+        let _guard = with_temp_home();
+        let dir = tempdir().unwrap();
+        let id = create_fresh(dir.path()).unwrap();
+        let prefix: String = id.chars().take(8).collect();
+        let resolved = resolve_resume(dir.path(), Some(prefix)).unwrap();
+        assert_eq!(resolved, Some(id));
+    }
+
+    #[test]
+    fn resolve_resume_unknown_uuid_passes_through_verbatim() {
+        // UUIDs not in sessions.json may still exist in the memory DB —
+        // resolve_resume should hand the caller's string back untouched.
+        let _guard = with_temp_home();
+        let dir = tempdir().unwrap();
+        let _ = create_fresh(dir.path()).unwrap();
+        let opaque = "not-a-known-uuid-but-opaque";
+        let resolved = resolve_resume(dir.path(), Some(opaque.to_string())).unwrap();
+        assert_eq!(resolved.as_deref(), Some(opaque));
+    }
+
+    #[test]
+    fn resolve_resume_picker_needs_tty_errors_off_tty() {
+        let _guard = with_temp_home();
+        let dir = tempdir().unwrap();
+        let _ = create_fresh(dir.path()).unwrap();
+        // `cargo test` runs without a stderr TTY, so the picker path must bail.
+        let err =
+            resolve_resume(dir.path(), Some(String::new())).expect_err("picker off-TTY must fail");
+        assert!(err.to_string().contains("interactive terminal"));
+    }
+
+    #[test]
+    fn resolve_resume_picker_no_sessions_errors() {
+        let _guard = with_temp_home();
+        let dir = tempdir().unwrap();
+        let err =
+            resolve_resume(dir.path(), Some(String::new())).expect_err("empty history must fail");
+        assert!(err.to_string().contains("no previous sessions"));
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -335,13 +335,17 @@ pub fn create_fresh(dir: &Path) -> Result<String> {
     Ok(new_id)
 }
 
-/// Interactively resolve a session UUID for the `--resume` flag.
+/// Interactively resolve a session identifier for the `--resume` flag.
 ///
 /// Three cases, driven by the raw value coming off the CLI (which uses
 /// `num_args = 0..=1`, so `--resume` without a value produces `Some("".into())`):
 ///
-/// * `arg` is a non-empty, well-formed UUID, or matches an existing record's
-///   UUID prefix uniquely (≥ 4 chars) — returned verbatim / completed.
+/// * `arg` is a non-empty string matching an existing record's UUID prefix
+///   uniquely (≥ 4 chars) — completed to the full stored UUID.
+///   Any other non-empty string is treated as an opaque session identifier
+///   and returned unchanged, so callers can resume sessions whose records
+///   have been pruned from `sessions.json` but whose history still exists
+///   in the SQLite memory DB.  No UUID-syntax validation is performed.
 /// * `arg` is `None` or an empty / `"list"` string — a numbered picker is
 ///   printed to stderr listing this directory's session history (newest first)
 ///   and the user's selection is returned.
@@ -349,7 +353,7 @@ pub fn create_fresh(dir: &Path) -> Result<String> {
 ///   letting the caller fall back to starting a fresh session (or aborting).
 ///
 /// Returns `Err` when no sessions exist for the directory but a picker was
-/// requested, or when stderr is not a TTY (nothing to prompt on).
+/// requested, or when stderr/stdin is not a TTY (nothing to prompt on).
 pub fn resolve_resume(dir: &Path, arg: Option<String>) -> Result<Option<String>> {
     let trimmed = arg.as_deref().map(str::trim).unwrap_or("");
     let want_picker = trimmed.is_empty() || trimmed.eq_ignore_ascii_case("list");
@@ -1135,10 +1139,17 @@ mod tests {
 
     #[test]
     fn resolve_resume_picker_needs_tty_errors_off_tty() {
+        use std::io::IsTerminal;
+        // Skip this test if both stdin and stderr happen to be TTYs in the
+        // runner (e.g. `cargo test -- --nocapture` on an interactive shell);
+        // otherwise the picker would block forever waiting for a selection.
+        if std::io::stderr().is_terminal() && std::io::stdin().is_terminal() {
+            eprintln!("skipping: stdin+stderr are TTYs; picker would block");
+            return;
+        }
         let _guard = with_temp_home();
         let dir = tempdir().unwrap();
         let _ = create_fresh(dir.path()).unwrap();
-        // `cargo test` runs without a stderr TTY, so the picker path must bail.
         let err =
             resolve_resume(dir.path(), Some(String::new())).expect_err("picker off-TTY must fail");
         assert!(err.to_string().contains("interactive terminal"));


### PR DESCRIPTION
## Summary
- Add `-r/--resume` to `amaebi chat`; `ask` and `chat` now share the same flag semantics.
- Extract the resume argument resolution into `session::resolve_resume` so both subcommands go through one code path.
- When `-r` is passed without a value, an interactive picker lists this directory's session history (newest first) for the user to choose from.
- UUID prefixes (≥ 4 chars) resolve to the unique match; unknown UUIDs pass through verbatim so sessions pruned from `sessions.json` but still present in the SQLite memory DB remain resumable.

## Implementation notes
- `chat` reuses `Request::Chat` with the resumed UUID instead of introducing a new IPC variant — on the first turn the daemon already hydrates full history from SQLite whenever it sees a known `session_id`, matching `Request::Resume` semantics.
- 5 new unit tests in `session.rs` cover: exact UUID, unique-prefix completion, unknown-UUID pass-through, picker-off-TTY error, empty-history error.

## Test plan
- [x] `cargo test` (35 passed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [ ] Manual: `amaebi chat -r` shows picker in an interactive terminal
- [ ] Manual: `amaebi chat -r <uuid-prefix>` resumes the right session
- [ ] Manual: `amaebi ask -r` still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)