### PR TITLE
fix(memory_db): scope session_summaries by dir to stop cross-project leaks

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -525,16 +525,24 @@ where
 ///
 /// Returns `(history, summaries, own_summary)`.  On error, logs a warning and
 /// returns empty defaults so the caller can still proceed with a fresh context.
+///
+/// Summaries are scoped to the session's working directory: we look up the
+/// dir for `session_id` in `sessions.json` and pass it to
+/// `get_recent_summaries` so cross-project sessions cannot see each other's
+/// compacted context.  If the lookup fails (session removed, race, etc.) we
+/// fall back to `""` — which only matches legacy pre-migration rows and
+/// never any dir-tagged summary.
 async fn load_session_state(
     state: &Arc<DaemonState>,
     session_id: &str,
 ) -> (Vec<memory_db::DbMemoryEntry>, Vec<String>, Option<String>) {
+    let dir = resolve_session_dir(session_id).await;
     with_db(Arc::clone(&state.db), {
         let sid = session_id.to_owned();
         move |conn| {
             Ok((
                 memory_db::get_session_history(conn, &sid)?,
-                memory_db::get_recent_summaries(conn, &sid, MAX_SUMMARIES)?,
+                memory_db::get_recent_summaries(conn, &sid, &dir, MAX_SUMMARIES)?,
                 memory_db::get_session_own_summary(conn, &sid)?,
             ))
         }
@@ -544,6 +552,29 @@ async fn load_session_state(
         tracing::warn!(error = %e, session_id, "failed to load session state");
         (vec![], vec![], None)
     })
+}
+
+/// Resolve the working directory for `session_id` from `sessions.json`.
+///
+/// Returns the directory path string if found, otherwise `""` — which matches
+/// only legacy pre-migration `session_summaries` rows and never any
+/// dir-tagged summary.  Never errors: a failed lookup (session removed,
+/// lock contention, corrupt JSON) is treated as "unknown dir" so a missing
+/// mapping isolates the session rather than bailing out of compaction.
+async fn resolve_session_dir(session_id: &str) -> String {
+    let sid = session_id.to_owned();
+    tokio::task::spawn_blocking(move || {
+        session::list_all()
+            .ok()
+            .and_then(|map| {
+                map.into_iter()
+                    .find(|(_, rec)| rec.uuid == sid)
+                    .map(|(d, _)| d)
+            })
+            .unwrap_or_default()
+    })
+    .await
+    .unwrap_or_default()
 }
 
 // ---------------------------------------------------------------------------
@@ -3425,12 +3456,13 @@ async fn compact_session(
             let db = Arc::clone(&state.db);
             let sid = session_id.clone();
             let ts = chrono::Utc::now().to_rfc3339();
+            let dir = resolve_session_dir(&sid).await;
             let result = tokio::task::spawn_blocking(move || {
                 let conn = db.lock().unwrap_or_else(|p| p.into_inner());
                 let tx = conn
                     .unchecked_transaction()
                     .context("compact_session: begin transaction")?;
-                memory_db::store_session_summary(&conn, &sid, &summary, &ts)?;
+                memory_db::store_session_summary(&conn, &sid, &summary, &ts, &dir)?;
                 memory_db::archive_session_turns(&conn, &ids_to_archive)?;
                 tx.commit().context("compact_session: commit transaction")
             })
@@ -3719,6 +3751,7 @@ async fn compact_in_loop(
         let db = Arc::clone(&state.db);
         let sid_owned = sid.to_owned();
         let ts = chrono::Utc::now().to_rfc3339();
+        let dir = resolve_session_dir(sid).await;
         let archive_result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
             let conn = db.lock().unwrap_or_else(|p| p.into_inner());
             // Always persist the summary (even when nothing is archived) so a
@@ -3728,7 +3761,7 @@ async fn compact_in_loop(
             let tx = conn
                 .unchecked_transaction()
                 .context("compact_in_loop: begin transaction")?;
-            memory_db::store_session_summary(&conn, &sid_owned, &summary_text, &ts)?;
+            memory_db::store_session_summary(&conn, &sid_owned, &summary_text, &ts, &dir)?;
             if summarised_row_count > 0 {
                 let rows = memory_db::get_session_oldest(&conn, &sid_owned, summarised_row_count)?;
                 let ids: Vec<i64> = rows.iter().map(|r| r.id).collect();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7102,4 +7102,113 @@ mod tests {
             "expected tmux-probe failure for %9999999, got errors: {err_texts:?}"
         );
     }
+
+    // ------------------------------------------------------------------
+    // resolve_session_dir + load_session_state dir-scoping regression
+    //
+    // These guard the core behaviour of PR #121: summaries must be scoped
+    // by working directory, and the sentinel fallback must never read
+    // back rows tagged with it (otherwise cross-project leakage returns).
+    // ------------------------------------------------------------------
+
+    /// A resumable (rotated) session UUID must resolve back to its owning
+    /// directory, even after a newer UUID has been issued for the same dir.
+    /// This is the regression test for the `list_all()` → `dir_for_uuid`
+    /// switch (Copilot review comment on `resolve_session_dir`): `list_all()`
+    /// only returns the most-recent record per dir and would miss the old UUID.
+    #[tokio::test]
+    async fn resolve_session_dir_finds_rotated_uuid() {
+        let _guard = crate::test_utils::with_temp_home();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let old_uuid = crate::session::get_or_create(dir.path()).expect("create first");
+        let new_uuid = crate::session::create_fresh(dir.path()).expect("rotate");
+        assert_ne!(old_uuid, new_uuid);
+
+        let canonical = std::fs::canonicalize(dir.path())
+            .expect("canonicalize")
+            .to_string_lossy()
+            .into_owned();
+
+        assert_eq!(
+            resolve_session_dir(&new_uuid).await,
+            canonical,
+            "current UUID must resolve to its canonical directory"
+        );
+        assert_eq!(
+            resolve_session_dir(&old_uuid).await,
+            canonical,
+            "rotated/historical UUID must still resolve (list_all would miss this)"
+        );
+    }
+
+    /// An unknown UUID must fall back to the sentinel, not to `""`.  Falling
+    /// back to `""` would match legacy pre-migration rows (`dir = ''`) and
+    /// re-introduce the cross-project leak this PR fixes.
+    #[tokio::test]
+    async fn resolve_session_dir_unknown_uuid_returns_sentinel() {
+        let _guard = crate::test_utils::with_temp_home();
+        // No sessions.json entries at all.
+        assert_eq!(
+            resolve_session_dir("not-in-sessions").await,
+            UNKNOWN_DIR_SENTINEL,
+            "unknown UUID must quarantine via sentinel, not leak via empty-string"
+        );
+    }
+
+    /// `load_session_state` must short-circuit the summaries query when the
+    /// resolved dir is the sentinel, so rows previously written with the
+    /// sentinel (after a failed resolve) cannot be read back.  Exercises
+    /// the integration between `resolve_session_dir` (returns sentinel for
+    /// unknown UUID) and `load_session_state` (short-circuits on sentinel).
+    #[tokio::test]
+    async fn load_session_state_sentinel_skips_summaries_query() {
+        let _guard = crate::test_utils::with_temp_home();
+
+        // File-backed DB under the temp HOME so `init_db` runs the full
+        // schema + migration path exactly as the daemon would.
+        let db_dir = tempfile::tempdir().expect("tempdir for db");
+        let db_path = db_dir.path().join("memory.db");
+        let conn = memory_db::init_db(&db_path).expect("init memory db");
+
+        // Seed a summary row tagged with the sentinel — simulates what
+        // `compact_session` would have written for an unresolvable session.
+        memory_db::store_session_summary(
+            &conn,
+            "sid-quarantined",
+            "quarantined summary text",
+            "2026-01-01T00:00:00Z",
+            UNKNOWN_DIR_SENTINEL,
+        )
+        .expect("seed sentinel row");
+
+        // Sanity: the raw query at the DB layer CAN read the row back if
+        // asked directly with the sentinel — proves the short-circuit at
+        // the daemon layer is load-bearing, not a trivial no-op.
+        let raw = memory_db::get_recent_summaries(&conn, "other-sid", UNKNOWN_DIR_SENTINEL, 10)
+            .expect("raw summaries read");
+        assert_eq!(
+            raw,
+            vec!["quarantined summary text"],
+            "sentinel rows are reachable at the memory_db layer — daemon must short-circuit"
+        );
+
+        let state = Arc::new(DaemonState {
+            http: reqwest::Client::new(),
+            tokens: Arc::new(TokenCache::new()),
+            executor: Box::new(tools::LocalExecutor::new()),
+            db: Arc::new(Mutex::new(conn)),
+            compacting_sessions: Arc::new(Mutex::new(HashSet::new())),
+            active_sessions: Arc::new(Mutex::new(HashSet::new())),
+            user_aliases: Arc::new(std::collections::HashMap::new()),
+        });
+
+        // "sid-quarantined" has no entry in the empty sessions.json under
+        // the temp $HOME, so resolve_session_dir returns the sentinel and
+        // load_session_state MUST skip the query.
+        let (_hist, summaries, _own) = load_session_state(&state, "sid-quarantined").await;
+        assert!(
+            summaries.is_empty(),
+            "load_session_state must not read sentinel rows back; got {summaries:?}"
+        );
+    }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -554,27 +554,36 @@ async fn load_session_state(
     })
 }
 
+/// Sentinel stored as `session_summaries.dir` when the real directory for
+/// a session cannot be recovered.  Chosen to start with a character that
+/// cannot appear in an absolute path, so a reader querying for a real
+/// directory never returns these rows (strict isolation: a failed
+/// resolve never leaks into another project's summary stream).  Rows
+/// written with this sentinel are effectively orphaned — they are still
+/// stored for forensic debugging but never read back.
+const UNKNOWN_DIR_SENTINEL: &str = "<unknown>";
+
 /// Resolve the working directory for `session_id` from `sessions.json`.
 ///
-/// Returns the directory path string if found, otherwise `""` — which matches
-/// only legacy pre-migration `session_summaries` rows and never any
-/// dir-tagged summary.  Never errors: a failed lookup (session removed,
-/// lock contention, corrupt JSON) is treated as "unknown dir" so a missing
-/// mapping isolates the session rather than bailing out of compaction.
+/// Scans the full per-directory history so resumed sessions (UUIDs that
+/// have been rotated past) still resolve correctly.  On any failure the
+/// sentinel [`UNKNOWN_DIR_SENTINEL`] is returned, which matches no real
+/// directory and so quarantines the summary rather than leaking it into
+/// another project.
+///
+/// Note: the underlying `session::dir_for_uuid` takes a blocking shared
+/// flock, so under heavy contention this will block the `spawn_blocking`
+/// thread briefly before returning.
 async fn resolve_session_dir(session_id: &str) -> String {
     let sid = session_id.to_owned();
     tokio::task::spawn_blocking(move || {
-        session::list_all()
+        session::dir_for_uuid(&sid)
             .ok()
-            .and_then(|map| {
-                map.into_iter()
-                    .find(|(_, rec)| rec.uuid == sid)
-                    .map(|(d, _)| d)
-            })
-            .unwrap_or_default()
+            .flatten()
+            .unwrap_or_else(|| UNKNOWN_DIR_SENTINEL.to_string())
     })
     .await
-    .unwrap_or_default()
+    .unwrap_or_else(|_| UNKNOWN_DIR_SENTINEL.to_string())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -529,20 +529,27 @@ where
 /// Summaries are scoped to the session's working directory: we look up the
 /// dir for `session_id` in `sessions.json` and pass it to
 /// `get_recent_summaries` so cross-project sessions cannot see each other's
-/// compacted context.  If the lookup fails (session removed, race, etc.) we
-/// fall back to `""` — which only matches legacy pre-migration rows and
-/// never any dir-tagged summary.
+/// compacted context.  If the lookup fails we skip the summaries query
+/// entirely (returning an empty list) — this avoids reading back rows that
+/// were themselves written with the same sentinel after a previous failed
+/// resolution.
 async fn load_session_state(
     state: &Arc<DaemonState>,
     session_id: &str,
 ) -> (Vec<memory_db::DbMemoryEntry>, Vec<String>, Option<String>) {
     let dir = resolve_session_dir(session_id).await;
+    let dir_for_read = dir.clone();
     with_db(Arc::clone(&state.db), {
         let sid = session_id.to_owned();
         move |conn| {
+            let summaries = if dir_for_read == UNKNOWN_DIR_SENTINEL {
+                Vec::new()
+            } else {
+                memory_db::get_recent_summaries(conn, &sid, &dir_for_read, MAX_SUMMARIES)?
+            };
             Ok((
                 memory_db::get_session_history(conn, &sid)?,
-                memory_db::get_recent_summaries(conn, &sid, &dir, MAX_SUMMARIES)?,
+                summaries,
                 memory_db::get_session_own_summary(conn, &sid)?,
             ))
         }
@@ -555,12 +562,15 @@ async fn load_session_state(
 }
 
 /// Sentinel stored as `session_summaries.dir` when the real directory for
-/// a session cannot be recovered.  Chosen to start with a character that
-/// cannot appear in an absolute path, so a reader querying for a real
-/// directory never returns these rows (strict isolation: a failed
-/// resolve never leaks into another project's summary stream).  Rows
-/// written with this sentinel are effectively orphaned — they are still
-/// stored for forensic debugging but never read back.
+/// a session cannot be recovered.  Canonical session directory keys are
+/// always absolute paths starting with `/` (see `session::canonical_key`),
+/// so this sentinel cannot collide with any legitimate key — a reader
+/// querying for `/some/proj` will never match these rows.
+///
+/// `load_session_state` also explicitly short-circuits when the resolved
+/// dir equals this sentinel, so a row written after one failed resolve is
+/// not read back by the same session on a subsequent failed resolve.
+/// Sentinel rows are therefore quarantined on write AND ignored on read.
 const UNKNOWN_DIR_SENTINEL: &str = "<unknown>";
 
 /// Resolve the working directory for `session_id` from `sessions.json`.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -529,10 +529,12 @@ where
 /// Summaries are scoped to the session's working directory: we look up the
 /// dir for `session_id` in `sessions.json` and pass it to
 /// `get_recent_summaries` so cross-project sessions cannot see each other's
-/// compacted context.  If the lookup fails we skip the summaries query
-/// entirely (returning an empty list) — this avoids reading back rows that
-/// were themselves written with the same sentinel after a previous failed
-/// resolution.
+/// compacted context.  When `resolve_session_dir` falls back to
+/// [`UNKNOWN_DIR_SENTINEL`] (unknown UUID, I/O error, lock failure, etc.)
+/// we short-circuit and return no summaries at all — this avoids reading
+/// back rows that were themselves written with the same sentinel after a
+/// previous failed resolution, and it never reads legacy `dir = ''` rows
+/// either.
 async fn load_session_state(
     state: &Arc<DaemonState>,
     session_id: &str,
@@ -562,38 +564,73 @@ async fn load_session_state(
 }
 
 /// Sentinel stored as `session_summaries.dir` when the real directory for
-/// a session cannot be recovered.  Canonical session directory keys are
-/// always absolute paths starting with `/` (see `session::canonical_key`),
-/// so this sentinel cannot collide with any legitimate key — a reader
-/// querying for `/some/proj` will never match these rows.
+/// a session cannot be recovered.
 ///
-/// `load_session_state` also explicitly short-circuits when the resolved
-/// dir equals this sentinel, so a row written after one failed resolve is
-/// not read back by the same session on a subsequent failed resolve.
-/// Sentinel rows are therefore quarantined on write AND ignored on read.
+/// Collision reasoning: `session::canonical_key` prefers the result of
+/// `std::fs::canonicalize`, which on Unix always produces an absolute path
+/// (`/…`).  It only falls back to the raw input path when `canonicalize`
+/// fails (dir deleted/inaccessible), so a relative path key is possible in
+/// degenerate cases.  The sentinel is therefore chosen to not match any
+/// typical path component: it starts with `<` and ends with `>`, a
+/// combination no sane working directory would produce, and it is compared
+/// as an exact whole string — not a prefix — so `/tmp/<unknown>/…` would
+/// not collide.  If a real dir ever did happen to equal the sentinel
+/// verbatim, the only consequence is that its sessions' summaries get
+/// lumped into the quarantine set, which is strictly safer than leaking
+/// across unrelated projects.
+///
+/// Defense-in-depth: `load_session_state` also explicitly short-circuits
+/// when the resolved dir equals this sentinel, so a row written after one
+/// failed resolve is not read back by the same session on a subsequent
+/// failed resolve.  Sentinel rows are therefore quarantined on write AND
+/// ignored on read.
 const UNKNOWN_DIR_SENTINEL: &str = "<unknown>";
 
 /// Resolve the working directory for `session_id` from `sessions.json`.
 ///
 /// Scans the full per-directory history so resumed sessions (UUIDs that
-/// have been rotated past) still resolve correctly.  On any failure the
-/// sentinel [`UNKNOWN_DIR_SENTINEL`] is returned, which matches no real
-/// directory and so quarantines the summary rather than leaking it into
-/// another project.
+/// have been rotated past) still resolve correctly.  On any failure —
+/// I/O error, parse error, lock acquisition failure, unknown UUID, or a
+/// panic in the spawned blocking thread — the sentinel
+/// [`UNKNOWN_DIR_SENTINEL`] is returned so the caller's summary gets
+/// quarantined instead of being written/read as an empty-dir row that
+/// could match legacy pre-migration entries.
 ///
-/// Note: the underlying `session::dir_for_uuid` takes a blocking shared
-/// flock, so under heavy contention this will block the `spawn_blocking`
-/// thread briefly before returning.
+/// Blocking behavior: the underlying `session::dir_for_uuid` takes a
+/// `lock_shared()` on the sessions lock file, which is a genuinely
+/// blocking call — under contention this waits rather than failing
+/// fast.  It runs on `spawn_blocking`, so the daemon's async runtime is
+/// not stalled; only the blocking pool thread is held.
+///
+/// Real I/O / lock failures are logged at debug level so silent masking
+/// of persistent problems can still be traced in logs.
 async fn resolve_session_dir(session_id: &str) -> String {
     let sid = session_id.to_owned();
-    tokio::task::spawn_blocking(move || {
-        session::dir_for_uuid(&sid)
-            .ok()
-            .flatten()
-            .unwrap_or_else(|| UNKNOWN_DIR_SENTINEL.to_string())
+    tokio::task::spawn_blocking(move || match session::dir_for_uuid(&sid) {
+        Ok(Some(dir)) => dir,
+        Ok(None) => {
+            // Unknown UUID — expected for brand-new or purged sessions;
+            // quarantine silently without a log.
+            UNKNOWN_DIR_SENTINEL.to_string()
+        }
+        Err(e) => {
+            tracing::debug!(
+                session_id = %sid,
+                error = %e,
+                "resolve_session_dir: dir_for_uuid failed; falling back to sentinel"
+            );
+            UNKNOWN_DIR_SENTINEL.to_string()
+        }
     })
     .await
-    .unwrap_or_else(|_| UNKNOWN_DIR_SENTINEL.to_string())
+    .unwrap_or_else(|e| {
+        tracing::debug!(
+            session_id,
+            error = %e,
+            "resolve_session_dir: blocking task panicked; falling back to sentinel"
+        );
+        UNKNOWN_DIR_SENTINEL.to_string()
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/src/memory_db.rs
+++ b/src/memory_db.rs
@@ -159,12 +159,16 @@ pub fn init_db(path: &Path) -> Result<Connection> {
     // table, so probe PRAGMA table_info and ALTER when missing.  Legacy rows
     // keep `dir = ''`, which never matches a non-empty dir filter in
     // `get_recent_summaries` — correctly isolated rather than cross-leaked.
-    let has_dir = conn
+    //
+    // Propagate row-decode errors so schema introspection surprises (e.g.
+    // unexpected PRAGMA shape) fail loudly instead of being silently
+    // treated as "column absent" and triggering a spurious ALTER.
+    let columns: Vec<String> = conn
         .prepare("PRAGMA table_info(session_summaries)")?
         .query_map([], |row| row.get::<_, String>(1))?
-        .filter_map(Result::ok)
-        .any(|col| col == "dir");
-    if !has_dir {
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .context("reading PRAGMA table_info(session_summaries)")?;
+    if !columns.iter().any(|col| col == "dir") {
         conn.execute(
             "ALTER TABLE session_summaries ADD COLUMN dir TEXT NOT NULL DEFAULT ''",
             [],
@@ -497,8 +501,14 @@ pub fn get_sessions_without_summary(
 /// Excludes the current session so the model does not see a stale summary of
 /// the conversation it is actively participating in.  Filtering by `dir`
 /// prevents cross-project context leakage when two `amaebi chat` sessions
-/// run concurrently in different directories.  An empty `dir` only matches
-/// legacy (pre-migration) rows with `dir = ''`.
+/// run concurrently in different directories.
+///
+/// Never pass `dir = ""` here in production code.  Empty-string matches
+/// every legacy pre-migration row *and* any row written when the dir
+/// lookup failed without a sentinel — exactly the cross-project leak this
+/// PR fixes.  Callers that cannot resolve a real canonical path should pass
+/// a sentinel value (see `UNKNOWN_DIR_SENTINEL` in `daemon.rs`) and
+/// additionally short-circuit the read so sentinel rows are never matched.
 pub fn get_recent_summaries(
     conn: &Connection,
     exclude_session: &str,

--- a/src/memory_db.rs
+++ b/src/memory_db.rs
@@ -105,10 +105,16 @@ END;
 -- (a) a new session starts in the same folder (cross-session learning), or
 -- (b) the session history grows beyond the sliding-window cap (within-session).
 -- Provides cross-session context without injecting full raw history.
+--
+-- `dir` scopes summaries to the originating working directory so two concurrent
+-- `amaebi chat` sessions in different projects cannot leak each other's
+-- compacted context through `get_recent_summaries`.  Pre-migration rows stay
+-- at `dir = ''` and fall out of any non-empty dir filter.
 CREATE TABLE IF NOT EXISTS session_summaries (
     session_id TEXT PRIMARY KEY,
     summary    TEXT NOT NULL,
-    timestamp  TEXT NOT NULL
+    timestamp  TEXT NOT NULL,
+    dir        TEXT NOT NULL DEFAULT ''
 );
 ";
 
@@ -147,6 +153,24 @@ pub fn init_db(path: &Path) -> Result<Connection> {
 
     conn.execute_batch(SCHEMA)
         .context("applying memory DB schema")?;
+
+    // Additive migration: older databases were created before `dir` existed.
+    // `CREATE TABLE IF NOT EXISTS` will not add the column to an existing
+    // table, so probe PRAGMA table_info and ALTER when missing.  Legacy rows
+    // keep `dir = ''`, which never matches a non-empty dir filter in
+    // `get_recent_summaries` — correctly isolated rather than cross-leaked.
+    let has_dir = conn
+        .prepare("PRAGMA table_info(session_summaries)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .filter_map(Result::ok)
+        .any(|col| col == "dir");
+    if !has_dir {
+        conn.execute(
+            "ALTER TABLE session_summaries ADD COLUMN dir TEXT NOT NULL DEFAULT ''",
+            [],
+        )
+        .context("adding dir column to session_summaries")?;
+    }
 
     Ok(conn)
 }
@@ -347,19 +371,24 @@ pub fn clear(conn: &Connection) -> Result<()> {
 /// Upsert a compacted summary for `session_id`.
 ///
 /// Called by `compact_session` in the daemon.  `timestamp` should be an RFC 3339 UTC string.
+/// `dir` is the canonical working directory the session was created in; it
+/// scopes the summary so `get_recent_summaries` cannot leak it into sessions
+/// from other directories.  Pass `""` when the dir cannot be resolved.
 pub fn store_session_summary(
     conn: &Connection,
     session_id: &str,
     summary: &str,
     timestamp: &str,
+    dir: &str,
 ) -> Result<()> {
     conn.execute(
-        "INSERT INTO session_summaries (session_id, summary, timestamp)
-         VALUES (?1, ?2, ?3)
+        "INSERT INTO session_summaries (session_id, summary, timestamp, dir)
+         VALUES (?1, ?2, ?3, ?4)
          ON CONFLICT(session_id) DO UPDATE SET
              summary   = excluded.summary,
-             timestamp = excluded.timestamp",
-        params![session_id, summary, timestamp],
+             timestamp = excluded.timestamp,
+             dir       = excluded.dir",
+        params![session_id, summary, timestamp, dir],
     )
     .context("storing session summary")?;
     Ok(())
@@ -459,28 +488,33 @@ pub fn get_sessions_without_summary(
     Ok(sessions)
 }
 
-/// Return up to `limit` summaries from sessions other than `exclude_session`,
-/// ordered oldest-first so the caller can inject them chronologically.
+/// Return up to `limit` summaries from sessions other than `exclude_session`
+/// that originate from the same working `dir`, ordered oldest-first so the
+/// caller can inject them chronologically.
 ///
 /// Excludes the current session so the model does not see a stale summary of
-/// the conversation it is actively participating in.
+/// the conversation it is actively participating in.  Filtering by `dir`
+/// prevents cross-project context leakage when two `amaebi chat` sessions
+/// run concurrently in different directories.  An empty `dir` only matches
+/// legacy (pre-migration) rows with `dir = ''`.
 pub fn get_recent_summaries(
     conn: &Connection,
     exclude_session: &str,
+    dir: &str,
     limit: usize,
 ) -> Result<Vec<String>> {
     // Fetch most-recent first, then reverse so injection is chronological.
     let mut stmt = conn
         .prepare(
             "SELECT summary FROM session_summaries
-             WHERE session_id != ?1
+             WHERE session_id != ?1 AND dir = ?2
              ORDER BY timestamp DESC
-             LIMIT ?2",
+             LIMIT ?3",
         )
         .context("preparing get_recent_summaries")?;
 
     let mut summaries = stmt
-        .query_map(params![exclude_session, limit as i64], |row| {
+        .query_map(params![exclude_session, dir, limit as i64], |row| {
             row.get::<_, String>(0)
         })
         .context("executing get_recent_summaries")?
@@ -768,12 +802,26 @@ mod tests {
     fn store_session_summary_upserts() {
         let (conn, _dir) = open_test_db();
 
-        store_session_summary(&conn, "s1", "first summary", "2026-01-01T00:00:00Z").unwrap();
+        store_session_summary(
+            &conn,
+            "s1",
+            "first summary",
+            "2026-01-01T00:00:00Z",
+            "/proj",
+        )
+        .unwrap();
         let s1 = get_session_own_summary(&conn, "s1").unwrap();
         assert_eq!(s1.as_deref(), Some("first summary"));
 
         // Upsert — should update, not create a second row.
-        store_session_summary(&conn, "s1", "updated summary", "2026-01-02T00:00:00Z").unwrap();
+        store_session_summary(
+            &conn,
+            "s1",
+            "updated summary",
+            "2026-01-02T00:00:00Z",
+            "/proj",
+        )
+        .unwrap();
         let s2 = get_session_own_summary(&conn, "s1").unwrap();
         assert_eq!(s2.as_deref(), Some("updated summary"));
 
@@ -800,7 +848,14 @@ mod tests {
         store_memory(&conn, "2026-01-01T00:00:00Z", "s1", "user", "hi", "").unwrap();
         store_memory(&conn, "2026-01-01T00:00:00Z", "s2", "user", "hi", "").unwrap();
         store_memory(&conn, "2026-01-01T00:00:00Z", "s3", "user", "hi", "").unwrap();
-        store_session_summary(&conn, "s2", "summary for s2", "2026-01-01T00:00:00Z").unwrap();
+        store_session_summary(
+            &conn,
+            "s2",
+            "summary for s2",
+            "2026-01-01T00:00:00Z",
+            "/proj",
+        )
+        .unwrap();
 
         // s1 has no summary; s2 has a summary; s3 is the "current" session (excluded).
         let unsummarised = get_sessions_without_summary(&conn, "s3", 10).unwrap();
@@ -810,12 +865,12 @@ mod tests {
     #[test]
     fn get_recent_summaries_excludes_current_and_orders_oldest_first() {
         let (conn, _dir) = open_test_db();
-        store_session_summary(&conn, "s1", "summary A", "2026-01-01T00:00:00Z").unwrap();
-        store_session_summary(&conn, "s2", "summary B", "2026-01-03T00:00:00Z").unwrap();
-        store_session_summary(&conn, "s3", "summary C", "2026-01-02T00:00:00Z").unwrap();
+        store_session_summary(&conn, "s1", "summary A", "2026-01-01T00:00:00Z", "/proj").unwrap();
+        store_session_summary(&conn, "s2", "summary B", "2026-01-03T00:00:00Z", "/proj").unwrap();
+        store_session_summary(&conn, "s3", "summary C", "2026-01-02T00:00:00Z", "/proj").unwrap();
 
         // Exclude s3 (current session); expect oldest-first order.
-        let summaries = get_recent_summaries(&conn, "s3", 10).unwrap();
+        let summaries = get_recent_summaries(&conn, "s3", "/proj", 10).unwrap();
         assert_eq!(summaries, vec!["summary A", "summary B"]);
     }
 
@@ -863,5 +918,87 @@ mod tests {
         // Newest first → s3, s2.
         assert_eq!(rows[0].session_id, "s3");
         assert_eq!(rows[1].session_id, "s2");
+    }
+
+    #[test]
+    fn get_recent_summaries_isolates_by_dir() {
+        let (conn, _dir) = open_test_db();
+        // Two summaries in /proj-a, two in /proj-b.
+        store_session_summary(&conn, "a1", "A1", "2026-01-01T00:00:00Z", "/proj-a").unwrap();
+        store_session_summary(&conn, "a2", "A2", "2026-01-02T00:00:00Z", "/proj-a").unwrap();
+        store_session_summary(&conn, "b1", "B1", "2026-01-03T00:00:00Z", "/proj-b").unwrap();
+        store_session_summary(&conn, "b2", "B2", "2026-01-04T00:00:00Z", "/proj-b").unwrap();
+
+        let a = get_recent_summaries(&conn, "sid-x", "/proj-a", 10).unwrap();
+        assert_eq!(a, vec!["A1", "A2"]);
+
+        let b = get_recent_summaries(&conn, "sid-x", "/proj-b", 10).unwrap();
+        assert_eq!(b, vec!["B1", "B2"]);
+    }
+
+    #[test]
+    fn get_recent_summaries_empty_dir_does_not_match_non_empty_query() {
+        let (conn, _dir) = open_test_db();
+        // Simulate a legacy pre-migration row with dir = ''.
+        store_session_summary(&conn, "legacy", "old summary", "2026-01-01T00:00:00Z", "").unwrap();
+
+        let got = get_recent_summaries(&conn, "sid-x", "/proj-a", 10).unwrap();
+        assert!(
+            got.is_empty(),
+            "legacy dir='' rows must not leak into a non-empty dir query"
+        );
+
+        // But querying for dir='' explicitly *does* return the legacy row.
+        let legacy = get_recent_summaries(&conn, "sid-x", "", 10).unwrap();
+        assert_eq!(legacy, vec!["old summary"]);
+    }
+
+    #[test]
+    fn init_db_migration_is_idempotent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("memory.db");
+        // First open creates the schema with the `dir` column.
+        {
+            let conn = init_db(&path).unwrap();
+            store_session_summary(&conn, "s1", "A", "2026-01-01T00:00:00Z", "/proj").unwrap();
+        }
+        // Second open must succeed without re-adding the column.
+        let conn = init_db(&path).unwrap();
+        let got = get_recent_summaries(&conn, "sid-x", "/proj", 10).unwrap();
+        assert_eq!(got, vec!["A"]);
+    }
+
+    #[test]
+    fn init_db_backfills_missing_dir_column() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("memory.db");
+        // Create a legacy schema without the `dir` column and insert a raw row.
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE session_summaries (
+                     session_id TEXT PRIMARY KEY,
+                     summary    TEXT NOT NULL,
+                     timestamp  TEXT NOT NULL
+                 );
+                 INSERT INTO session_summaries (session_id, summary, timestamp)
+                 VALUES ('legacy', 'legacy summary', '2026-01-01T00:00:00Z');",
+            )
+            .unwrap();
+        }
+        // Opening via init_db must add the column and default the legacy row to ''.
+        let conn = init_db(&path).unwrap();
+        let dir_val: String = conn
+            .query_row(
+                "SELECT dir FROM session_summaries WHERE session_id = 'legacy'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(dir_val, "");
+
+        // A non-empty dir query must not return the legacy row.
+        let got = get_recent_summaries(&conn, "sid-x", "/proj-a", 10).unwrap();
+        assert!(got.is_empty());
     }
 }

--- a/src/memory_db.rs
+++ b/src/memory_db.rs
@@ -373,7 +373,9 @@ pub fn clear(conn: &Connection) -> Result<()> {
 /// Called by `compact_session` in the daemon.  `timestamp` should be an RFC 3339 UTC string.
 /// `dir` is the canonical working directory the session was created in; it
 /// scopes the summary so `get_recent_summaries` cannot leak it into sessions
-/// from other directories.  Pass `""` when the dir cannot be resolved.
+/// from other directories.  When the dir cannot be resolved, callers should
+/// pass a sentinel that cannot match any real path (e.g. `"<unknown>"`) so
+/// the row is effectively quarantined.  Pre-migration rows retain `""`.
 pub fn store_session_summary(
     conn: &Connection,
     session_id: &str,

--- a/src/session.rs
+++ b/src/session.rs
@@ -544,8 +544,25 @@ pub fn current_record(dir: &Path) -> Result<Option<SessionRecord>> {
 /// also finds UUIDs the user has since rotated past (e.g. resuming an
 /// older session).
 ///
-/// Returns `Ok(None)` when the UUID is not present anywhere in the file,
-/// `Err` on I/O or parse failure.
+/// # Return values
+///
+/// - `Ok(Some(dir))` — UUID found; `dir` is the canonical directory key.
+/// - `Ok(None)` — `sessions.json` does not exist, is empty, is corrupted
+///   (see below), or does not contain the requested UUID.
+/// - `Err(_)` — filesystem I/O failure (read permission denied, disk
+///   error, or lock acquisition failure).
+///
+/// # Corruption handling
+///
+/// JSON parse failures are intentionally treated as an empty map rather
+/// than propagated as `Err` — mirrors [`load_map`]'s "sessions.json is
+/// corrupted; resetting to empty" policy, tested by
+/// `corrupted_sessions_json_recovers`.  This keeps the daemon operable
+/// against a manually-edited or partially-written JSON file; the
+/// trade-off is that callers cannot distinguish "UUID not found" from
+/// "file is corrupt".  `resolve_session_dir` in `daemon.rs` handles
+/// both uniformly by falling back to `UNKNOWN_DIR_SENTINEL`, so the
+/// distinction would be informational only.
 pub fn dir_for_uuid(uuid: &str) -> Result<Option<String>> {
     let path = sessions_path()?;
     if !path.exists() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -539,6 +539,31 @@ pub fn current_record(dir: &Path) -> Result<Option<SessionRecord>> {
     Ok(result)
 }
 
+/// Look up the directory that owns `uuid` by scanning every record in
+/// `sessions.json` (current and historical).  Unlike [`list_all`], this
+/// also finds UUIDs the user has since rotated past (e.g. resuming an
+/// older session).
+///
+/// Returns `Ok(None)` when the UUID is not present anywhere in the file,
+/// `Err` on I/O or parse failure.
+pub fn dir_for_uuid(uuid: &str) -> Result<Option<String>> {
+    let path = sessions_path()?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let lock_file = open_lock_file()?;
+    lock_file.lock_shared().context("acquiring sessions lock")?;
+    let map = load_map(&path)?;
+    lock_file.unlock().context("releasing sessions lock")?;
+
+    for (dir, recs) in map {
+        if recs.iter().any(|r| r.uuid == uuid) {
+            return Ok(Some(dir));
+        }
+    }
+    Ok(None)
+}
+
 /// Return all session records (directory → most-recent SessionRecord).
 ///
 /// Returns one record per directory (the most recent / current one).
@@ -872,6 +897,29 @@ mod tests {
         let _ = get_or_create(d2.path()).unwrap();
         let all = list_all().unwrap();
         assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn dir_for_uuid_finds_current_and_historical() {
+        let _guard = with_temp_home();
+        let dir = tempdir().unwrap();
+        let old_uuid = get_or_create(dir.path()).unwrap();
+        // Rotate: create_fresh appends without overwriting old_uuid.
+        let new_uuid = create_fresh(dir.path()).unwrap();
+        assert_ne!(old_uuid, new_uuid);
+
+        // Current UUID resolves.
+        assert_eq!(
+            dir_for_uuid(&new_uuid).unwrap().as_deref(),
+            Some(canonical_key(dir.path()).as_str())
+        );
+        // Historical UUID still resolves (list_all would miss this).
+        assert_eq!(
+            dir_for_uuid(&old_uuid).unwrap().as_deref(),
+            Some(canonical_key(dir.path()).as_str())
+        );
+        // Unknown UUID → None.
+        assert_eq!(dir_for_uuid("not-in-sessions").unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two concurrent `amaebi chat` sessions in different directories could each see the other's compacted summaries injected as system-level context, because `get_recent_summaries` only filtered by `session_id`. Raw history is already session-isolated; summaries are now also dir-isolated.

- Add `dir TEXT NOT NULL DEFAULT ''` to `session_summaries` (schema + idempotent PRAGMA table_info / ALTER migration for existing DBs). PRAGMA probe propagates row-decode errors via `rusqlite::Result<Vec<_>>` so schema introspection failures fail loudly rather than silently triggering a spurious ALTER.
- `store_session_summary` and `get_recent_summaries` take a `dir` param; the read-path filter becomes `session_id != ?1 AND dir = ?2`.
- Daemon resolves each session's dir via `session::dir_for_uuid` (scans the full per-dir history via `sessions.json`, so resumed/rotated UUIDs still resolve — `session::list_all` was insufficient because it only returns the most-recent record per dir).

### Fallback behaviour on resolution failure

When the dir lookup fails (unknown UUID, I/O error, lock failure, panic), `resolve_session_dir` returns the sentinel **`"<unknown>"`** — not `""`. Rationale: `""` would match legacy pre-migration rows (which default to `dir = ''`) and re-introduce the cross-project leak this PR fixes.

The sentinel is quarantined on both sides:
- **Write path**: `compact_session` / `compact_in_loop` store the summary with `dir = "<unknown>"`. Rows so tagged never match any real dir filter.
- **Read path**: `load_session_state` short-circuits when `resolve_session_dir` returns the sentinel and returns no summaries at all — so sentinel rows written after a previous failed resolve are not read back by the same session on a subsequent failed resolve.

Defense-in-depth: `resolve_session_dir` logs `dir_for_uuid` errors at `debug!` level so persistent I/O/lock failures are traceable in logs instead of silently masked.

Cross-session learning within the same project continues to work; cross-project leakage stops.

## Test plan

- [x] `cargo test` — 572 unit + 38 integration tests pass, including:
  - `memory_db` tests for dir-isolation, empty-dir-never-matches-non-empty, migration idempotency, and legacy-row backfill.
  - `resolve_session_dir_finds_rotated_uuid` — rotated session UUIDs still resolve to their original dir (the `list_all → dir_for_uuid` regression).
  - `resolve_session_dir_unknown_uuid_returns_sentinel` — fallback is the sentinel, not `""`.
  - `load_session_state_sentinel_skips_summaries_query` — sentinel-tagged rows are NOT read back; seeds a row, proves it IS reachable at the `memory_db` layer, then proves `load_session_state` short-circuits.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy -- -D warnings` clean.
- [ ] Manual: run two `amaebi chat` sessions in `/proj-a` and `/proj-b` concurrently; after each session compacts, confirm neither session's context shows the other's summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)