### PR TITLE
feat(dashboard): live TUI aggregating pane/session/inbox/cron state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.28.0",
 ]
 
 [[package]]
@@ -43,6 +43,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "amaebi"
 version = "0.2.0"
 dependencies = [
@@ -53,9 +59,11 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "crossterm 0.28.1",
  "fs2",
  "futures-util",
  "libc",
+ "ratatui",
  "reqwest",
  "rusqlite",
  "serde",
@@ -69,7 +77,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "unicode-width",
+ "unicode-width 0.1.14",
  "uuid",
 ]
 
@@ -285,6 +293,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +387,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,7 +424,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4d7a805ca0d92f8c61a31c809d4323fdaa939b0b440e544d21db7797c5aaad"
 dependencies = [
- "crossterm",
+ "crossterm 0.23.2",
 ]
 
 [[package]]
@@ -469,12 +506,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio 1.1.1",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -516,6 +603,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -754,6 +847,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1000,6 +1095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1134,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1176,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1101,6 +1233,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1125,6 +1263,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1187,6 +1334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1249,6 +1397,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1417,6 +1571,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1752,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1584,7 +1772,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1823,6 +2011,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio 0.8.11",
+ "mio 1.1.1",
  "signal-hook",
 ]
 
@@ -1877,6 +2066,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,11 +2079,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -1949,7 +2166,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1961,10 +2178,10 @@ checksum = "2e32883199fc52cda7e431958dee8bc3ec6898afabc152b76959b9e0e74e2202"
 dependencies = [
  "coolor",
  "crossbeam",
- "crossterm",
+ "crossterm 0.23.2",
  "minimad",
  "thiserror 1.0.69",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2246,10 +2463,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "crossterm 0.28.1",
+ "crossterm",
  "fs2",
  "futures-util",
  "libc",
@@ -166,7 +166,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -270,6 +279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,16 +305,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -371,7 +389,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -388,9 +406,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -420,11 +438,11 @@ dependencies = [
 
 [[package]]
 name = "coolor"
-version = "0.5.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4d7a805ca0d92f8c61a31c809d4323fdaa939b0b440e544d21db7797c5aaad"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
 dependencies = [
- "crossterm 0.23.2",
+ "crossterm",
 ]
 
 [[package]]
@@ -432,6 +450,41 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crokey"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
+dependencies = [
+ "crossterm",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "crossbeam"
@@ -491,31 +544,17 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.23.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio 0.8.11",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.0",
  "crossterm_winapi",
- "mio 1.1.1",
+ "derive_more",
+ "document-features",
+ "mio",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -528,6 +567,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -550,7 +609,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -561,7 +620,22 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -583,8 +657,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -595,7 +679,16 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -624,6 +717,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -661,6 +763,16 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
@@ -677,10 +789,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -769,7 +910,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -799,6 +940,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -847,8 +998,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -858,6 +1007,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -875,6 +1026,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1152,7 +1309,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1179,9 +1336,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1200,6 +1357,46 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1232,10 +1429,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1248,6 +1448,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1266,11 +1472,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1278,6 +1484,16 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
 
 [[package]]
 name = "matchers"
@@ -1301,6 +1517,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,24 +1539,18 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimad"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b136454924e4d020e55c4992e07c105b40d5c41b84662862f0e15bc0a2efef"
+checksum = "df8b688969b16915f3ecadc7829d5b7779dee4977e503f767f34136803d5c06f"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.11"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1340,6 +1565,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,12 +1597,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1368,6 +1642,15 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking"
@@ -1399,16 +1682,105 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1429,6 +1801,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1814,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1453,7 +1837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1494,7 +1878,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -1543,12 +1927,21 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1558,8 +1951,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1572,22 +1971,86 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags 2.11.0",
- "cassowary",
  "compact_str",
- "crossterm 0.28.1",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
- "strum 0.26.3",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.2",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
  "unicode-width 0.2.0",
 ]
 
@@ -1617,7 +2080,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1752,19 +2215,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1772,7 +2222,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -1854,7 +2304,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1902,7 +2352,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1913,7 +2363,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1975,7 +2425,18 @@ checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2010,8 +2471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 0.8.11",
- "mio 1.1.1",
+ "mio",
  "signal-hook",
 ]
 
@@ -2024,6 +2484,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -2072,6 +2538,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,11 +2551,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.26.4",
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -2097,15 +2569,14 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2117,7 +2588,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2125,6 +2596,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2154,7 +2636,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2166,22 +2648,87 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "termimad"
-version = "0.23.2"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e32883199fc52cda7e431958dee8bc3ec6898afabc152b76959b9e0e74e2202"
+checksum = "889a9370996b74cf46016ce35b96c248a9ac36d69aab1d112b3e09bc33affa49"
 dependencies = [
  "coolor",
+ "crokey",
  "crossbeam",
- "crossterm 0.23.2",
+ "lazy-regex",
  "minimad",
- "thiserror 1.0.69",
+ "serde",
+ "thiserror 2.0.18",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.0",
+ "fancy-regex 0.11.0",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -2210,7 +2757,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2221,7 +2768,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2242,11 +2789,32 @@ dependencies = [
  "anyhow",
  "base64",
  "bstr",
- "fancy-regex",
+ "fancy-regex 0.13.0",
  "lazy_static",
  "regex",
  "rustc-hash 1.1.0",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -2281,7 +2849,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.1.1",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2298,7 +2866,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2402,7 +2970,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2451,6 +3019,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,13 +3044,13 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2527,6 +3107,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
@@ -2543,6 +3124,21 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "want"
@@ -2623,7 +3219,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2713,6 +3309,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,7 +3423,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2766,7 +3434,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2795,15 +3463,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2827,21 +3486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2879,12 +3523,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2897,12 +3535,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2912,12 +3544,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2945,12 +3571,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2960,12 +3580,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2981,12 +3595,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2996,12 +3604,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3045,7 +3647,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3061,7 +3663,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3128,7 +3730,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3149,7 +3751,7 @@ checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3169,7 +3771,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3209,7 +3811,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ tokio-util = { version = "0.7", features = ["compat"] }
 fs2 = "0.4"
 libc = "0.2"
 unicode-width = "0.1"
-termimad = "0.23"
-ratatui = "0.29"
-crossterm = "0.28"
+termimad = "0.34"
+ratatui = "0.30"
+crossterm = "0.29"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ fs2 = "0.4"
 libc = "0.2"
 unicode-width = "0.1"
 termimad = "0.23"
+ratatui = "0.29"
+crossterm = "0.28"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,6 +159,15 @@ pub enum Command {
         #[command(subcommand)]
         action: InboxAction,
     },
+    /// Live TUI dashboard aggregating session, pane, inbox, and cron state.
+    ///
+    /// Full-screen view that auto-refreshes every 2 s.  Shows environment
+    /// context, a task-summary card, and a unified activity stream merged
+    /// from panes (`~/.amaebi/tmux-state.json`), sessions (`memory.db`,
+    /// newest turn per session), inbox arrivals, and cron `last_run` events.
+    ///
+    /// Keys: `q` / Esc / Ctrl-C exits; `r` forces a re-read.
+    Dashboard,
 }
 
 #[derive(clap::Subcommand, Debug)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1965,7 +1965,7 @@ struct TaskContext {
 
 /// Run a single git command with an optional `-C <cwd>` prefix.
 /// Returns trimmed stdout on success, empty string on failure (best-effort).
-fn git_output(cwd: Option<&str>, args: &[&str]) -> String {
+pub(crate) fn git_output(cwd: Option<&str>, args: &[&str]) -> String {
     let mut cmd = std::process::Command::new("git");
     if let Some(c) = cwd {
         cmd.args(["-C", c]);

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -7,7 +7,7 @@
 //! the dashboard must render even on a freshly installed machine.
 //!
 //! Layout is three vertical panels, top to bottom:
-//! * Environment (5 lines) — cwd, git branch, model, sandbox
+//! * Environment (5 lines) — cwd, git branch, sandbox
 //! * Task summary (5 lines) — pane / cron / inbox counts
 //! * Activity (remaining) — unified event stream, tail mode, newest first
 //!
@@ -78,7 +78,6 @@ struct CronSummary {
 struct Environment {
     cwd: String,
     git_branch: String,
-    model: String,
     sandbox: String,
 }
 
@@ -172,11 +171,6 @@ fn collect_env() -> Environment {
     let cwd_for_git = cwd.clone();
     let git_branch = git_output(Some(&cwd_for_git), &["rev-parse", "--abbrev-ref", "HEAD"]);
 
-    let model = std::env::var("AMAEBI_MODEL")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| crate::provider::DEFAULT_MODEL.to_string());
-
     let sandbox = match std::env::var("AMAEBI_SANDBOX").as_deref() {
         Ok("docker") => {
             let image = std::env::var("AMAEBI_SANDBOX_IMAGE")
@@ -193,7 +187,6 @@ fn collect_env() -> Environment {
         } else {
             git_branch
         },
-        model,
         sandbox,
     }
 }
@@ -245,7 +238,15 @@ fn short_uuid(uuid: &str) -> String {
 }
 
 fn truncate_snippet(s: &str, max: usize) -> String {
-    let compact: String = s.chars().map(|c| if c == '\n' { ' ' } else { c }).collect();
+    // Drop C0 control chars (ESC, BEL, bare CR, etc.) so ANSI escape
+    // sequences stored in memory/inbox content cannot escape the ratatui
+    // buffer and mess up the dashboard's rendering.  Keep \n/\t and collapse
+    // whitespace.
+    let compact: String = s
+        .chars()
+        .map(|c| if c == '\n' { ' ' } else { c })
+        .filter(|c| !c.is_control() || *c == '\t')
+        .collect();
     let compact = compact.split_whitespace().collect::<Vec<_>>().join(" ");
     if compact.chars().count() <= max {
         compact
@@ -380,10 +381,6 @@ fn env_lines(env: &Environment) -> Vec<Line<'_>> {
             Span::raw("   "),
             Span::styled("branch: ", Style::default().fg(Color::DarkGray)),
             Span::raw(env.git_branch.clone()),
-        ]),
-        Line::from(vec![
-            Span::styled("model: ", Style::default().fg(Color::DarkGray)),
-            Span::raw(env.model.clone()),
         ]),
         Line::from(vec![
             Span::styled("sandbox: ", Style::default().fg(Color::DarkGray)),
@@ -758,6 +755,19 @@ mod tests {
         assert_eq!(truncate_snippet(s, 20), "abcdefghij");
         // Multi-line collapses.
         assert_eq!(truncate_snippet("a\nb\nc", 20), "a b c");
+    }
+
+    #[test]
+    fn truncate_snippet_strips_control_chars() {
+        // Stripping the leading ESC is enough to neutralise the sequence —
+        // the terminal can no longer interpret `[31m...` as a color code
+        // without the preceding ESC, so the TUI buffer stays intact.  The
+        // residual `[31m` characters are harmless ASCII.
+        let out = truncate_snippet("\x1b[31mred\x1b[0m done", 50);
+        assert!(!out.contains('\x1b'), "ESC must be stripped: {out:?}");
+        assert_eq!(truncate_snippet("before\x07after", 50), "beforeafter");
+        // Tab is preserved (gets collapsed by split_whitespace).
+        assert_eq!(truncate_snippet("a\tb", 50), "a b");
     }
 
     #[test]

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -1,0 +1,749 @@
+//! `amaebi dashboard` — live TUI aggregating pane / session / inbox / cron state.
+//!
+//! Read-only observer: does not touch the daemon via IPC and does not modify
+//! any on-disk state. Every tick re-reads the existing files (sessions.json,
+//! tmux-state.json, inbox.db, cron.db, memory.db) and rebuilds a fresh
+//! `Snapshot`. Sources that are missing or fail to open are treated as empty —
+//! the dashboard must render even on a freshly installed machine.
+//!
+//! Layout is three vertical panels, top to bottom:
+//! * Environment (5 lines) — cwd, git branch, model, sandbox
+//! * Task summary (5 lines) — pane / cron / inbox counts
+//! * Activity (remaining) — unified event stream, tail mode, newest first
+//!
+//! Keys: `q` / Esc / Ctrl-C exit; `r` forces an immediate re-read. Auto-refresh
+//! ticks every [`REFRESH`].
+
+use std::io::{stdout, Stdout};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, TimeZone, Utc};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::Terminal;
+
+use crate::cron::CronJob;
+use crate::inbox::InboxReport;
+use crate::memory_db;
+use crate::pane_lease::{PaneLease, PaneStatus};
+
+const REFRESH: Duration = Duration::from_secs(2);
+const ACTIVITY_CAP: usize = 20;
+const SESSION_EVENT_CAP: usize = 20;
+const PROMPT_SNIPPET_CHARS: usize = 80;
+
+// ---------------------------------------------------------------------------
+// Snapshot aggregation
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+enum Source {
+    Pane(String),
+    Session(String),
+    Cron,
+    Inbox(i64),
+}
+
+#[derive(Clone, Debug)]
+struct ActivityEvent {
+    when: DateTime<Utc>,
+    source: Source,
+    summary: String,
+}
+
+#[derive(Default, Clone, Debug)]
+struct PaneCounts {
+    busy: usize,
+    idle: usize,
+    /// Busy panes that have not yet started `claude` — still spinning up.
+    starting: usize,
+}
+
+#[derive(Clone, Debug)]
+struct CronSummary {
+    scheduled: usize,
+    last_run: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Debug)]
+struct Environment {
+    cwd: String,
+    git_branch: String,
+    model: String,
+    sandbox: String,
+}
+
+#[derive(Clone, Debug)]
+struct Snapshot {
+    env: Environment,
+    panes: PaneCounts,
+    cron: CronSummary,
+    inbox_unread: usize,
+    activity: Vec<ActivityEvent>,
+}
+
+impl Snapshot {
+    fn collect() -> Self {
+        let env = collect_env();
+        let panes_vec = crate::pane_lease::read_state().unwrap_or_default();
+        let panes = count_panes(&panes_vec.values().cloned().collect::<Vec<_>>());
+
+        let inbox_reports = crate::inbox::InboxStore::open()
+            .and_then(|s| s.get_all())
+            .unwrap_or_default();
+        let inbox_unread = inbox_reports.iter().filter(|r| !r.read).count();
+
+        let cron_jobs = crate::cron::load_jobs().unwrap_or_default();
+        let cron = summarize_cron(&cron_jobs);
+
+        let session_events = collect_session_events().unwrap_or_default();
+
+        let mut activity = Vec::new();
+        activity.extend(collect_pane_events(panes_vec.values()));
+        activity.extend(collect_cron_events(&cron_jobs));
+        activity.extend(collect_inbox_events(&inbox_reports));
+        activity.extend(session_events);
+        activity.sort_by(|a, b| b.when.cmp(&a.when));
+        activity.truncate(ACTIVITY_CAP);
+
+        Self {
+            env,
+            panes,
+            cron,
+            inbox_unread,
+            activity,
+        }
+    }
+}
+
+fn collect_env() -> Environment {
+    let cwd = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "(unknown)".to_string());
+
+    let cwd_for_git = cwd.clone();
+    let git_branch = git_output(Some(&cwd_for_git), &["rev-parse", "--abbrev-ref", "HEAD"]);
+
+    let model = std::env::var("AMAEBI_MODEL")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| crate::provider::DEFAULT_MODEL.to_string());
+
+    let sandbox = match std::env::var("AMAEBI_SANDBOX").as_deref() {
+        Ok("docker") => {
+            let image = std::env::var("AMAEBI_SANDBOX_IMAGE")
+                .unwrap_or_else(|_| "amaebi-sandbox:bookworm-slim".to_string());
+            format!("docker ({image})")
+        }
+        _ => "off".to_string(),
+    };
+
+    Environment {
+        cwd,
+        git_branch: if git_branch.is_empty() {
+            "(not a git repo)".to_string()
+        } else {
+            git_branch
+        },
+        model,
+        sandbox,
+    }
+}
+
+/// Best-effort git probe; returns empty string on any failure.
+fn git_output(cwd: Option<&str>, args: &[&str]) -> String {
+    let mut cmd = std::process::Command::new("git");
+    if let Some(c) = cwd {
+        cmd.args(["-C", c]);
+    }
+    cmd.args(args)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn count_panes(panes: &[PaneLease]) -> PaneCounts {
+    let mut out = PaneCounts::default();
+    for p in panes {
+        match p.effective_status() {
+            PaneStatus::Busy => {
+                if p.has_claude {
+                    out.busy += 1;
+                } else {
+                    // Busy but claude not yet running = still starting up.
+                    out.starting += 1;
+                }
+            }
+            PaneStatus::Idle => out.idle += 1,
+        }
+    }
+    out
+}
+
+fn summarize_cron(jobs: &[CronJob]) -> CronSummary {
+    let last_run = jobs
+        .iter()
+        .filter_map(|j| j.last_run.as_deref().and_then(parse_rfc3339))
+        .max();
+    CronSummary {
+        scheduled: jobs.len(),
+        last_run,
+    }
+}
+
+fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|d| d.with_timezone(&Utc))
+}
+
+fn from_unix_secs(ts: u64) -> Option<DateTime<Utc>> {
+    Utc.timestamp_opt(ts as i64, 0).single()
+}
+
+fn short_uuid(uuid: &str) -> String {
+    uuid.chars().take(8).collect()
+}
+
+fn truncate_snippet(s: &str, max: usize) -> String {
+    let compact: String = s.chars().map(|c| if c == '\n' { ' ' } else { c }).collect();
+    let compact = compact.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= max {
+        compact
+    } else {
+        let head: String = compact.chars().take(max).collect();
+        format!("{head}…")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Event collectors (pure, individually testable)
+// ---------------------------------------------------------------------------
+
+fn collect_pane_events<'a, I>(panes: I) -> Vec<ActivityEvent>
+where
+    I: IntoIterator<Item = &'a PaneLease>,
+{
+    let mut events = Vec::new();
+    for p in panes {
+        let Some(when) = from_unix_secs(p.heartbeat_at) else {
+            continue;
+        };
+        let status = match p.effective_status() {
+            PaneStatus::Busy if p.has_claude => "busy",
+            PaneStatus::Busy => "starting",
+            PaneStatus::Idle => "idle",
+        };
+        let task = p.task_id.as_deref().unwrap_or("(idle)");
+        let summary = format!("{status} — {task}");
+        events.push(ActivityEvent {
+            when,
+            source: Source::Pane(p.pane_id.clone()),
+            summary,
+        });
+    }
+    events
+}
+
+fn collect_cron_events(jobs: &[CronJob]) -> Vec<ActivityEvent> {
+    jobs.iter()
+        .filter_map(|j| {
+            let last = j.last_run.as_deref().and_then(parse_rfc3339)?;
+            Some(ActivityEvent {
+                when: last,
+                source: Source::Cron,
+                summary: format!("\"{}\" ran", j.description),
+            })
+        })
+        .collect()
+}
+
+fn collect_inbox_events(reports: &[InboxReport]) -> Vec<ActivityEvent> {
+    reports
+        .iter()
+        .filter_map(|r| {
+            let when = parse_rfc3339(&r.created_at)?;
+            let read_marker = if r.read { "" } else { " (unread)" };
+            Some(ActivityEvent {
+                when,
+                source: Source::Inbox(r.id),
+                summary: format!("{}{}", r.task_description, read_marker),
+            })
+        })
+        .collect()
+}
+
+fn collect_session_events() -> Result<Vec<ActivityEvent>> {
+    // Reading memory.db requires opening a fresh connection each tick; keep
+    // it best-effort so a missing file or schema mismatch does not kill the
+    // dashboard.
+    let path = memory_db::db_path()?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let conn = memory_db::init_db(&path)?;
+    let entries = memory_db::get_latest_per_session(&conn, SESSION_EVENT_CAP)?;
+    let mut events = Vec::new();
+    for e in entries {
+        let Some(when) = parse_rfc3339(&e.timestamp) else {
+            continue;
+        };
+        let snippet = truncate_snippet(&e.content, PROMPT_SNIPPET_CHARS);
+        let summary = format!("{}: \"{}\"", e.role, snippet);
+        events.push(ActivityEvent {
+            when,
+            source: Source::Session(short_uuid(&e.session_id)),
+            summary,
+        });
+    }
+    Ok(events)
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+fn relative_time(when: DateTime<Utc>, now: DateTime<Utc>) -> String {
+    let delta = now.signed_duration_since(when);
+    let secs = delta.num_seconds();
+    if secs < 0 {
+        return "soon".to_string();
+    }
+    if secs < 60 {
+        return format!("{secs}s ago");
+    }
+    let mins = secs / 60;
+    if mins < 60 {
+        return format!("{mins}m ago");
+    }
+    let hours = mins / 60;
+    if hours < 24 {
+        return format!("{hours}h ago");
+    }
+    let days = hours / 24;
+    format!("{days}d ago")
+}
+
+fn format_source(src: &Source) -> String {
+    match src {
+        Source::Pane(id) => format!("[pane {id}]"),
+        Source::Session(id) => format!("[session {id}]"),
+        Source::Cron => "[cron]".to_string(),
+        Source::Inbox(id) => format!("[inbox #{id}]"),
+    }
+}
+
+fn env_lines(env: &Environment) -> Vec<Line<'_>> {
+    vec![
+        Line::from(vec![
+            Span::styled("cwd: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(env.cwd.clone()),
+            Span::raw("   "),
+            Span::styled("branch: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(env.git_branch.clone()),
+        ]),
+        Line::from(vec![
+            Span::styled("model: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(env.model.clone()),
+        ]),
+        Line::from(vec![
+            Span::styled("sandbox: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(env.sandbox.clone()),
+        ]),
+    ]
+}
+
+fn summary_lines(snap: &Snapshot, now: DateTime<Utc>) -> Vec<Line<'_>> {
+    let panes_line = format!(
+        "Panes    {busy} busy · {idle} idle · {starting} starting",
+        busy = snap.panes.busy,
+        idle = snap.panes.idle,
+        starting = snap.panes.starting,
+    );
+    let last_run = snap
+        .cron
+        .last_run
+        .map(|t| relative_time(t, now))
+        .unwrap_or_else(|| "never".to_string());
+    let cron_line = format!(
+        "Cron     {n} scheduled · last {last}",
+        n = snap.cron.scheduled,
+        last = last_run,
+    );
+    let inbox_line = format!("Inbox    {} unread", snap.inbox_unread);
+    vec![
+        Line::from(panes_line),
+        Line::from(cron_line),
+        Line::from(inbox_line),
+    ]
+}
+
+fn activity_lines(events: &[ActivityEvent], now: DateTime<Utc>) -> Vec<Line<'_>> {
+    if events.is_empty() {
+        return vec![Line::from(Span::styled(
+            "(no activity yet — start a chat, spawn a pane, or wait for cron)",
+            Style::default().fg(Color::DarkGray),
+        ))];
+    }
+    events
+        .iter()
+        .map(|e| {
+            let time = relative_time(e.when, now);
+            let src = format_source(&e.source);
+            Line::from(vec![
+                Span::styled(format!("{time:>8}  "), Style::default().fg(Color::DarkGray)),
+                Span::styled(format!("{src:<18} "), Style::default().fg(Color::Cyan)),
+                Span::raw(e.summary.clone()),
+            ])
+        })
+        .collect()
+}
+
+fn draw(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    snap: &Snapshot,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    terminal
+        .draw(|f| {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(5),
+                    Constraint::Length(5),
+                    Constraint::Min(5),
+                ])
+                .split(f.area());
+
+            let env_block = Paragraph::new(env_lines(&snap.env)).block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Environment "),
+            );
+            f.render_widget(env_block, chunks[0]);
+
+            let summary_block = Paragraph::new(summary_lines(snap, now)).block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Task summary "),
+            );
+            f.render_widget(summary_block, chunks[1]);
+
+            let activity_title = format!(
+                " Activity (last {}, newest first — q quit, r refresh) ",
+                snap.activity.len()
+            );
+            let activity_block = Paragraph::new(activity_lines(&snap.activity, now)).block(
+                Block::default().borders(Borders::ALL).title(Span::styled(
+                    activity_title,
+                    Style::default().add_modifier(Modifier::BOLD),
+                )),
+            );
+            f.render_widget(activity_block, chunks[2]);
+        })
+        .context("drawing dashboard frame")?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Entry point + terminal lifecycle
+// ---------------------------------------------------------------------------
+
+struct TerminalGuard;
+
+impl TerminalGuard {
+    fn enter() -> Result<Self> {
+        enable_raw_mode().context("enabling raw mode")?;
+        execute!(stdout(), EnterAlternateScreen).context("entering alternate screen")?;
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(stdout(), LeaveAlternateScreen);
+    }
+}
+
+/// Run the dashboard until the user exits.
+pub async fn run() -> Result<()> {
+    // Spin up terminal in a `spawn_blocking` so we don't hold the runtime
+    // busy in the raw-mode polling loop.
+    tokio::task::spawn_blocking(run_blocking)
+        .await
+        .context("dashboard task panicked")?
+}
+
+fn run_blocking() -> Result<()> {
+    let _guard = TerminalGuard::enter()?;
+    let backend = CrosstermBackend::new(stdout());
+    let mut terminal = Terminal::new(backend).context("creating terminal")?;
+
+    let mut snap = Snapshot::collect();
+    let mut last_refresh = Instant::now();
+    draw(&mut terminal, &snap, Utc::now())?;
+
+    loop {
+        // Poll with a short timeout so we can both react to keys and refresh.
+        let remaining = REFRESH.saturating_sub(last_refresh.elapsed());
+        let poll_timeout = remaining.min(Duration::from_millis(250));
+        let had_event = event::poll(poll_timeout).context("polling terminal events")?;
+        if had_event {
+            match event::read().context("reading terminal event")? {
+                Event::Key(KeyEvent {
+                    code, modifiers, ..
+                }) => {
+                    let ctrl_c = modifiers.contains(KeyModifiers::CONTROL)
+                        && matches!(code, KeyCode::Char('c') | KeyCode::Char('C'));
+                    let quit = ctrl_c
+                        || matches!(code, KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc);
+                    if quit {
+                        break;
+                    }
+                    if matches!(code, KeyCode::Char('r') | KeyCode::Char('R')) {
+                        snap = Snapshot::collect();
+                        last_refresh = Instant::now();
+                        draw(&mut terminal, &snap, Utc::now())?;
+                    }
+                }
+                Event::Resize(_, _) => {
+                    draw(&mut terminal, &snap, Utc::now())?;
+                }
+                _ => {}
+            }
+        }
+        if last_refresh.elapsed() >= REFRESH {
+            snap = Snapshot::collect();
+            last_refresh = Instant::now();
+            draw(&mut terminal, &snap, Utc::now())?;
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cron::CronJob;
+    use crate::inbox::{InboxReport, InboxStore};
+    use crate::pane_lease::{PaneLease, PaneStatus};
+    use crate::test_utils::with_temp_home;
+
+    fn pane(
+        id: &str,
+        status: PaneStatus,
+        has_claude: bool,
+        heartbeat: u64,
+        task: Option<&str>,
+    ) -> PaneLease {
+        PaneLease {
+            pane_id: id.to_string(),
+            window_id: "@0".to_string(),
+            status,
+            task_id: task.map(String::from),
+            session_id: None,
+            worktree: None,
+            heartbeat_at: heartbeat,
+            has_claude,
+        }
+    }
+
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    #[test]
+    fn count_panes_separates_busy_idle_starting() {
+        // Use fresh heartbeats so effective_status() doesn't downgrade Busy
+        // past LEASE_TTL_SECS.
+        let now = now_secs();
+        let panes = vec![
+            pane("%1", PaneStatus::Busy, true, now, Some("pr-1")),
+            pane("%2", PaneStatus::Busy, false, now, Some("pr-2")), // starting
+            pane("%3", PaneStatus::Idle, true, now, None),
+            pane("%4", PaneStatus::Idle, false, now, None),
+        ];
+        let c = count_panes(&panes);
+        assert_eq!(c.busy, 1);
+        assert_eq!(c.starting, 1);
+        assert_eq!(c.idle, 2);
+    }
+
+    #[test]
+    fn collect_pane_events_one_per_pane() {
+        let now = now_secs();
+        let panes = vec![
+            pane("%1", PaneStatus::Busy, true, now, Some("pr-1")),
+            pane("%2", PaneStatus::Idle, false, now, None),
+        ];
+        let events: Vec<_> = collect_pane_events(panes.iter()).into_iter().collect();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0].source, Source::Pane(ref id) if id == "%1"));
+        assert!(events[0].summary.contains("busy"));
+        assert!(events[1].summary.contains("idle"));
+    }
+
+    #[test]
+    fn collect_cron_events_skips_jobs_with_no_last_run() {
+        let jobs = vec![
+            CronJob {
+                id: "a".into(),
+                description: "ran".into(),
+                schedule: "* * * * *".into(),
+                created_at: "2026-04-22T00:00:00Z".into(),
+                last_run: Some("2026-04-22T10:00:00Z".into()),
+            },
+            CronJob {
+                id: "b".into(),
+                description: "never".into(),
+                schedule: "* * * * *".into(),
+                created_at: "2026-04-22T00:00:00Z".into(),
+                last_run: None,
+            },
+        ];
+        let events = collect_cron_events(&jobs);
+        assert_eq!(events.len(), 1);
+        assert!(events[0].summary.contains("\"ran\""));
+    }
+
+    #[test]
+    fn collect_inbox_events_tags_unread() {
+        let reports = vec![
+            InboxReport {
+                id: 1,
+                session_id: "s1".into(),
+                task_description: "unread task".into(),
+                output: String::new(),
+                created_at: "2026-04-22T09:00:00Z".into(),
+                read: false,
+            },
+            InboxReport {
+                id: 2,
+                session_id: "s2".into(),
+                task_description: "read task".into(),
+                output: String::new(),
+                created_at: "2026-04-22T08:00:00Z".into(),
+                read: true,
+            },
+        ];
+        let events = collect_inbox_events(&reports);
+        assert_eq!(events.len(), 2);
+        assert!(events[0].summary.contains("(unread)"));
+        assert!(!events[1].summary.contains("(unread)"));
+    }
+
+    #[test]
+    fn snapshot_sort_is_descending_and_capped() {
+        // Build events with known timestamps; the merge in Snapshot::collect
+        // sorts descending and truncates to ACTIVITY_CAP.
+        let now = Utc::now();
+        let mut events: Vec<ActivityEvent> = (0..50)
+            .map(|i| ActivityEvent {
+                when: now - chrono::Duration::minutes(i),
+                source: Source::Cron,
+                summary: format!("e{i}"),
+            })
+            .collect();
+        events.sort_by(|a, b| b.when.cmp(&a.when));
+        events.truncate(ACTIVITY_CAP);
+        assert_eq!(events.len(), ACTIVITY_CAP);
+        // Newest first.
+        for w in events.windows(2) {
+            assert!(w[0].when >= w[1].when);
+        }
+    }
+
+    #[test]
+    fn snapshot_collect_runs_with_empty_home() {
+        let _guard = with_temp_home();
+        // Should not panic or hang with zero data sources in a fresh HOME.
+        let snap = Snapshot::collect();
+        assert_eq!(snap.panes.busy, 0);
+        assert_eq!(snap.panes.idle, 0);
+        assert_eq!(snap.cron.scheduled, 0);
+        assert_eq!(snap.inbox_unread, 0);
+    }
+
+    #[test]
+    fn snapshot_collect_sees_inbox_unread() {
+        let _guard = with_temp_home();
+        let store = InboxStore::open().unwrap();
+        store.save_report("sid", "task 1", "out").unwrap();
+        store.save_report("sid", "task 2", "out").unwrap();
+
+        let snap = Snapshot::collect();
+        assert_eq!(snap.inbox_unread, 2);
+        // Inbox events should be present.
+        assert!(snap
+            .activity
+            .iter()
+            .any(|e| matches!(e.source, Source::Inbox(_))));
+    }
+
+    #[test]
+    fn relative_time_formats() {
+        let now = Utc::now();
+        assert!(relative_time(now, now).ends_with("s ago"));
+        assert_eq!(
+            relative_time(now - chrono::Duration::minutes(5), now),
+            "5m ago"
+        );
+        assert_eq!(
+            relative_time(now - chrono::Duration::hours(2), now),
+            "2h ago"
+        );
+        assert_eq!(
+            relative_time(now - chrono::Duration::days(3), now),
+            "3d ago"
+        );
+    }
+
+    #[test]
+    fn truncate_snippet_respects_char_boundary() {
+        let s = "abcdefghij";
+        assert_eq!(truncate_snippet(s, 5), "abcde…");
+        assert_eq!(truncate_snippet(s, 20), "abcdefghij");
+        // Multi-line collapses.
+        assert_eq!(truncate_snippet("a\nb\nc", 20), "a b c");
+    }
+
+    #[test]
+    fn short_uuid_is_first_eight() {
+        assert_eq!(
+            short_uuid("7fd69d7f-9195-4d98-bfe5-6b61d887ec97"),
+            "7fd69d7f"
+        );
+    }
+
+    #[test]
+    fn format_source_shapes() {
+        assert_eq!(format_source(&Source::Cron), "[cron]");
+        assert_eq!(format_source(&Source::Inbox(17)), "[inbox #17]");
+        assert_eq!(format_source(&Source::Pane("%3".into())), "[pane %3]");
+        assert_eq!(
+            format_source(&Source::Session("abc".into())),
+            "[session abc]"
+        );
+    }
+}

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -97,23 +97,38 @@ impl Snapshot {
         let panes_vec = crate::pane_lease::read_state().unwrap_or_default();
         let panes = count_panes(&panes_vec.values().cloned().collect::<Vec<_>>());
 
-        let inbox_reports = crate::inbox::InboxStore::open()
-            .and_then(|s| s.get_all())
-            .unwrap_or_default();
+        // All three SQLite sources are opened as "best-effort read".  If the
+        // DB file does not exist yet (user hasn't used that feature), skip
+        // the open entirely so the dashboard never creates empty .db/WAL/SHM
+        // files as a side effect of running `amaebi dashboard`.
+        let inbox_reports = if amaebi_file_exists("inbox.db") {
+            crate::inbox::InboxStore::open()
+                .and_then(|s| s.get_all())
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
         let inbox_unread = inbox_reports.iter().filter(|r| !r.read).count();
 
-        let cron_jobs = crate::cron::load_jobs().unwrap_or_default();
+        let cron_jobs = if amaebi_file_exists("cron.db") {
+            crate::cron::load_jobs().unwrap_or_default()
+        } else {
+            Vec::new()
+        };
         let cron = summarize_cron(&cron_jobs);
 
-        let session_events = collect_session_events().unwrap_or_default();
+        let session_events = if memory_db_exists() {
+            collect_session_events().unwrap_or_default()
+        } else {
+            Vec::new()
+        };
 
         let mut activity = Vec::new();
         activity.extend(collect_pane_events(panes_vec.values()));
         activity.extend(collect_cron_events(&cron_jobs));
         activity.extend(collect_inbox_events(&inbox_reports));
         activity.extend(session_events);
-        activity.sort_by_key(|e| std::cmp::Reverse(e.when));
-        activity.truncate(ACTIVITY_CAP);
+        finalize_activity(&mut activity);
 
         Self {
             env,
@@ -123,6 +138,30 @@ impl Snapshot {
             activity,
         }
     }
+}
+
+/// Sort `events` newest-first and truncate to [`ACTIVITY_CAP`].
+///
+/// Extracted from `Snapshot::collect` so tests can exercise the real
+/// merge/sort/truncate pipeline instead of re-implementing it.
+fn finalize_activity(events: &mut Vec<ActivityEvent>) {
+    events.sort_by_key(|e| std::cmp::Reverse(e.when));
+    events.truncate(ACTIVITY_CAP);
+}
+
+/// True when `~/.amaebi/<name>` exists.  Used to skip opening SQLite
+/// connections for sources the user hasn't initialised yet, so the
+/// dashboard never creates empty DB/WAL/SHM files as a side effect.
+fn amaebi_file_exists(name: &str) -> bool {
+    crate::auth::amaebi_home()
+        .map(|p| p.join(name).exists())
+        .unwrap_or(false)
+}
+
+fn memory_db_exists() -> bool {
+    crate::memory_db::db_path()
+        .map(|p| p.exists())
+        .unwrap_or(false)
 }
 
 fn collect_env() -> Environment {
@@ -159,21 +198,8 @@ fn collect_env() -> Environment {
     }
 }
 
-/// Best-effort git probe; returns empty string on any failure.
-fn git_output(cwd: Option<&str>, args: &[&str]) -> String {
-    let mut cmd = std::process::Command::new("git");
-    if let Some(c) = cwd {
-        cmd.args(["-C", c]);
-    }
-    cmd.args(args)
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .unwrap_or_default()
-        .trim()
-        .to_string()
-}
+// Re-use the daemon's best-effort git helper so the two stay in sync.
+use crate::daemon::git_output;
 
 fn count_panes(panes: &[PaneLease]) -> PaneCounts {
     let mut out = PaneCounts::default();
@@ -467,7 +493,12 @@ struct TerminalGuard;
 impl TerminalGuard {
     fn enter() -> Result<Self> {
         enable_raw_mode().context("enabling raw mode")?;
-        execute!(stdout(), EnterAlternateScreen).context("entering alternate screen")?;
+        // If entering the alt screen fails we need to roll raw mode back;
+        // otherwise the caller's terminal is left in a broken state.
+        if let Err(e) = execute!(stdout(), EnterAlternateScreen) {
+            let _ = disable_raw_mode();
+            return Err(anyhow::Error::new(e).context("entering alternate screen"));
+        }
         Ok(Self)
     }
 }
@@ -655,18 +686,19 @@ mod tests {
 
     #[test]
     fn snapshot_sort_is_descending_and_capped() {
-        // Build events with known timestamps; the merge in Snapshot::collect
-        // sorts descending and truncates to ACTIVITY_CAP.
+        // Build unsorted events and run them through the same helper the
+        // production Snapshot::collect uses, so this test fails if the
+        // merge/sort/truncate logic regresses.
         let now = Utc::now();
         let mut events: Vec<ActivityEvent> = (0..50)
             .map(|i| ActivityEvent {
-                when: now - chrono::Duration::minutes(i),
+                // Interleave so the input is not already sorted.
+                when: now - chrono::Duration::minutes((i * 37) % 50),
                 source: Source::Cron,
                 summary: format!("e{i}"),
             })
             .collect();
-        events.sort_by(|a, b| b.when.cmp(&a.when));
-        events.truncate(ACTIVITY_CAP);
+        finalize_activity(&mut events);
         assert_eq!(events.len(), ACTIVITY_CAP);
         // Newest first.
         for w in events.windows(2) {

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -112,7 +112,7 @@ impl Snapshot {
         activity.extend(collect_cron_events(&cron_jobs));
         activity.extend(collect_inbox_events(&inbox_reports));
         activity.extend(session_events);
-        activity.sort_by(|a, b| b.when.cmp(&a.when));
+        activity.sort_by_key(|e| std::cmp::Reverse(e.when));
         activity.truncate(ACTIVITY_CAP);
 
         Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod config;
 mod copilot;
 mod cron;
 mod daemon;
+mod dashboard;
 mod inbox;
 mod ipc;
 mod memory_db;
@@ -122,6 +123,7 @@ async fn main() -> Result<()> {
         cli::Command::Cache { action } => run_cache(action),
         cli::Command::Inbox { action } => run_inbox(action),
         cli::Command::Cron { action } => run_cron(action),
+        cli::Command::Dashboard => dashboard::run().await,
     }
 }
 

--- a/src/memory_db.rs
+++ b/src/memory_db.rs
@@ -818,4 +818,50 @@ mod tests {
         let summaries = get_recent_summaries(&conn, "s3", 10).unwrap();
         assert_eq!(summaries, vec!["summary A", "summary B"]);
     }
+
+    #[test]
+    fn get_latest_per_session_returns_one_row_per_session_newest_first() {
+        let (conn, _dir) = open_test_db();
+        // s1: two messages; we expect the later one (id 2).
+        store_memory(&conn, "2026-01-01T00:00:00Z", "s1", "user", "hi s1", "").unwrap();
+        store_memory(
+            &conn,
+            "2026-01-01T00:00:01Z",
+            "s1",
+            "assistant",
+            "s1 reply",
+            "",
+        )
+        .unwrap();
+        // s2: single message (id 3).
+        store_memory(&conn, "2026-01-01T00:00:02Z", "s2", "user", "hi s2", "").unwrap();
+        // s3: single message (id 4) but archive it — must be excluded.
+        store_memory(&conn, "2026-01-01T00:00:03Z", "s3", "user", "archived", "").unwrap();
+        conn.execute(
+            "UPDATE memories SET archived = 1 WHERE session_id = 's3'",
+            [],
+        )
+        .unwrap();
+
+        let rows = get_latest_per_session(&conn, 10).unwrap();
+        // Expect: s2 (id 3) then s1 (id 2). s3 is archived → excluded.
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].session_id, "s2");
+        assert_eq!(rows[0].content, "hi s2");
+        assert_eq!(rows[1].session_id, "s1");
+        assert_eq!(rows[1].content, "s1 reply");
+    }
+
+    #[test]
+    fn get_latest_per_session_respects_limit() {
+        let (conn, _dir) = open_test_db();
+        store_memory(&conn, "2026-01-01T00:00:00Z", "s1", "user", "a", "").unwrap();
+        store_memory(&conn, "2026-01-01T00:00:01Z", "s2", "user", "b", "").unwrap();
+        store_memory(&conn, "2026-01-01T00:00:02Z", "s3", "user", "c", "").unwrap();
+        let rows = get_latest_per_session(&conn, 2).unwrap();
+        assert_eq!(rows.len(), 2);
+        // Newest first → s3, s2.
+        assert_eq!(rows[0].session_id, "s3");
+        assert_eq!(rows[1].session_id, "s2");
+    }
 }

--- a/src/memory_db.rs
+++ b/src/memory_db.rs
@@ -221,6 +221,31 @@ pub fn get_recent(conn: &Connection, limit: usize) -> Result<Vec<DbMemoryEntry>>
     Ok(entries)
 }
 
+/// Return the most-recent entry for each distinct `session_id`, newest first.
+///
+/// Used by the dashboard to show one "latest activity" line per session
+/// without being swamped by intra-session chatter.  Honors `archived = 0`.
+pub fn get_latest_per_session(conn: &Connection, limit: usize) -> Result<Vec<DbMemoryEntry>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, timestamp, session_id, role, content, summary
+             FROM memories
+             WHERE archived = 0 AND id IN (
+                 SELECT MAX(id) FROM memories WHERE archived = 0 GROUP BY session_id
+             )
+             ORDER BY id DESC
+             LIMIT ?1",
+        )
+        .context("preparing get_latest_per_session query")?;
+
+    let entries = stmt
+        .query_map(params![limit as i64], row_to_entry)
+        .context("executing get_latest_per_session")?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .context("collecting get_latest_per_session results")?;
+    Ok(entries)
+}
+
 /// Return all messages for a given `session_id` in chronological order.
 ///
 /// Used by `--resume` to reload full conversation history from the DB


### PR DESCRIPTION
## Summary
Adds \`amaebi dashboard\` — a full-screen ratatui view that auto-refreshes every 2 s and gives a single pane of glass for:

- **Environment**: cwd, git branch, model, sandbox
- **Task summary**: pane busy/idle/starting, cron scheduled + last run, inbox unread
- **Activity** (unified stream, newest first, capped 20): panes, cron \`last_run\`, inbox arrivals, and one latest-turn-per-session entry from \`memory.db\`

Read-only — no IPC changes, no on-disk writes. Every source is best-effort: if a file or db is missing, its slice of the stream is simply empty.

Keys: \`q\` / Esc / Ctrl-C exit; \`r\` forces a re-read.

## What's new
- \`src/dashboard.rs\` — the module (~600 LOC, 11 unit tests)
- \`ratatui 0.29\` + \`crossterm 0.28\` as direct deps
- \`memory_db::get_latest_per_session(conn, limit)\` — needed because no existing API answered \"newest turn per session\"; implemented with a single \`MAX(id) GROUP BY session_id\` SQL
- \`cli::Command::Dashboard\` + main.rs routing

## Layout
\`\`\`
┌─ Environment ─────────────────────────────┐
│ cwd: …   branch: …                        │
│ model: …                                  │
│ sandbox: …                                │
└───────────────────────────────────────────┘
┌─ Task summary ────────────────────────────┐
│ Panes    N busy · N idle · N starting     │
│ Cron     N scheduled · last …             │
│ Inbox    N unread                         │
└───────────────────────────────────────────┘
┌─ Activity (last 20, newest first) ────────┐
│ 2m ago   [pane %3]       busy — pr-124    │
│ 28m ago  [session abc1…] user: \"…\"      │
│ 2h ago   [cron]          \"nightly\" ran  │
│ …                                         │
└───────────────────────────────────────────┘
\`\`\`

## Test plan
- [x] \`cargo test\` — all 35 pass, 11 new dashboard tests
- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy -- -D warnings\` — clean (matches CI)
- [ ] Manual smoke: \`cargo run -- dashboard\` renders, \`q\` exits cleanly, terminal restored

## Non-goals (deferred)
- History scrolling / PgUp — tail mode only
- Pause / control actions — read-only MVP
- \`Request::Status\` IPC for \"is this session currently running in daemon\" — future iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)