### PR TITLE
feat(config): user-defined model aliases in config.json

### DIFF
--- a/src/agent_server.rs
+++ b/src/agent_server.rs
@@ -373,16 +373,18 @@ impl acp::Agent for AmaebiAgent {
 /// `socket` is the path to a running daemon's Unix socket.  Memory operations
 /// are routed through it so the daemon remains the sole SQLite writer.
 pub async fn run(model: Option<String>, socket: PathBuf) -> Result<()> {
-    let model: Arc<str> = model
-        .or_else(|| std::env::var("AMAEBI_MODEL").ok())
-        .unwrap_or_else(|| crate::provider::DEFAULT_MODEL.to_string())
-        .into();
-
     let state = Arc::new(
         DaemonState::new()
             .await
             .context("initialising daemon state")?,
     );
+
+    // Build state first so we can expand any user-defined alias in the CLI
+    // arg or AMAEBI_MODEL env var using the snapshotted alias table.
+    let raw_model = model
+        .or_else(|| std::env::var("AMAEBI_MODEL").ok())
+        .unwrap_or_else(|| crate::provider::DEFAULT_MODEL.to_string());
+    let model: Arc<str> = crate::daemon::expand_user_alias(&raw_model, &state.user_aliases).into();
 
     let outgoing = tokio::io::stdout().compat_write();
     let incoming = tokio::io::stdin().compat();

--- a/src/banner.rs
+++ b/src/banner.rs
@@ -47,11 +47,19 @@ pub fn print(model: &str, session_id: &str, cwd: &Path) {
     };
 
     // Always show the resolved provider/ prefix so users see which backend
-    // will be hit.  Unknown prefixes (e.g. `azure/`) route to Bedrock by
-    // default — reflect that rather than echoing the raw input.
-    let spec = crate::provider::resolve(model);
+    // will be hit.  If the user typed a config-file alias (e.g. `opus`), show
+    // both the alias and its target so there's no ambiguity about what will
+    // actually be sent on the wire.
+    let user_aliases = crate::config::Config::load().model_aliases;
+    let spec = crate::provider::resolve_with_aliases(model, &user_aliases);
     let model_display = if model.starts_with("copilot/") || model.starts_with("bedrock/") {
         model.to_string()
+    } else if let Some(target) = user_aliases
+        .get(model.trim_end_matches("[1m]"))
+        .filter(|_| !crate::provider::is_builtin_bedrock_alias(model.trim_end_matches("[1m]")))
+    {
+        // Alias in effect — show "opus → bedrock/claude-opus-4.7".
+        format!("{model} → {target}")
     } else {
         format!("{}/{}", spec.provider, model)
     };

--- a/src/banner.rs
+++ b/src/banner.rs
@@ -58,8 +58,16 @@ pub fn print(model: &str, session_id: &str, cwd: &Path) {
         .get(model.trim_end_matches("[1m]"))
         .filter(|_| !crate::provider::is_builtin_bedrock_alias(model.trim_end_matches("[1m]")))
     {
-        // Alias in effect — show "opus → bedrock/claude-opus-4.7".
-        format!("{model} → {target}")
+        // Alias in effect — show "opus → bedrock/claude-opus-4.7".  If the
+        // user typed `alias[1m]` we append `[1m]` to the target for display
+        // unless it is already there, since the daemon reattaches the suffix
+        // when expanding.
+        let needs_1m = model.ends_with("[1m]") && !target.ends_with("[1m]");
+        if needs_1m {
+            format!("{model} → {target}[1m]")
+        } else {
+            format!("{model} → {target}")
+        }
     } else {
         format!("{}/{}", spec.provider, model)
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -258,7 +258,7 @@ mod tests {
         cfg.model_aliases
             .insert("opus".into(), "bedrock/claude-opus-4.7".into());
         cfg.model_aliases
-            .insert("fast".into(), "bedrock/claude-haiku-4.5".into());
+            .insert("haiku".into(), "bedrock/claude-haiku-4.5".into());
         let json = serde_json::to_string(&cfg).unwrap();
         let cfg2: Config = serde_json::from_str(&json).unwrap();
         assert_eq!(
@@ -266,7 +266,7 @@ mod tests {
             Some(&"bedrock/claude-opus-4.7".to_string())
         );
         assert_eq!(
-            cfg2.model_aliases.get("fast"),
+            cfg2.model_aliases.get("haiku"),
             Some(&"bedrock/claude-haiku-4.5".to_string())
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,15 @@ pub struct Config {
     /// 5. built-in 30-minute fallback
     #[serde(default)]
     pub ttl_minutes: HashMap<String, u64>,
+
+    /// User-defined model aliases.  Keys are short names typed on the CLI
+    /// (e.g. `"opus"`), values are full model strings (`"bedrock/claude-opus-4.7"`
+    /// or `"copilot/gpt-4o"`).  Built-in aliases in `provider::BEDROCK_ALIASES`
+    /// take precedence on a name conflict.  Alias values are resolved once
+    /// (no chain resolution): the value must be a final model string or a
+    /// built-in alias name.
+    #[serde(default)]
+    pub model_aliases: HashMap<String, String>,
 }
 
 impl Config {
@@ -233,5 +242,32 @@ mod tests {
         let cfg2: Config = serde_json::from_str(&json).unwrap();
         assert_eq!(cfg2.ttl_minutes.get("default"), Some(&30));
         assert_eq!(cfg2.ttl_minutes.get("/projectX"), Some(&120));
+    }
+
+    #[test]
+    fn model_aliases_default_empty_when_missing() {
+        // Older configs without model_aliases must still load cleanly.
+        let json = r#"{"ttl_minutes":{"default":30}}"#;
+        let cfg: Config = serde_json::from_str(json).unwrap();
+        assert!(cfg.model_aliases.is_empty());
+    }
+
+    #[test]
+    fn model_aliases_roundtrip_serde() {
+        let mut cfg = Config::default();
+        cfg.model_aliases
+            .insert("opus".into(), "bedrock/claude-opus-4.7".into());
+        cfg.model_aliases
+            .insert("fast".into(), "bedrock/claude-haiku-4.5".into());
+        let json = serde_json::to_string(&cfg).unwrap();
+        let cfg2: Config = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            cfg2.model_aliases.get("opus"),
+            Some(&"bedrock/claude-opus-4.7".to_string())
+        );
+        assert_eq!(
+            cfg2.model_aliases.get("fast"),
+            Some(&"bedrock/claude-haiku-4.5".to_string())
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4516,9 +4516,13 @@ async fn run_cron_job(state: Arc<DaemonState>, job: &cron::CronJob) {
     // Generate a fresh session UUID for this run.
     let session_id = uuid::Uuid::new_v4().to_string();
 
-    // Resolve model from env var (same default as CLI client).
+    // Resolve model from env var (same default as CLI client), then expand
+    // any user-defined alias (e.g. AMAEBI_MODEL=opus) using the daemon's
+    // snapshotted alias table so cron jobs hit the same backend as
+    // interactive requests.
     let model = std::env::var("AMAEBI_MODEL")
         .unwrap_or_else(|_| crate::provider::DEFAULT_MODEL.to_string());
+    let model = expand_user_alias(&model, &state.user_aliases);
 
     let mut messages = build_messages(&job.description, None, &[], &[], None, &model);
     inject_skill_files(&mut messages).await;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -358,8 +358,9 @@ pub(crate) fn expand_user_alias(
     user_aliases: &std::collections::HashMap<String, String>,
 ) -> String {
     // If the caller typed `name[1m]`, strip the suffix, expand the bare name,
-    // then reattach the suffix.  Aliases in config.json should not contain
-    // the `[1m]` suffix themselves.
+    // then reattach the suffix.  Alias targets in config.json may themselves
+    // carry `[1m]` (e.g. `"sonnet": "bedrock/claude-sonnet-4.6[1m]"`) — the
+    // downstream `provider::resolve()` normalizes the suffix either way.
     let (bare, suffix) = if let Some(stripped) = model.strip_suffix("[1m]") {
         (stripped, "[1m]")
     } else {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -146,8 +146,10 @@ pub struct DaemonState {
     /// concurrent clients cannot interleave writes to the same session history.
     pub active_sessions: Arc<Mutex<HashSet<String>>>,
     /// User-defined model aliases loaded once from `~/.amaebi/config.json` at
-    /// daemon startup.  Consulted by `provider::resolve_with_aliases` on every
-    /// request.  Empty when the config file is missing or has no aliases.
+    /// daemon startup.  Expanded by `expand_user_alias` at each request entry
+    /// point so the rest of the pipeline can keep using bare
+    /// `provider::resolve()`.  Empty when the config file is missing or has
+    /// no aliases.
     pub user_aliases: Arc<std::collections::HashMap<String, String>>,
 }
 
@@ -347,7 +349,7 @@ fn needs_copilot_auth(model: &str) -> bool {
 ///
 /// This is called once on every request-entry so the rest of the daemon can
 /// keep using bare `provider::resolve()` without knowing about user aliases.
-fn expand_user_alias(
+pub(crate) fn expand_user_alias(
     model: &str,
     user_aliases: &std::collections::HashMap<String, String>,
 ) -> String {
@@ -5995,5 +5997,61 @@ mod tests {
     fn summarise_tool_detail_unknown_tool_returns_empty() {
         let args = serde_json::json!({ "command": "ignored" });
         assert_eq!(summarise_tool_detail("bogus_tool", &args), "");
+    }
+
+    // ---- expand_user_alias -------------------------------------------------
+
+    fn aliases(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn expand_user_alias_expands_bare_name() {
+        let map = aliases(&[("opus", "bedrock/claude-opus-4.7")]);
+        assert_eq!(expand_user_alias("opus", &map), "bedrock/claude-opus-4.7");
+    }
+
+    #[test]
+    fn expand_user_alias_preserves_1m_suffix() {
+        // `opus[1m]` must expand the bare name and reattach the suffix.
+        let map = aliases(&[("opus", "bedrock/claude-opus-4.7")]);
+        assert_eq!(
+            expand_user_alias("opus[1m]", &map),
+            "bedrock/claude-opus-4.7[1m]"
+        );
+    }
+
+    #[test]
+    fn expand_user_alias_builtin_shadows_user() {
+        // `claude-opus-4.6` is a built-in; user alias must be ignored.
+        let map = aliases(&[("claude-opus-4.6", "bedrock/claude-sonnet-4.6")]);
+        assert_eq!(
+            expand_user_alias("claude-opus-4.6", &map),
+            "claude-opus-4.6"
+        );
+    }
+
+    #[test]
+    fn expand_user_alias_passes_through_provider_prefix() {
+        // `bedrock/...` already carries a provider prefix and must not be
+        // treated as a bare-name candidate for expansion.
+        let map = aliases(&[("bedrock/foo", "bedrock/bar")]);
+        assert_eq!(expand_user_alias("bedrock/foo", &map), "bedrock/foo");
+    }
+
+    #[test]
+    fn expand_user_alias_unknown_passes_through() {
+        let map = aliases(&[("opus", "bedrock/claude-opus-4.7")]);
+        assert_eq!(expand_user_alias("unknown", &map), "unknown");
+    }
+
+    #[test]
+    fn expand_user_alias_no_chain_resolution() {
+        // `a -> b`, `b -> bedrock/...`.  Expanding "a" must stop at "b".
+        let map = aliases(&[("a", "b"), ("b", "bedrock/claude-opus-4.7")]);
+        assert_eq!(expand_user_alias("a", &map), "b");
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -145,6 +145,10 @@ pub struct DaemonState {
     /// it is already present the request is rejected with a Response::Error so
     /// concurrent clients cannot interleave writes to the same session history.
     pub active_sessions: Arc<Mutex<HashSet<String>>>,
+    /// User-defined model aliases loaded once from `~/.amaebi/config.json` at
+    /// daemon startup.  Consulted by `provider::resolve_with_aliases` on every
+    /// request.  Empty when the config file is missing or has no aliases.
+    pub user_aliases: Arc<std::collections::HashMap<String, String>>,
 }
 
 impl DaemonState {
@@ -166,11 +170,16 @@ impl DaemonState {
 
         let tokens = Arc::new(TokenCache::new());
 
+        // Load user model aliases from the config file.  Never fatal — falls
+        // back to an empty map if the file is missing or malformed.
+        let user_aliases = Arc::new(crate::config::Config::load().model_aliases);
+
         let spawn_ctx = Arc::new(tools::SpawnContext {
             http: http.clone(),
             db: Arc::clone(&db),
             compacting_sessions: Arc::clone(&compacting_sessions),
             tokens: Arc::clone(&tokens),
+            user_aliases: Arc::clone(&user_aliases),
         });
 
         let mut executor = tools::LocalExecutor::new();
@@ -183,6 +192,7 @@ impl DaemonState {
             db,
             compacting_sessions,
             active_sessions,
+            user_aliases,
         })
     }
 }
@@ -328,6 +338,36 @@ fn compaction_threshold_tokens(model: &str) -> usize {
 /// token pre-flight check is required before dispatching the request.
 fn needs_copilot_auth(model: &str) -> bool {
     crate::provider::resolve(model).provider == crate::provider::ProviderKind::Copilot
+}
+
+/// Expand a user-defined alias in `model` using the daemon's loaded alias
+/// table.  Returns the expanded target string, or the original input if no
+/// alias matches.  The `[1m]` suffix is preserved across expansion so
+/// `amaebi chat --model opus[1m]` works when `opus` maps to a Bedrock model.
+///
+/// This is called once on every request-entry so the rest of the daemon can
+/// keep using bare `provider::resolve()` without knowing about user aliases.
+fn expand_user_alias(
+    model: &str,
+    user_aliases: &std::collections::HashMap<String, String>,
+) -> String {
+    // If the caller typed `name[1m]`, strip the suffix, expand the bare name,
+    // then reattach the suffix.  Aliases in config.json should not contain
+    // the `[1m]` suffix themselves.
+    let (bare, suffix) = if let Some(stripped) = model.strip_suffix("[1m]") {
+        (stripped, "[1m]")
+    } else {
+        (model, "")
+    };
+
+    // Built-in aliases win on conflict (same rule as provider::resolve_with_aliases).
+    if bare.contains('/') || crate::provider::is_builtin_bedrock_alias(bare) {
+        return model.to_owned();
+    }
+    match user_aliases.get(bare) {
+        Some(target) => format!("{target}{suffix}"),
+        None => model.to_owned(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -524,6 +564,7 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                 model,
                 session_id,
             } => {
+                let model = expand_user_alias(&model, &state.user_aliases);
                 tracing::info!(model = %model, prompt_len = prompt.len(), "received detach request");
                 if needs_copilot_auth(&model) {
                     if let Err(e) = state.tokens.get(&state.http).await {
@@ -603,6 +644,7 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                 model,
                 session_id,
             } => {
+                let model = expand_user_alias(&model, &state.user_aliases);
                 let mut conn_state = ConnState {
                     frame_rx: &mut frame_rx,
                     pending_unsolicited: &mut pending_unsolicited,
@@ -629,6 +671,7 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                 model,
                 session_id,
             } => {
+                let model = expand_user_alias(&model, &state.user_aliases);
                 let mut conn_state = ConnState {
                     frame_rx: &mut frame_rx,
                     pending_unsolicited: &mut pending_unsolicited,
@@ -662,6 +705,7 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
                 model,
                 session_id,
             } => {
+                let model = expand_user_alias(&model, &state.user_aliases);
                 handle_supervision(&writer, &mut frame_rx, panes, model, &state, session_id)
                     .await?;
             }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -147,9 +147,13 @@ pub struct DaemonState {
     pub active_sessions: Arc<Mutex<HashSet<String>>>,
     /// User-defined model aliases loaded once from `~/.amaebi/config.json` at
     /// daemon startup.  Expanded by `expand_user_alias` at each request entry
-    /// point so the rest of the pipeline can keep using bare
-    /// `provider::resolve()`.  Empty when the config file is missing or has
-    /// no aliases.
+    /// point (and inside the `switch_model` tool handler) so the rest of the
+    /// pipeline can keep using bare `provider::resolve()`.  Empty when the
+    /// config file is missing or has no aliases.
+    ///
+    /// **Not hot-reloaded**: the daemon snapshots the alias table once at
+    /// startup.  The user must restart the daemon after editing
+    /// `~/.amaebi/config.json` for changes to take effect.
     pub user_aliases: Arc<std::collections::HashMap<String, String>>,
 }
 
@@ -4101,6 +4105,11 @@ where
                             let result = match parse_switch_model_arg(args["model"].as_str()) {
                                 Err(e) => e,
                                 Ok(new_model) => {
+                                    // Expand user-defined aliases so the LLM can
+                                    // switch_model with a short alias like "opus"
+                                    // and land on the configured target.
+                                    let new_model =
+                                        expand_user_alias(&new_model, &state.user_aliases);
                                     let old =
                                         std::mem::replace(&mut current_model, new_model.clone());
                                     // LLM made an explicit choice — stop auto-switching

--- a/src/models.rs
+++ b/src/models.rs
@@ -72,6 +72,27 @@ pub async fn run() -> Result<()> {
             println!("  (could not fetch Copilot models: {e:#})");
         }
     }
+    println!();
+
+    // ── User-defined aliases ──────────────────────────────────────────────
+    println!("User aliases (from ~/.amaebi/config.json):");
+    let user_aliases = crate::config::Config::load().model_aliases;
+    if user_aliases.is_empty() {
+        println!("  (none configured — add a \"model_aliases\" object to the config file)");
+    } else {
+        // Sort alphabetically for stable display.
+        let mut sorted: Vec<(&String, &String)> = user_aliases.iter().collect();
+        sorted.sort_by_key(|(k, _)| k.as_str());
+        let name_width = sorted.iter().map(|(k, _)| k.len()).max().unwrap_or(0);
+        for (name, target) in sorted {
+            let shadowed = if crate::provider::is_builtin_bedrock_alias(name) {
+                "  (shadowed by built-in)"
+            } else {
+                ""
+            };
+            println!("  {name:<name_width$}  → {target}{shadowed}");
+        }
+    }
 
     Ok(())
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -143,7 +143,7 @@ pub fn resolve_with_aliases(raw: &str, user_aliases: &HashMap<String, String>) -
     // AND does not collide with a built-in Bedrock alias.  Built-in wins on
     // conflict so the LLM-visible `claude-opus-4.6` etc. are stable.
     let expanded: String;
-    let bare: &str = if bare.contains('/') || BEDROCK_ALIASES.iter().any(|(a, _)| *a == bare) {
+    let bare: &str = if bare.contains('/') || is_builtin_bedrock_alias(bare) {
         bare
     } else if let Some(target) = user_aliases.get(bare) {
         expanded = target.clone();

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -5,6 +5,8 @@
 //!
 //! When no provider prefix is given, the default provider is **Bedrock**.
 
+use std::collections::HashMap;
+
 /// Supported model providers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderKind {
@@ -112,6 +114,20 @@ pub const DEFAULT_MODEL: &str = "claude-sonnet-4.6";
 /// part of the model ID.  This avoids a hard error for forward-compatible
 /// model names that happen to contain a slash.
 pub fn resolve(raw: &str) -> ModelSpec {
+    resolve_with_aliases(raw, &HashMap::new())
+}
+
+/// Parse a raw model string into a [`ModelSpec`], consulting user-defined
+/// aliases from the config file before falling back to the built-in table.
+///
+/// Resolution order when the bare name has no recognised provider prefix:
+/// 1. Built-in `BEDROCK_ALIASES` — wins on name conflict.
+/// 2. `user_aliases` — the value replaces `bare` and re-enters the normal
+///    prefix-parsing path (so aliases may expand to `copilot/...`,
+///    `bedrock/...`, or another bare name).  Alias values are resolved
+///    exactly once; no chain expansion.
+/// 3. Default provider (Bedrock), passing the bare name through unchanged.
+pub fn resolve_with_aliases(raw: &str, user_aliases: &HashMap<String, String>) -> ModelSpec {
     let display_name = raw.to_owned();
 
     // Strip the `[1m]` opt-in suffix before routing and alias resolution.
@@ -121,6 +137,19 @@ pub fn resolve(raw: &str) -> ModelSpec {
         &raw[..raw.len() - "[1m]".len()]
     } else {
         raw
+    };
+
+    // Expand user alias only when `bare` is a plain name (no provider prefix)
+    // AND does not collide with a built-in Bedrock alias.  Built-in wins on
+    // conflict so the LLM-visible `claude-opus-4.6` etc. are stable.
+    let expanded: String;
+    let bare: &str = if bare.contains('/') || BEDROCK_ALIASES.iter().any(|(a, _)| *a == bare) {
+        bare
+    } else if let Some(target) = user_aliases.get(bare) {
+        expanded = target.clone();
+        &expanded
+    } else {
+        bare
     };
 
     if let Some((prefix, model)) = bare.split_once('/') {
@@ -177,6 +206,14 @@ fn resolve_bedrock_alias(name: &str) -> String {
 /// Return the Bedrock alias table for display (e.g. `amaebi models`).
 pub fn bedrock_aliases() -> &'static [(&'static str, &'static str)] {
     BEDROCK_ALIASES
+}
+
+/// Returns `true` when `name` is a key in the built-in Bedrock alias table.
+///
+/// Used by the daemon's user-alias expansion logic so that built-in aliases
+/// always win on name conflicts.
+pub fn is_builtin_bedrock_alias(name: &str) -> bool {
+    BEDROCK_ALIASES.iter().any(|(a, _)| *a == name)
 }
 
 // ---------------------------------------------------------------------------
@@ -336,5 +373,78 @@ mod tests {
     #[test]
     fn bedrock_aliases_not_empty() {
         assert!(!bedrock_aliases().is_empty());
+    }
+
+    // ---- resolve_with_aliases() -------------------------------------------
+
+    #[test]
+    fn resolve_with_aliases_expands_user_alias() {
+        let mut map = HashMap::new();
+        map.insert("opus".into(), "bedrock/claude-opus-4.7".into());
+        let spec = resolve_with_aliases("opus", &map);
+        assert_eq!(spec.provider, ProviderKind::Bedrock);
+        assert_eq!(spec.model_id, "us.anthropic.claude-opus-4-7");
+        // display_name preserves what the user typed.
+        assert_eq!(spec.display_name, "opus");
+    }
+
+    #[test]
+    fn user_alias_does_not_override_builtin() {
+        // Built-in alias `claude-opus-4.6` must win even when the user tries
+        // to point it at something else.
+        let mut map = HashMap::new();
+        map.insert("claude-opus-4.6".into(), "bedrock/claude-sonnet-4.6".into());
+        let spec = resolve_with_aliases("claude-opus-4.6", &map);
+        assert_eq!(spec.model_id, "us.anthropic.claude-opus-4-6-v1");
+    }
+
+    #[test]
+    fn user_alias_preserves_1m_suffix() {
+        let mut map = HashMap::new();
+        map.insert("opus".into(), "bedrock/claude-opus-4.7".into());
+        let spec = resolve_with_aliases("opus[1m]", &map);
+        assert!(spec.use_1m);
+        assert_eq!(spec.model_id, "us.anthropic.claude-opus-4-7");
+        assert_eq!(spec.display_name, "opus[1m]");
+    }
+
+    #[test]
+    fn user_alias_target_is_not_chain_resolved() {
+        // `a -> b`, `b -> bedrock/...`.  Expanding "a" must stop at "b".
+        let mut map = HashMap::new();
+        map.insert("a".into(), "b".into());
+        map.insert("b".into(), "bedrock/claude-opus-4.7".into());
+        let spec = resolve_with_aliases("a", &map);
+        // "b" is not a built-in alias, so it passes through unchanged.
+        assert_eq!(spec.model_id, "b");
+        assert_eq!(spec.provider, ProviderKind::Bedrock);
+    }
+
+    #[test]
+    fn user_alias_can_target_copilot() {
+        let mut map = HashMap::new();
+        map.insert("fast".into(), "copilot/gpt-4o-mini".into());
+        let spec = resolve_with_aliases("fast", &map);
+        assert_eq!(spec.provider, ProviderKind::Copilot);
+        assert_eq!(spec.model_id, "gpt-4o-mini");
+    }
+
+    #[test]
+    fn resolve_wrapper_passes_empty_aliases() {
+        // The zero-config wrapper must behave exactly like the old resolve().
+        let spec = resolve("claude-opus-4.7");
+        assert_eq!(spec.model_id, "us.anthropic.claude-opus-4-7");
+    }
+
+    #[test]
+    fn user_alias_ignored_when_input_has_prefix() {
+        // `bedrock/foo` should never try to expand `bedrock/foo` as a user alias.
+        let mut map = HashMap::new();
+        map.insert(
+            "bedrock/claude-opus-4.7".into(),
+            "bedrock/claude-sonnet-4.6".into(),
+        );
+        let spec = resolve_with_aliases("bedrock/claude-opus-4.7", &map);
+        assert_eq!(spec.model_id, "us.anthropic.claude-opus-4-7");
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -152,6 +152,16 @@ pub fn resolve_with_aliases(raw: &str, user_aliases: &HashMap<String, String>) -
         bare
     };
 
+    // Alias targets in config.json may themselves carry a `[1m]` suffix
+    // (e.g. `"sonnet": "bedrock/claude-sonnet-4.6[1m]"`).  Normalize again
+    // after alias expansion so the suffix is always recorded on `use_1m`
+    // and never left embedded inside the Bedrock model id.
+    let (bare, use_1m) = if let Some(stripped) = bare.strip_suffix("[1m]") {
+        (stripped, true)
+    } else {
+        (bare, use_1m)
+    };
+
     if let Some((prefix, model)) = bare.split_once('/') {
         match prefix {
             "copilot" => {
@@ -406,6 +416,28 @@ mod tests {
         assert!(spec.use_1m);
         assert_eq!(spec.model_id, "us.anthropic.claude-opus-4-7");
         assert_eq!(spec.display_name, "opus[1m]");
+    }
+
+    #[test]
+    fn user_alias_target_can_include_1m_suffix() {
+        // config.json may carry `[1m]` inside the target; it must be parsed
+        // as the opt-in flag, not left embedded in the resolved model id.
+        let mut map = HashMap::new();
+        map.insert("sonnet".into(), "bedrock/claude-sonnet-4.6[1m]".into());
+        let spec = resolve_with_aliases("sonnet", &map);
+        assert!(spec.use_1m);
+        assert_eq!(spec.model_id, "us.anthropic.claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn user_alias_target_1m_and_input_1m_both_enable_use_1m() {
+        // User typed `sonnet[1m]` AND the alias target also has `[1m]` —
+        // resolution stays idempotent.
+        let mut map = HashMap::new();
+        map.insert("sonnet".into(), "bedrock/claude-sonnet-4.6[1m]".into());
+        let spec = resolve_with_aliases("sonnet[1m]", &map);
+        assert!(spec.use_1m);
+        assert_eq!(spec.model_id, "us.anthropic.claude-sonnet-4-6");
     }
 
     #[test]

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -423,8 +423,8 @@ mod tests {
     #[test]
     fn user_alias_can_target_copilot() {
         let mut map = HashMap::new();
-        map.insert("fast".into(), "copilot/gpt-4o-mini".into());
-        let spec = resolve_with_aliases("fast", &map);
+        map.insert("mini".into(), "copilot/gpt-4o-mini".into());
+        let spec = resolve_with_aliases("mini", &map);
         assert_eq!(spec.provider, ProviderKind::Copilot);
         assert_eq!(spec.model_id, "gpt-4o-mini");
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -24,6 +24,10 @@ pub struct SpawnContext {
     /// Shared Copilot token cache — reused by child agents to avoid redundant
     /// token fetches.
     pub tokens: Arc<crate::auth::TokenCache>,
+    /// User-defined model aliases from `~/.amaebi/config.json`, shared with
+    /// child agents so they can resolve aliases (e.g. `opus`) in spawn_agent
+    /// calls the same way the parent does.
+    pub user_aliases: Arc<HashMap<String, String>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -604,6 +608,8 @@ async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<Stri
         // Child agents get their own active_sessions set; they are ephemeral
         // and don't share the parent's session-lock namespace.
         active_sessions: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+        // Inherit user aliases so spawn_agent's `model` arg can reference them.
+        user_aliases: Arc::clone(&ctx.user_aliases),
     };
 
     let messages = vec![
@@ -1406,6 +1412,7 @@ mod tests {
             db: Arc::new(Mutex::new(rusqlite::Connection::open_in_memory().unwrap())),
             compacting_sessions: Arc::new(Mutex::new(HashSet::new())),
             tokens: Arc::new(crate::auth::TokenCache::new()),
+            user_aliases: Arc::new(HashMap::new()),
         }
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -456,6 +456,11 @@ async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<Stri
         .as_str()
         .map(|s| s.to_string())
         .unwrap_or_else(subagent_default_model);
+    // Expand user-defined aliases here: the downstream run_agentic_loop
+    // resolves the model via provider::resolve() which does not consult
+    // user aliases, so `{"model": "opus"}` from the LLM must be expanded
+    // before the child loop sees it.
+    let model = crate::daemon::expand_user_alias(&model, &ctx.user_aliases);
 
     let extra_mounts = args["extra_mounts"].as_array().cloned().unwrap_or_default();
     let mut ro_paths: Vec<PathBuf> = vec![];

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -24,9 +24,12 @@ pub struct SpawnContext {
     /// Shared Copilot token cache — reused by child agents to avoid redundant
     /// token fetches.
     pub tokens: Arc<crate::auth::TokenCache>,
-    /// User-defined model aliases from `~/.amaebi/config.json`, shared with
-    /// child agents so they can resolve aliases (e.g. `opus`) in spawn_agent
-    /// calls the same way the parent does.
+    /// User-defined model aliases from `~/.amaebi/config.json`.  Consulted by
+    /// `spawn_agent` (parent scope) when expanding the `model` argument
+    /// before launching a child agent.  Children cannot themselves call
+    /// `spawn_agent` (`spawn_ctx: None`, `include_spawn_agent: false`), so
+    /// they do not need this map at runtime; it is still propagated into
+    /// the child `DaemonState` for consistency.
     pub user_aliases: Arc<HashMap<String, String>>,
 }
 
@@ -613,7 +616,9 @@ async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<Stri
         // Child agents get their own active_sessions set; they are ephemeral
         // and don't share the parent's session-lock namespace.
         active_sessions: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
-        // Inherit user aliases so spawn_agent's `model` arg can reference them.
+        // Propagated into the child state for consistency.  Children cannot
+        // themselves spawn further agents, so this map is unused at runtime
+        // today; alias expansion happens in the parent's spawn_agent call.
         user_aliases: Arc::clone(&ctx.user_aliases),
     };
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -26,10 +26,11 @@ pub struct SpawnContext {
     pub tokens: Arc<crate::auth::TokenCache>,
     /// User-defined model aliases from `~/.amaebi/config.json`.  Consulted by
     /// `spawn_agent` (parent scope) when expanding the `model` argument
-    /// before launching a child agent.  Children cannot themselves call
-    /// `spawn_agent` (`spawn_ctx: None`, `include_spawn_agent: false`), so
-    /// they do not need this map at runtime; it is still propagated into
-    /// the child `DaemonState` for consistency.
+    /// before launching a child agent.  Also propagated into the child's
+    /// `DaemonState.user_aliases` so the child's `switch_model` tool
+    /// handler can resolve user aliases the same way the parent's does —
+    /// children cannot `spawn_agent` themselves, but `switch_model` is
+    /// always available.
     pub user_aliases: Arc<HashMap<String, String>>,
 }
 
@@ -616,9 +617,10 @@ async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<Stri
         // Child agents get their own active_sessions set; they are ephemeral
         // and don't share the parent's session-lock namespace.
         active_sessions: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
-        // Propagated into the child state for consistency.  Children cannot
-        // themselves spawn further agents, so this map is unused at runtime
-        // today; alias expansion happens in the parent's spawn_agent call.
+        // Children cannot themselves spawn further agents, but the
+        // switch_model tool schema is still available to them.  Propagating
+        // the alias table lets a child's switch_model call resolve user
+        // aliases the same way the parent's does.
         user_aliases: Arc::clone(&ctx.user_aliases),
     };
 


### PR DESCRIPTION
## Summary

Users can now declare short model aliases in \`~/.amaebi/config.json\`:

\`\`\`json
{
  \"model_aliases\": {
    \"opus\": \"bedrock/claude-opus-4.7\",
    \"sonnet\": \"bedrock/claude-sonnet-4.6[1m]\",
    \"haiku\": \"bedrock/claude-haiku-4.5\"
  }
}
\`\`\`

Then \`amaebi chat --model opus\` and \`/model sonnet\` Just Work. When a new model is released, one line change in the config and every script/prompt tracks the latest — no code changes, no rebuild.

## Design

- **No chain resolution**: alias values must be final model strings. \`a → b → model\` expands only \"a\" to \"b\"; \"b\" is passed through as-is. Keeps the code simple and prevents infinite loops.
- **Built-in wins on conflict**: if a user defines \`claude-opus-4.6\` the built-in still takes effect. User aliases can only add, never override.
- **No CLI management command**: users edit the JSON directly, same as \`ttl_minutes\`.

## Test plan

- [x] \`cargo test\` (all unit + integration tests pass, including new ones for \`expand_user_alias\` and \`resolve_with_aliases\`)
- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy -- -D warnings\` passes
- [x] Manual: added aliases to config.json, verified \`amaebi models\` listing, banner display (\`opus → bedrock/claude-opus-4.7\`), top-level \`--model opus\` routing, built-in shadow conflict, no-chain rule, and \`spawn_agent({\"model\":\"sonnet\"})\` alias expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)