### PR TITLE
feat(claude): /claude --resume-pane <pid> for explicit pane reuse

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -283,7 +283,8 @@ fn parse_claude(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> {
     let rest = rest.trim_start();
     let usage = "usage: /claude [--worktree <path> | --resume-pane <pane_id>] \
                  [--cwd <path>] [--no-enter] [\"task description\" [\"task2\" ...]] \
-                 (task description optional with --resume-pane)";
+                 (--resume-pane supports at most one optional task description; \
+                 omitting the task description is only valid with --resume-pane)";
     if rest.is_empty() {
         return Some(Err(usage.to_string()));
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -215,6 +215,9 @@ struct ClaudeTask {
     /// Override for the client working directory used to locate the git repo
     /// when auto-creating a worktree.  Maps to TaskSpec::client_cwd.
     cwd: Option<String>,
+    /// Optional tmux pane id (e.g. `"%41"`) to reuse via `--resume-pane`.
+    /// Mutually exclusive with `worktree`; checked at parse time.
+    resume_pane: Option<String>,
 }
 
 /// A parsed slash command from user input.
@@ -278,8 +281,8 @@ fn parse_claude(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> {
         return None;
     }
     let rest = rest.trim_start();
-    let usage = "usage: /claude [--worktree <path>] [--cwd <path>] [--no-enter] \
-                 \"task description\" [\"task2\" ...]";
+    let usage = "usage: /claude [--worktree <path> | --resume-pane <pane_id>] \
+                 [--cwd <path>] [--no-enter] \"task description\" [\"task2\" ...]";
     if rest.is_empty() {
         return Some(Err(usage.to_string()));
     }
@@ -290,6 +293,7 @@ fn parse_claude(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> {
     }
 
     let mut worktree: Option<String> = None;
+    let mut resume_pane: Option<String> = None;
     let mut auto_enter = true;
     let mut cwd: Option<String> = None;
     // (description, was_quoted) pairs for non-flag tokens.
@@ -298,6 +302,15 @@ fn parse_claude(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> {
     let mut i = 0;
     while i < tokens.len() {
         match tokens[i].0.as_str() {
+            "--resume-pane" => {
+                i += 1;
+                if i >= tokens.len() || tokens[i].0.starts_with("--") {
+                    return Some(Err(
+                        "--resume-pane requires a pane id argument (e.g. `%41`)".to_string(),
+                    ));
+                }
+                resume_pane = Some(tokens[i].0.clone());
+            }
             "--worktree" => {
                 i += 1;
                 // Require a non-flag value to follow --worktree.
@@ -366,7 +379,19 @@ fn parse_claude(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> {
         i += 1;
     }
 
-    if desc_tokens.is_empty() {
+    // --resume-pane and --worktree are mutually exclusive: resume-pane
+    // inherits the target pane's existing worktree and would conflict with
+    // an explicit --worktree.
+    if resume_pane.is_some() && worktree.is_some() {
+        return Some(Err("--resume-pane and --worktree are mutually exclusive; \
+             --resume-pane inherits the target pane's worktree"
+            .to_string()));
+    }
+
+    // Description is required in the normal path, but optional with
+    // --resume-pane: if omitted, the daemon reuses the description
+    // previously persisted on the pane's lease.
+    if desc_tokens.is_empty() && resume_pane.is_none() {
         return Some(Err(usage.to_string()));
     }
 
@@ -374,7 +399,11 @@ fn parse_claude(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> {
     // tokens are joined as a single task (e.g. `/claude write some code` →
     // one task "write some code", not three separate tasks).
     let all_quoted = desc_tokens.iter().all(|(_, q)| *q);
-    let descriptions: Vec<String> = if all_quoted || desc_tokens.len() == 1 {
+    let descriptions: Vec<String> = if desc_tokens.is_empty() {
+        // resume-pane with no description: use an empty-string sentinel so
+        // the daemon will look up the description from the lease.
+        vec![String::new()]
+    } else if all_quoted || desc_tokens.len() == 1 {
         desc_tokens.into_iter().map(|(s, _)| s).collect()
     } else {
         vec![desc_tokens
@@ -383,6 +412,13 @@ fn parse_claude(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> {
             .collect::<Vec<_>>()
             .join(" ")]
     };
+
+    // One pane can only run one task at a time.
+    if resume_pane.is_some() && descriptions.len() > 1 {
+        return Some(Err(
+            "--resume-pane can only be used with a single task".to_string()
+        ));
+    }
 
     let tasks = descriptions
         .into_iter()
@@ -395,6 +431,7 @@ fn parse_claude(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> {
                 worktree: worktree.clone(),
                 auto_enter,
                 cwd: cwd.clone(),
+                resume_pane: resume_pane.clone(),
             }
         })
         .collect();
@@ -540,6 +577,7 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                     worktree: t.worktree,
                     client_cwd: t.cwd.or_else(|| Some(cwd_str.clone())),
                     auto_enter: t.auto_enter,
+                    resume_pane: t.resume_pane,
                 })
                 .collect(),
         };
@@ -1001,6 +1039,7 @@ pub async fn run_chat_loop(
                             worktree: t.worktree,
                             client_cwd: t.cwd.or_else(|| Some(cwd_str.clone())),
                             auto_enter: t.auto_enter,
+                            resume_pane: t.resume_pane,
                         })
                         .collect(),
                 };
@@ -3920,6 +3959,62 @@ mod tests {
         let result = parse_claude(input);
         let err = result.expect("should be Some").unwrap_err();
         assert!(err.contains("--cwd requires a path"));
+    }
+
+    // -----------------------------------------------------------------------
+    // /claude --resume-pane
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_claude_resume_pane_basic() {
+        let tasks = claude_tasks(r#"/claude --resume-pane %41 "continue fmha4""#);
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].description, "continue fmha4");
+        assert_eq!(tasks[0].resume_pane.as_deref(), Some("%41"));
+        assert!(tasks[0].worktree.is_none());
+    }
+
+    #[test]
+    fn parse_claude_resume_pane_unquoted_description() {
+        let tasks = claude_tasks("/claude --resume-pane %41 继续完成上次的开发");
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].description, "继续完成上次的开发");
+        assert_eq!(tasks[0].resume_pane.as_deref(), Some("%41"));
+    }
+
+    #[test]
+    fn parse_claude_resume_pane_no_value_errors() {
+        let err = claude_err("/claude --resume-pane");
+        assert!(err.contains("--resume-pane requires a pane id"));
+    }
+
+    #[test]
+    fn parse_claude_resume_pane_with_worktree_is_rejected() {
+        let err = claude_err(r#"/claude --resume-pane %41 --worktree /tmp "x""#);
+        assert!(err.contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn parse_claude_resume_pane_multiple_tasks_rejected() {
+        let err = claude_err(r#"/claude --resume-pane %41 "task a" "task b""#);
+        assert!(err.contains("single task"));
+    }
+
+    #[test]
+    fn parse_claude_resume_pane_empty_description_is_ok() {
+        // Valid: daemon will pull the description from the lease.
+        let tasks = claude_tasks("/claude --resume-pane %41");
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].description, "");
+        assert_eq!(tasks[0].resume_pane.as_deref(), Some("%41"));
+    }
+
+    #[test]
+    fn parse_claude_bare_without_resume_pane_still_errors() {
+        // Without --resume-pane, a missing description is still an error
+        // (guards the normal-path invariant).
+        let err = claude_err("/claude");
+        assert!(err.contains("usage"));
     }
 
     // -----------------------------------------------------------------------

--- a/src/client.rs
+++ b/src/client.rs
@@ -282,7 +282,8 @@ fn parse_claude(input: &str) -> Option<Result<Vec<ClaudeTask>, String>> {
     }
     let rest = rest.trim_start();
     let usage = "usage: /claude [--worktree <path> | --resume-pane <pane_id>] \
-                 [--cwd <path>] [--no-enter] \"task description\" [\"task2\" ...]";
+                 [--cwd <path>] [--no-enter] [\"task description\" [\"task2\" ...]] \
+                 (task description optional with --resume-pane)";
     if rest.is_empty() {
         return Some(Err(usage.to_string()));
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -935,134 +935,232 @@ async fn handle_claude_launch(
         // the task description mentions a PR number.  The context is prepended
         // to the description so Claude knows where to start, what branch it is
         // on, and how to push when done.
+        // For the resume-pane path we may need to pull the description from
+        // the lease first (when the user typed `/claude --resume-pane %N`
+        // with no description).  So resolve `raw_description` BEFORE running
+        // the git-context prefix step.  In the normal path `task.description`
+        // is always non-empty (parser guards it).
+        let resume_prefetched_desc: Option<String> = if let Some(ref rp) = task.resume_pane {
+            if task.description.trim().is_empty() {
+                let rp_owned = rp.clone();
+                let lease_desc = tokio::task::spawn_blocking(move || {
+                    pane_lease::read_state()
+                        .ok()
+                        .and_then(|s| s.get(&rp_owned).and_then(|l| l.task_description.clone()))
+                })
+                .await
+                .ok()
+                .flatten();
+                match lease_desc {
+                    Some(d) if !d.trim().is_empty() => Some(d),
+                    _ => {
+                        let mut w = writer.lock().await;
+                        write_frame(
+                            &mut *w,
+                            &Response::Error {
+                                message: format!(
+                                    "[error] pane {rp} has no saved task description; \
+                                     pass a description explicitly after --resume-pane"
+                                ),
+                            },
+                        )
+                        .await?;
+                        return Ok(());
+                    }
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let raw_desc = resume_prefetched_desc
+            .clone()
+            .unwrap_or_else(|| task.description.clone());
+
         let (description, ctx_start_branch) = {
-            let raw_desc = task.description.clone();
+            let raw = raw_desc.clone();
             let cwd = task.client_cwd.clone();
             tokio::task::spawn_blocking(move || {
-                let ctx = gather_task_context(cwd.as_deref(), &raw_desc);
-                let enriched = format!("{}\n{}", ctx.preamble, raw_desc);
+                let ctx = gather_task_context(cwd.as_deref(), &raw);
+                let enriched = format!("{}\n{}", ctx.preamble, raw);
                 (enriched, ctx.start_branch)
             })
             .await
-            .unwrap_or_else(|_| (task.description.clone(), None))
+            .unwrap_or_else(|_| (raw_desc.clone(), None))
         };
 
-        // Each parallel Claude session must work in its own git worktree so
-        // concurrent tasks cannot trample each other's in-progress file edits.
-        // Auto-create a worktree when the caller did not supply one explicitly.
-        // Track whether the worktree was auto-created so we can clean it up
-        // if pane acquisition subsequently fails (avoiding orphaned branches).
-        let was_explicit_worktree = task.worktree.is_some();
-        let worktree: Option<String> = match task.worktree {
-            Some(wt) => Some(wt),
-            None => {
-                let tid = task_id.clone();
-                let cwd = task.client_cwd.clone();
-                let base = ctx_start_branch.clone();
-                match tokio::task::spawn_blocking(move || {
-                    create_task_worktree(&tid, cwd.as_deref(), base.as_deref())
+        // Determine worktree + acquire pane.  Two paths:
+        //
+        // 1. `--resume-pane <pid>` path: reuse a specific pane whose lease
+        //    already records a worktree and `has_claude = true`.  The CLI
+        //    parser rejects `--resume-pane` combined with `--worktree`, so
+        //    `task.worktree` is always None here.  We read the lease, inherit
+        //    its worktree, and acquire THAT pane specifically via
+        //    `pane_lease::acquire_lease`.  `had_claude` is forced true so
+        //    `handle_claude_launch` runs the `/compact + inject` tier-1
+        //    reuse path instead of launching a fresh `claude` process.
+        //
+        // 2. Normal path: auto-create a worktree if the caller didn't pass
+        //    `--worktree`, then let `ensure_and_acquire_idle` pick a pane.
+        //
+        // `was_explicit_worktree` gates cleanup of auto-created worktrees on
+        // pane-acquisition failure.  The resume-pane path never auto-creates
+        // anything, so no cleanup is needed there.
+        let was_explicit_worktree = task.worktree.is_some() || task.resume_pane.is_some();
+        let sid_placeholder = uuid::Uuid::new_v4().to_string();
+
+        let (pane_id, had_claude, worktree): (String, bool, Option<String>) = if let Some(ref rp) =
+            task.resume_pane
+        {
+            // --- resume-pane path ---
+            let rp_owned = rp.clone();
+            let tid_for_lease = task_id.clone();
+            let sid_for_lease = sid_placeholder.clone();
+            let probe = tokio::task::spawn_blocking(move || {
+                    let state = pane_lease::read_state()?;
+                    let lease = state.get(&rp_owned).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "pane {rp_owned} not found in lease state; run `amaebi dashboard` to list active panes"
+                        )
+                    })?;
+                    if !lease.has_claude {
+                        anyhow::bail!(
+                            "pane {rp_owned} has no `claude` process running; drop --resume-pane and let the scheduler pick or start a new pane"
+                        );
+                    }
+                    let wt = lease.worktree.clone().ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "pane {rp_owned} has no associated worktree; cannot resume"
+                        )
+                    })?;
+                    pane_lease::acquire_lease(
+                        &rp_owned,
+                        &tid_for_lease,
+                        &sid_for_lease,
+                        Some(&wt),
+                    )?;
+                    Ok::<(String, bool, Option<String>), anyhow::Error>((rp_owned, true, Some(wt)))
                 })
                 .await
-                .context("create_task_worktree panicked")?
-                {
-                    Ok(path) => Some(path.to_string_lossy().into_owned()),
-                    Err(e) => {
-                        tracing::warn!(
-                            task_id = %task_id,
-                            error = %e,
-                            "auto-worktree creation failed; launching claude without worktree isolation"
-                        );
-                        None
-                    }
-                }
-            }
-        };
+                .context("resume-pane probe task panicked")?;
 
-        let tid_for_lease = task_id.clone();
-        let wt_for_lease = worktree.clone();
-
-        // Acquire a pane lease *before* creating session state so that a
-        // capacity failure does not leave orphan session entries on disk.
-        // A placeholder session_id is stored now; it is corrected to the real
-        // UUID via `update_session_id` after `session::get_or_create` returns.
-        let sid_placeholder = uuid::Uuid::new_v4().to_string();
-        let sid_for_lease = sid_placeholder.clone();
-        let pane_result = tokio::task::spawn_blocking(move || {
-            pane_lease::ensure_and_acquire_idle(
-                &tid_for_lease,
-                &sid_for_lease,
-                wt_for_lease.as_deref(),
-            )
-        })
-        .await
-        .context("ensure_and_acquire_idle task panicked")?;
-
-        let (pane_id, had_claude) = match pane_result {
-            Ok(p) => p,
-            Err(e) => {
-                // If the worktree was auto-created, remove it and its branch
-                // to avoid orphaned state after a capacity error.
-                // Use client_cwd with -C so git targets the right repo
-                // regardless of where the daemon was started.
-                // The branch name equals the worktree directory's basename
-                // (both set to unique_name = "<task_id>-<uuid8>").
-                if !was_explicit_worktree {
-                    if let Some(ref wt) = worktree {
-                        let wt_path = wt.clone();
-                        let cleanup_cwd = task.client_cwd.clone();
-                        tokio::task::spawn_blocking(move || {
-                            let branch = std::path::Path::new(&wt_path)
-                                .file_name()
-                                .and_then(|n| n.to_str())
-                                .map(str::to_string);
-                            let mut rm_cmd = std::process::Command::new("git");
-                            if let Some(ref cwd) = cleanup_cwd {
-                                rm_cmd.args(["-C", cwd.as_str()]);
-                            }
-                            let removed = rm_cmd
-                                .args(["worktree", "remove", "--force", &wt_path])
-                                .output()
-                                .map(|o| o.status.success())
-                                .unwrap_or(false);
-                            if removed {
-                                if let (Some(ref cwd), Some(ref br)) = (&cleanup_cwd, &branch) {
-                                    let _ = std::process::Command::new("git")
-                                        .args(["-C", cwd.as_str(), "branch", "-D", br.as_str()])
-                                        .output();
-                                }
-                            }
-                        })
-                        .await
-                        .ok();
-                    }
-                }
-                // Surface CapacityError as a typed terminal response.
-                // Report tasks still unassigned (including this one) so the
-                // caller sees the real demand that exceeded capacity.
-                let remaining = total_tasks - task_idx;
-                let mut w = writer.lock().await;
-                if let Some(cap) = e.downcast_ref::<pane_lease::CapacityError>() {
-                    write_frame(
-                        &mut *w,
-                        &Response::CapacityError {
-                            requested: remaining,
-                            max_panes: cap.max_panes,
-                            current_busy: cap.current_busy,
-                        },
-                    )
-                    .await?;
-                } else {
+            match probe {
+                Ok(triple) => triple,
+                Err(e) => {
+                    let mut w = writer.lock().await;
                     write_frame(
                         &mut *w,
                         &Response::Error {
-                            message: format!("[error] {e:#}"),
+                            message: format!("[error] {e}"),
                         },
                     )
                     .await?;
+                    return Ok(());
                 }
-                // Both Error and CapacityError are terminal: the client
-                // breaks its read loop on either, so return immediately.
-                return Ok(());
+            }
+        } else {
+            // --- normal path: auto-worktree + scheduler-picked pane ---
+            let wt_val: Option<String> = match task.worktree.clone() {
+                Some(wt) => Some(wt),
+                None => {
+                    let tid = task_id.clone();
+                    let cwd = task.client_cwd.clone();
+                    let base = ctx_start_branch.clone();
+                    match tokio::task::spawn_blocking(move || {
+                        create_task_worktree(&tid, cwd.as_deref(), base.as_deref())
+                    })
+                    .await
+                    .context("create_task_worktree panicked")?
+                    {
+                        Ok(path) => Some(path.to_string_lossy().into_owned()),
+                        Err(e) => {
+                            tracing::warn!(
+                                task_id = %task_id,
+                                error = %e,
+                                "auto-worktree creation failed; launching claude without worktree isolation"
+                            );
+                            None
+                        }
+                    }
+                }
+            };
+
+            let tid_for_lease = task_id.clone();
+            let wt_for_lease = wt_val.clone();
+            let sid_for_lease = sid_placeholder.clone();
+            let pane_result = tokio::task::spawn_blocking(move || {
+                pane_lease::ensure_and_acquire_idle(
+                    &tid_for_lease,
+                    &sid_for_lease,
+                    wt_for_lease.as_deref(),
+                )
+            })
+            .await
+            .context("ensure_and_acquire_idle task panicked")?;
+
+            match pane_result {
+                Ok((pid, hc)) => (pid, hc, wt_val),
+                Err(e) => {
+                    // If the worktree was auto-created, remove it and its
+                    // branch to avoid orphaned state after a capacity
+                    // error.  Skipped for --worktree (user-supplied) and
+                    // --resume-pane (pre-existing worktree on another
+                    // pane).
+                    if !was_explicit_worktree {
+                        if let Some(ref wt) = wt_val {
+                            let wt_path = wt.clone();
+                            let cleanup_cwd = task.client_cwd.clone();
+                            tokio::task::spawn_blocking(move || {
+                                let branch = std::path::Path::new(&wt_path)
+                                    .file_name()
+                                    .and_then(|n| n.to_str())
+                                    .map(str::to_string);
+                                let mut rm_cmd = std::process::Command::new("git");
+                                if let Some(ref cwd) = cleanup_cwd {
+                                    rm_cmd.args(["-C", cwd.as_str()]);
+                                }
+                                let removed = rm_cmd
+                                    .args(["worktree", "remove", "--force", &wt_path])
+                                    .output()
+                                    .map(|o| o.status.success())
+                                    .unwrap_or(false);
+                                if removed {
+                                    if let (Some(ref cwd), Some(ref br)) = (&cleanup_cwd, &branch) {
+                                        let _ = std::process::Command::new("git")
+                                            .args(["-C", cwd.as_str(), "branch", "-D", br.as_str()])
+                                            .output();
+                                    }
+                                }
+                            })
+                            .await
+                            .ok();
+                        }
+                    }
+                    let remaining = total_tasks - task_idx;
+                    let mut w = writer.lock().await;
+                    if let Some(cap) = e.downcast_ref::<pane_lease::CapacityError>() {
+                        write_frame(
+                            &mut *w,
+                            &Response::CapacityError {
+                                requested: remaining,
+                                max_panes: cap.max_panes,
+                                current_busy: cap.current_busy,
+                            },
+                        )
+                        .await?;
+                    } else {
+                        write_frame(
+                            &mut *w,
+                            &Response::Error {
+                                message: format!("[error] {e:#}"),
+                            },
+                        )
+                        .await?;
+                    }
+                    return Ok(());
+                }
             }
         };
 
@@ -1259,6 +1357,22 @@ async fn handle_claude_launch(
             let started_pane = pane_id.clone();
             tokio::task::spawn_blocking(move || {
                 let _ = pane_lease::mark_claude_started(&started_pane);
+            })
+            .await
+            .ok();
+        }
+
+        // Persist the raw (user-typed) task description on the lease so that
+        // `/claude --resume-pane <pid>` can reuse it without the user
+        // retyping on subsequent rounds.  Uses `raw_desc` (not `description`)
+        // to avoid storing the git-context preamble; that gets re-derived on
+        // each launch.  Skipped when resume-pane reused the lease's existing
+        // description (no new info to write).
+        if resume_prefetched_desc.is_none() && !raw_desc.trim().is_empty() {
+            let desc_pane = pane_id.clone();
+            let desc_text = raw_desc.clone();
+            tokio::task::spawn_blocking(move || {
+                let _ = pane_lease::set_task_description(&desc_pane, &desc_text);
             })
             .await
             .ok();
@@ -6337,6 +6451,7 @@ mod tests {
             worktree: Some(worktree.to_string()),
             heartbeat_at: now,
             has_claude: true,
+            task_description: None,
         };
         pane_lease::seed_state_for_test(seed).expect("seed pane state");
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6739,4 +6739,83 @@ mod tests {
             "expected missing-description error for %42, got {responses:?}"
         );
     }
+
+    /// When `--resume-pane` points at a lease that claims `has_claude=true`
+    /// but the target tmux pane does not actually exist (or isn't running
+    /// `claude`), the daemon must reject the request at the tmux probe step
+    /// rather than injecting `/compact` into whatever is there.  The task
+    /// description is non-empty here so the lease-description prefetch is
+    /// skipped and the probe runs.
+    #[tokio::test]
+    async fn resume_pane_tmux_probe_rejects_nonexistent_pane() {
+        let _guard = crate::test_utils::with_temp_home();
+        // Use a tmux pane id that does not exist in any tmux session.  The
+        // `tmux display-message -t %9999999` call will fail with a non-zero
+        // exit and an "unknown pane" / "can't find pane" stderr, which our
+        // probe surfaces as a tmux-inspection failure.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before UNIX epoch")
+            .as_secs();
+        let seed = pane_lease::PaneLease {
+            pane_id: "%9999999".to_string(),
+            window_id: "@1".to_string(),
+            status: pane_lease::PaneStatus::Idle,
+            task_id: None,
+            session_id: None,
+            worktree: Some("/tmp/fake-worktree/resume-probe".to_string()),
+            heartbeat_at: now,
+            has_claude: true,
+            task_description: Some("old task".to_string()),
+        };
+        pane_lease::seed_state_for_test(seed).expect("seed pane state");
+
+        let (client, server) = tokio::net::UnixStream::pair().expect("unix pair");
+        let (server_reader_unused, server_writer) = server.into_split();
+        let (client_reader, client_writer_unused) = client.into_split();
+        drop(server_reader_unused);
+        drop(client_writer_unused);
+        let writer = Arc::new(tokio::sync::Mutex::new(server_writer));
+
+        let task = crate::ipc::TaskSpec {
+            task_id: "task-probe".to_string(),
+            // Non-empty description: skips the lease-description prefetch
+            // early-return and forces execution into the tmux probe branch.
+            description: "run this task".to_string(),
+            worktree: None,
+            client_cwd: None,
+            auto_enter: true,
+            resume_pane: Some("%9999999".to_string()),
+        };
+        handle_claude_launch(&writer, vec![task])
+            .await
+            .expect("launch returns ok even on per-task error");
+        drop(writer);
+
+        let responses = collect_responses(client_reader).await;
+        let err_texts: Vec<&str> = responses
+            .iter()
+            .filter_map(|r| match r {
+                crate::ipc::Response::Error { message } => Some(message.as_str()),
+                _ => None,
+            })
+            .collect();
+        // When running under a live tmux server (CI and local dev both have
+        // one), `tmux display-message -t %9999999` exits 0 with empty stdout
+        // because tmux silently falls back to a nearby pane's formatting
+        // context — so our probe sees `pane_current_command == ""`, which
+        // trips the "not currently running `claude`" branch.  When there is
+        // no tmux at all, the probe fails on `.output()` and surfaces the
+        // "failed to inspect tmux pane" branch.  Either is acceptable; both
+        // are preferable to silently injecting `/compact` into the wrong
+        // thing.
+        assert!(
+            err_texts.iter().any(|m| {
+                m.contains("%9999999")
+                    && (m.contains("failed to inspect tmux pane")
+                        || m.contains("is not currently running `claude`"))
+            }),
+            "expected tmux-probe failure for %9999999, got errors: {err_texts:?}"
+        );
+    }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1082,6 +1082,44 @@ async fn handle_claude_launch(
                             "pane {rp_owned} has no associated worktree; cannot resume"
                         )
                     })?;
+                    // The lease's `has_claude` flag is persisted state and can
+                    // go stale (e.g. user `Ctrl-C`'d claude without the daemon
+                    // noticing).  Cross-check at the tmux layer so we don't
+                    // inject `/compact` + a task prompt into a bare shell.
+                    let tmux_probe = std::process::Command::new("tmux")
+                        .args([
+                            "display-message",
+                            "-p",
+                            "-t",
+                            &rp_owned,
+                            "#{pane_current_command}",
+                        ])
+                        .output()
+                        .with_context(|| {
+                            format!(
+                                "failed to inspect tmux pane {rp_owned}; cannot verify that `claude` is running"
+                            )
+                        })?;
+                    if !tmux_probe.status.success() {
+                        let stderr =
+                            String::from_utf8_lossy(&tmux_probe.stderr).trim().to_string();
+                        if stderr.is_empty() {
+                            anyhow::bail!(
+                                "failed to inspect tmux pane {rp_owned}; cannot verify that `claude` is running"
+                            );
+                        } else {
+                            anyhow::bail!(
+                                "failed to inspect tmux pane {rp_owned}; cannot verify that `claude` is running: {stderr}"
+                            );
+                        }
+                    }
+                    let pane_current_command =
+                        String::from_utf8_lossy(&tmux_probe.stdout).trim().to_string();
+                    if pane_current_command != "claude" {
+                        anyhow::bail!(
+                            "pane {rp_owned} is not currently running `claude` (tmux reports `{pane_current_command}`); drop --resume-pane and let the scheduler pick or start a new pane"
+                        );
+                    }
                     pane_lease::acquire_lease(
                         &rp_owned,
                         &tid_for_lease,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -942,29 +942,54 @@ async fn handle_claude_launch(
         // is always non-empty (parser guards it).
         let resume_prefetched_desc: Option<String> = if let Some(ref rp) = task.resume_pane {
             if task.description.trim().is_empty() {
+                // Distinguish three failure modes so the error message matches
+                // what actually went wrong: state-read I/O failure, unknown
+                // pane id, or pane exists but has no saved description.
+                enum LeaseDescLookup {
+                    Found(String),
+                    PaneMissing,
+                    NoDescription,
+                    ReadFailed(String),
+                }
                 let rp_owned = rp.clone();
-                let lease_desc = tokio::task::spawn_blocking(move || {
-                    pane_lease::read_state()
-                        .ok()
-                        .and_then(|s| s.get(&rp_owned).and_then(|l| l.task_description.clone()))
+                let lookup = tokio::task::spawn_blocking(move || match pane_lease::read_state() {
+                    Err(e) => LeaseDescLookup::ReadFailed(e.to_string()),
+                    Ok(state) => match state.get(&rp_owned) {
+                        None => LeaseDescLookup::PaneMissing,
+                        Some(lease) => match lease
+                            .task_description
+                            .as_deref()
+                            .map(str::trim)
+                            .filter(|s| !s.is_empty())
+                        {
+                            Some(d) => LeaseDescLookup::Found(d.to_string()),
+                            None => LeaseDescLookup::NoDescription,
+                        },
+                    },
                 })
                 .await
-                .ok()
-                .flatten();
-                match lease_desc {
-                    Some(d) if !d.trim().is_empty() => Some(d),
-                    _ => {
+                .unwrap_or_else(|e| LeaseDescLookup::ReadFailed(e.to_string()));
+
+                match lookup {
+                    LeaseDescLookup::Found(d) => Some(d),
+                    other => {
+                        let message = match other {
+                            LeaseDescLookup::PaneMissing => format!(
+                                "[error] pane {rp} not found in lease state; \
+                                 run `amaebi dashboard` to list active panes"
+                            ),
+                            LeaseDescLookup::NoDescription => format!(
+                                "[error] pane {rp} has no saved task description; \
+                                 pass a description explicitly after --resume-pane"
+                            ),
+                            LeaseDescLookup::ReadFailed(e) => format!(
+                                "[error] failed to read pane lease state while \
+                                 resolving --resume-pane {rp}: {e}"
+                            ),
+                            LeaseDescLookup::Found(_) => unreachable!(),
+                        };
                         let mut w = writer.lock().await;
-                        write_frame(
-                            &mut *w,
-                            &Response::Error {
-                                message: format!(
-                                    "[error] pane {rp} has no saved task description; \
-                                     pass a description explicitly after --resume-pane"
-                                ),
-                            },
-                        )
-                        .await?;
+                        write_frame(&mut *w, &Response::Error { message }).await?;
                         return Ok(());
                     }
                 }
@@ -1367,15 +1392,14 @@ async fn handle_claude_launch(
         // retyping on subsequent rounds.  Uses `raw_desc` (not `description`)
         // to avoid storing the git-context preamble; that gets re-derived on
         // each launch.  Skipped when resume-pane reused the lease's existing
-        // description (no new info to write).
+        // description (no new info to write).  Fire-and-forget — pane
+        // assignment latency should not wait on the state-file write.
         if resume_prefetched_desc.is_none() && !raw_desc.trim().is_empty() {
             let desc_pane = pane_id.clone();
             let desc_text = raw_desc.clone();
             tokio::task::spawn_blocking(move || {
                 let _ = pane_lease::set_task_description(&desc_pane, &desc_text);
-            })
-            .await
-            .ok();
+            });
         }
 
         let mut w = writer.lock().await;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1052,7 +1052,7 @@ async fn handle_claude_launch(
                     })?;
                     if !lease.has_claude {
                         anyhow::bail!(
-                            "pane {rp_owned} has no `claude` process running; drop --resume-pane and let the scheduler pick or start a new pane"
+                            "pane {rp_owned} is not marked in lease state as having `claude` started; drop --resume-pane and let the scheduler pick or start a new pane"
                         );
                     }
                     let wt = lease.worktree.clone().ok_or_else(|| {
@@ -6523,5 +6523,137 @@ mod tests {
         release_supervised_panes(&panes).await;
         let state = pane_lease::read_state().expect("read pane state");
         assert!(state.get("%999").is_none(), "no pane should be created");
+    }
+
+    // ------------------------------------------------------------------
+    // handle_claude_launch --resume-pane error-path tests
+    //
+    // These tests cover the "description omitted" resume-pane lookup:
+    // the daemon must read the lease, surface the specific failure mode
+    // to the user, and return WITHOUT touching tmux.  The happy path
+    // spawns `tmux send-keys` so is not exercised here (kept for
+    // integration tests).
+    // ------------------------------------------------------------------
+
+    /// Collect every frame the daemon writes on a connected pair until EOF,
+    /// parsing each newline-delimited JSON blob back into `Response`.
+    async fn collect_responses(
+        mut reader: tokio::net::unix::OwnedReadHalf,
+    ) -> Vec<crate::ipc::Response> {
+        use tokio::io::AsyncReadExt;
+        let mut buf = Vec::new();
+        reader
+            .read_to_end(&mut buf)
+            .await
+            .expect("read daemon responses");
+        let text = String::from_utf8(buf).expect("utf-8 daemon responses");
+        text.lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| {
+                serde_json::from_str::<crate::ipc::Response>(l)
+                    .unwrap_or_else(|e| panic!("parse response `{l}`: {e}"))
+            })
+            .collect()
+    }
+
+    /// When `--resume-pane` points at a pane that isn't in the lease state and
+    /// the task description is empty, the daemon must reply with a "not found"
+    /// error (distinct from the missing-description and read-failure cases).
+    #[tokio::test]
+    async fn resume_pane_missing_pane_returns_not_found_error() {
+        let _guard = crate::test_utils::with_temp_home();
+        let (client, server) = tokio::net::UnixStream::pair().expect("unix pair");
+        // `handle_claude_launch` writes to the daemon-side `writer`; the test
+        // reads those frames from the client-side reader.  `pair()` gives us
+        // a duplex socket, so server.writer -> client.reader is the right
+        // direction.  Drop the unused halves so EOF propagates cleanly.
+        let (server_reader_unused, server_writer) = server.into_split();
+        let (client_reader, client_writer_unused) = client.into_split();
+        drop(server_reader_unused);
+        drop(client_writer_unused);
+        let writer = Arc::new(tokio::sync::Mutex::new(server_writer));
+
+        let task = crate::ipc::TaskSpec {
+            task_id: "task-missing".to_string(),
+            description: String::new(),
+            worktree: None,
+            client_cwd: None,
+            auto_enter: true,
+            resume_pane: Some("%999".to_string()),
+        };
+        handle_claude_launch(&writer, vec![task])
+            .await
+            .expect("launch returns ok even on per-task error");
+        drop(writer);
+
+        let responses = collect_responses(client_reader).await;
+        assert!(
+            responses.iter().any(|r| matches!(
+                r,
+                crate::ipc::Response::Error { message }
+                    if message.contains("%999")
+                        && message.contains("not found in lease state")
+            )),
+            "expected not-found error for %999, got {responses:?}"
+        );
+    }
+
+    /// When `--resume-pane` points at a real lease that has no persisted
+    /// `task_description` and the user omitted one, the daemon must reply with
+    /// the "no saved task description" error rather than the not-found error.
+    #[tokio::test]
+    async fn resume_pane_existing_pane_without_description_errors() {
+        let _guard = crate::test_utils::with_temp_home();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock before UNIX epoch")
+            .as_secs();
+        let seed = pane_lease::PaneLease {
+            pane_id: "%42".to_string(),
+            window_id: "@1".to_string(),
+            status: pane_lease::PaneStatus::Idle,
+            task_id: None,
+            session_id: None,
+            worktree: Some("/tmp/fake-worktree/resume".to_string()),
+            heartbeat_at: now,
+            has_claude: true,
+            task_description: None,
+        };
+        pane_lease::seed_state_for_test(seed).expect("seed pane state");
+
+        let (client, server) = tokio::net::UnixStream::pair().expect("unix pair");
+        // `handle_claude_launch` writes to the daemon-side `writer`; the test
+        // reads those frames from the client-side reader.  `pair()` gives us
+        // a duplex socket, so server.writer -> client.reader is the right
+        // direction.  Drop the unused halves so EOF propagates cleanly.
+        let (server_reader_unused, server_writer) = server.into_split();
+        let (client_reader, client_writer_unused) = client.into_split();
+        drop(server_reader_unused);
+        drop(client_writer_unused);
+        let writer = Arc::new(tokio::sync::Mutex::new(server_writer));
+
+        let task = crate::ipc::TaskSpec {
+            task_id: "task-nodesc".to_string(),
+            description: String::new(),
+            worktree: None,
+            client_cwd: None,
+            auto_enter: true,
+            resume_pane: Some("%42".to_string()),
+        };
+        handle_claude_launch(&writer, vec![task])
+            .await
+            .expect("launch returns ok even on per-task error");
+        drop(writer);
+
+        let responses = collect_responses(client_reader).await;
+        assert!(
+            responses.iter().any(|r| matches!(
+                r,
+                crate::ipc::Response::Error { message }
+                    if message.contains("%42")
+                        && message.contains("has no saved task description")
+            )),
+            "expected missing-description error for %42, got {responses:?}"
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -942,9 +942,10 @@ async fn handle_claude_launch(
         // is always non-empty (parser guards it).
         let resume_prefetched_desc: Option<String> = if let Some(ref rp) = task.resume_pane {
             if task.description.trim().is_empty() {
-                // Distinguish three failure modes so the error message matches
+                // Distinguish four failure modes so the error message matches
                 // what actually went wrong: state-read I/O failure, unknown
-                // pane id, or pane exists but has no saved description.
+                // pane id, pane exists but has no saved description, or the
+                // blocking task itself panicked/was cancelled.
                 enum LeaseDescLookup {
                     Found(String),
                     PaneMissing,
@@ -952,23 +953,44 @@ async fn handle_claude_launch(
                     ReadFailed(String),
                 }
                 let rp_owned = rp.clone();
-                let lookup = tokio::task::spawn_blocking(move || match pane_lease::read_state() {
-                    Err(e) => LeaseDescLookup::ReadFailed(e.to_string()),
-                    Ok(state) => match state.get(&rp_owned) {
-                        None => LeaseDescLookup::PaneMissing,
-                        Some(lease) => match lease
-                            .task_description
-                            .as_deref()
-                            .map(str::trim)
-                            .filter(|s| !s.is_empty())
-                        {
-                            Some(d) => LeaseDescLookup::Found(d.to_string()),
-                            None => LeaseDescLookup::NoDescription,
+                let join_res =
+                    tokio::task::spawn_blocking(move || match pane_lease::read_state() {
+                        Err(e) => LeaseDescLookup::ReadFailed(e.to_string()),
+                        Ok(state) => match state.get(&rp_owned) {
+                            None => LeaseDescLookup::PaneMissing,
+                            Some(lease) => match lease
+                                .task_description
+                                .as_deref()
+                                .map(str::trim)
+                                .filter(|s| !s.is_empty())
+                            {
+                                Some(d) => LeaseDescLookup::Found(d.to_string()),
+                                None => LeaseDescLookup::NoDescription,
+                            },
                         },
-                    },
-                })
-                .await
-                .unwrap_or_else(|e| LeaseDescLookup::ReadFailed(e.to_string()));
+                    })
+                    .await;
+
+                let lookup = match join_res {
+                    Ok(l) => l,
+                    Err(join_err) => {
+                        // Blocking task panicked or was cancelled — surface
+                        // that distinctly instead of claiming a disk-read
+                        // failure we did not actually observe.
+                        let mut w = writer.lock().await;
+                        write_frame(
+                            &mut *w,
+                            &Response::Error {
+                                message: format!(
+                                    "[error] resume-pane lookup task panicked \
+                                     while resolving --resume-pane {rp}: {join_err}"
+                                ),
+                            },
+                        )
+                        .await?;
+                        return Ok(());
+                    }
+                };
 
                 match lookup {
                     LeaseDescLookup::Found(d) => Some(d),
@@ -1078,7 +1100,7 @@ async fn handle_claude_launch(
                     write_frame(
                         &mut *w,
                         &Response::Error {
-                            message: format!("[error] {e}"),
+                            message: format!("[error] {e:#}"),
                         },
                     )
                     .await?;
@@ -1392,14 +1414,37 @@ async fn handle_claude_launch(
         // retyping on subsequent rounds.  Uses `raw_desc` (not `description`)
         // to avoid storing the git-context preamble; that gets re-derived on
         // each launch.  Skipped when resume-pane reused the lease's existing
-        // description (no new info to write).  Fire-and-forget — pane
-        // assignment latency should not wait on the state-file write.
+        // description (no new info to write).  Awaited (not fire-and-forget)
+        // so an immediate follow-up `/claude --resume-pane <pid>` is
+        // guaranteed to observe the persisted description instead of racing
+        // a background write.  Failures are logged but do not block pane
+        // assignment — the user still gets a working pane; resume-pane just
+        // won't auto-recover the description.
         if resume_prefetched_desc.is_none() && !raw_desc.trim().is_empty() {
             let desc_pane = pane_id.clone();
             let desc_text = raw_desc.clone();
-            tokio::task::spawn_blocking(move || {
-                let _ = pane_lease::set_task_description(&desc_pane, &desc_text);
-            });
+            let persist_pane = pane_id.clone();
+            match tokio::task::spawn_blocking(move || {
+                pane_lease::set_task_description(&desc_pane, &desc_text)
+            })
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        pane_id = %persist_pane,
+                        error = %e,
+                        "failed to persist task description on lease"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        pane_id = %persist_pane,
+                        error = %e,
+                        "task-description persistence task panicked"
+                    );
+                }
+            }
         }
 
         let mut w = writer.lock().await;

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -591,6 +591,7 @@ mod tests {
             worktree: None,
             heartbeat_at: heartbeat,
             has_claude,
+            task_description: None,
         }
     }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -16,6 +16,15 @@ pub struct TaskSpec {
     /// If `false`, the command is injected into the pane without a trailing
     /// Enter key (useful for commands the user wants to review first).
     pub auto_enter: bool,
+    /// Optional tmux pane id (e.g. `"%41"`) to reuse instead of allocating a
+    /// new one.  When `Some`, the daemon validates the pane exists and has
+    /// `has_claude=true` in the lease map, acquires THAT pane specifically
+    /// (not a scheduler-picked one), inherits its existing worktree, and
+    /// injects `/compact + description` (tier-1 reuse path).  Mutually
+    /// exclusive with `worktree` at the CLI parser; the daemon treats a
+    /// `Some(resume_pane)` as authoritative and ignores any stray `worktree`.
+    #[serde(default)]
+    pub resume_pane: Option<String>,
 }
 
 /// A single pane+task pair for supervision.
@@ -557,6 +566,7 @@ mod tests {
             worktree: Some("/home/user/repo-wt/feat-x".into()),
             client_cwd: Some("/home/user/repo".into()),
             auto_enter: true,
+            resume_pane: None,
         };
         let json = serde_json::to_string(&spec).unwrap();
         let back: TaskSpec = serde_json::from_str(&json).unwrap();
@@ -564,6 +574,32 @@ mod tests {
         assert_eq!(back.description, "implement feature X");
         assert_eq!(back.worktree.as_deref(), Some("/home/user/repo-wt/feat-x"));
         assert!(back.auto_enter);
+        assert!(back.resume_pane.is_none());
+    }
+
+    #[test]
+    fn task_spec_resume_pane_round_trip() {
+        // With resume_pane set.
+        let spec = TaskSpec {
+            task_id: "t1".into(),
+            description: "continue".into(),
+            worktree: None,
+            client_cwd: None,
+            auto_enter: true,
+            resume_pane: Some("%41".into()),
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        let back: TaskSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.resume_pane.as_deref(), Some("%41"));
+    }
+
+    #[test]
+    fn task_spec_resume_pane_absent_field_deserializes_as_none() {
+        // Older clients on master still encode without `resume_pane`; the
+        // daemon must accept that payload and default the field to None.
+        let legacy = r#"{"task_id":"x","description":"d","worktree":null,"client_cwd":null,"auto_enter":true}"#;
+        let back: TaskSpec = serde_json::from_str(legacy).unwrap();
+        assert!(back.resume_pane.is_none());
     }
 
     #[test]
@@ -576,6 +612,7 @@ mod tests {
                     worktree: None,
                     client_cwd: Some("/home/user/repo".into()),
                     auto_enter: true,
+                    resume_pane: None,
                 },
                 TaskSpec {
                     task_id: "t2".into(),
@@ -583,6 +620,7 @@ mod tests {
                     worktree: Some("/wt/b".into()),
                     client_cwd: None,
                     auto_enter: false,
+                    resume_pane: None,
                 },
             ],
         };

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -409,13 +409,15 @@ pub fn release_lease(pane_id: &str) -> Result<()> {
             lease.task_id = None;
             lease.session_id = None;
             // Intentionally keep `worktree`, `has_claude`, and
-            // `task_description`: the pane still has `claude` running on the
-            // same task in the same directory.  Preserving these fields lets
-            // `/claude --resume-pane <pid>` re-acquire the pane and continue
-            // the same work with `/compact + original description` (tier-1
-            // reuse) without the user retyping the task.  They are cleared
-            // only when the pane is destroyed or explicitly reset to a
-            // blank shell.
+            // `task_description` so `/claude --resume-pane <pid>` can re-acquire
+            // the pane and continue the same work with `/compact + original
+            // description` (tier-1 reuse) when those fields still describe the
+            // current pane state.  Depending on why the lease was released
+            // (e.g. early startup or tmux injection failures), these fields may
+            // be absent or stale rather than proving that `claude` is still
+            // running on the same task — callers of resume-pane must treat
+            // them as hints and validate before reuse.  They are cleared only
+            // when the pane is destroyed or explicitly reset to a blank shell.
             lease.heartbeat_at = now_secs();
         }
         write_state_unlocked(&state)?;

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -698,8 +698,10 @@ pub fn set_task_description(pane_id: &str, description: &str) -> Result<()> {
         let mut state = read_state_unlocked()?;
         if let Some(lease) = state.get_mut(pane_id) {
             lease.task_description = Some(description.to_string());
+            write_state_unlocked(&state)
+        } else {
+            Ok(())
         }
-        write_state_unlocked(&state)
     })();
 
     lock.unlock()

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -1273,4 +1273,47 @@ mod tests {
             result.expect("should succeed without calling tmux");
         }
     }
+
+    #[test]
+    fn set_task_description_persists_to_disk_for_existing_pane() {
+        let _guard = crate::test_utils::with_temp_home();
+        let mut state: PaneState = HashMap::new();
+        let mut lease = make_idle("%7", "@0");
+        lease.task_description = None;
+        state.insert("%7".to_string(), lease);
+        write_state_unlocked(&state).expect("seed state");
+
+        set_task_description("%7", "resume this exact task").expect("persist");
+
+        let s = read_state_unlocked().expect("read back");
+        assert_eq!(
+            s["%7"].task_description.as_deref(),
+            Some("resume this exact task"),
+            "description must be persisted on the existing lease"
+        );
+    }
+
+    #[test]
+    fn set_task_description_is_noop_for_missing_pane() {
+        let _guard = crate::test_utils::with_temp_home();
+        let mut state: PaneState = HashMap::new();
+        let mut lease = make_idle("%7", "@0");
+        lease.task_description = Some("keep me".to_string());
+        state.insert("%7".to_string(), lease);
+        write_state_unlocked(&state).expect("seed state");
+
+        set_task_description("%999", "should not be written").expect("noop");
+
+        let s = read_state_unlocked().expect("read back");
+        assert_eq!(s.len(), 1, "no new entries must be added");
+        assert!(
+            !s.contains_key("%999"),
+            "missing pane must not be auto-inserted"
+        );
+        assert_eq!(
+            s["%7"].task_description.as_deref(),
+            Some("keep me"),
+            "existing pane's description must be left untouched"
+        );
+    }
 }

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -79,6 +79,12 @@ pub struct PaneLease {
     /// the scheduler injects just the prompt rather than launching a new session.
     #[serde(default)]
     pub has_claude: bool,
+    /// Full task description last injected into this pane, persisted so
+    /// `/claude --resume-pane <pid>` can reuse it without the user retyping.
+    /// Preserved by `release_lease` (alongside `worktree` / `has_claude`) so
+    /// the pane remembers what it was working on across supervision exits.
+    #[serde(default)]
+    pub task_description: Option<String>,
 }
 
 impl PaneLease {
@@ -92,6 +98,7 @@ impl PaneLease {
             worktree: None,
             heartbeat_at: now_secs(),
             has_claude: false,
+            task_description: None,
         }
     }
 
@@ -331,8 +338,9 @@ fn acquire_first_idle_locked(
 /// Acquire a lease on a **specific pane** by ID.
 ///
 /// Returns `Err` if the pane is already Busy (and not expired), or if the
-/// `worktree` conflicts with another Busy pane.
-#[allow(dead_code)]
+/// `worktree` conflicts with another Busy pane.  Used by
+/// `/claude --resume-pane <pane_id>` to target a specific pane instead of
+/// letting the scheduler pick one.
 pub fn acquire_lease(
     pane_id: &str,
     task_id: &str,
@@ -400,12 +408,14 @@ pub fn release_lease(pane_id: &str) -> Result<()> {
             lease.status = PaneStatus::Idle;
             lease.task_id = None;
             lease.session_id = None;
-            // Intentionally keep `worktree` and `has_claude`: the pane still
-            // has `claude` running in the same directory.  Preserving these
-            // fields allows the scheduler to reuse the pane for a future task
-            // in the same worktree (tier-1: /compact + inject) without a
-            // full relaunch.  They are only cleared when the pane is destroyed
-            // or explicitly reset to a blank shell.
+            // Intentionally keep `worktree`, `has_claude`, and
+            // `task_description`: the pane still has `claude` running on the
+            // same task in the same directory.  Preserving these fields lets
+            // `/claude --resume-pane <pid>` re-acquire the pane and continue
+            // the same work with `/compact + original description` (tier-1
+            // reuse) without the user retyping the task.  They are cleared
+            // only when the pane is destroyed or explicitly reset to a
+            // blank shell.
             lease.heartbeat_at = now_secs();
         }
         write_state_unlocked(&state)?;
@@ -672,6 +682,31 @@ pub fn ensure_and_acquire_idle(
     result
 }
 
+/// Record the full task description on the pane's lease.
+///
+/// Called by `handle_claude_launch` after successfully injecting the
+/// description, so subsequent `/claude --resume-pane <pid>` calls can
+/// retrieve it without the user retyping.  Best-effort: if the pane is no
+/// longer in the state map (e.g. removed by a concurrent cleanup), the call
+/// is a no-op.
+pub fn set_task_description(pane_id: &str, description: &str) -> Result<()> {
+    let lock = open_lock_file()?;
+    lock.lock_exclusive()
+        .context("acquiring flock for set_task_description")?;
+
+    let result = (|| {
+        let mut state = read_state_unlocked()?;
+        if let Some(lease) = state.get_mut(pane_id) {
+            lease.task_description = Some(description.to_string());
+        }
+        write_state_unlocked(&state)
+    })();
+
+    lock.unlock()
+        .context("releasing flock after set_task_description")?;
+    result
+}
+
 /// Correct the session ID stored in the pane lease after the real
 /// `session::get_or_create` UUID is known.
 ///
@@ -843,6 +878,7 @@ mod tests {
             worktree: worktree.map(str::to_string),
             heartbeat_at: now_secs(),
             has_claude: false,
+            task_description: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Adds \`/claude --resume-pane <pane_id>\` so users can continue work on an existing claude pane without the scheduler opening a new one. Description is optional — if omitted, the daemon pulls the full task description from the pane's lease (persisted every successful launch).

Companion to #119 (supervision exit releases the lease, merged). The reuse **mechanism** was already in \`handle_claude_launch\` (\`if had_claude { /compact + inject } else { launch claude }\`) + \`release_lease\` (preserves \`has_claude\` / \`worktree\`); this PR just adds the CLI surface and the matching daemon pane-selection branch that actually reaches that path.

## Why this matters

Before this PR, the tier-1 reuse path was unreachable in practice: \`/claude\` auto-generated a \`{task_id}-{uuid8}\` worktree when \`--worktree\` was omitted, so pane lookup (keyed by worktree equality) never matched an existing pane. Users saw "\`/claude\` done → new \`/claude\` always opens a new pane/window" as a structural mismatch.

## UX

\`\`\`
/claude --resume-pane %41                       # reuse %41, reuse saved description
/claude --resume-pane %41 继续完成上次的开发    # reuse %41, new description
\`\`\`

Mutually exclusive with \`--worktree\` (resume-pane inherits the pane's worktree). Only one task per invocation.

## Files

- \`src/ipc.rs\` — \`TaskSpec.resume_pane: Option<String>\` with serde default.
- \`src/pane_lease.rs\` — \`PaneLease.task_description: Option<String>\` (persisted, preserved across release_lease); new \`set_task_description\` helper; \`acquire_lease\` loses its \`#[allow(dead_code)]\`.
- \`src/client.rs\` — \`parse_claude\` gains \`--resume-pane\`; mutual-exclusion with \`--worktree\`; empty-description allowed iff \`--resume-pane\` is set.
- \`src/daemon.rs\` — \`handle_claude_launch\` branches: resume-pane path reads the lease, calls \`acquire_lease(pane_id, …)\`, inherits worktree, forces \`had_claude = true\`. Also persists \`raw_desc\` on the lease after successful injection.
- \`src/dashboard.rs\`, \`tests/support/helpers.rs\`, one daemon test fixture — PaneLease struct literal sites updated for the new field.

## Error cases (streamed as \`Response::Error\` → \`Done\`)

- Pane not in lease state → "pane %41 not found in lease state…"
- Pane has no claude running → "pane %41 has no \`claude\` process running…"
- Pane has no worktree → "pane %41 has no associated worktree…"
- Pane currently Busy → pass-through from \`acquire_lease\`.
- Empty description with no saved description on lease → explicit error.

## Test plan

- [x] \`cargo test\` — 35 integration + all unit tests green.
- [x] \`cargo fmt --check\` — clean.
- [x] \`cargo clippy -- -D warnings\` — clean (matches CI).
- New tests:
  - 6 × parse_claude: basic, unquoted description, empty description, missing value, \`--worktree\` mutual exclusion, multi-task rejection.
  - 2 × TaskSpec serde: new-field round-trip; legacy-payload-without-field deserializes.
- [ ] Manual E2E: \`amaebi chat\` → \`/claude --resume-pane %41\` → verify \`PaneAssigned.pane_id == %41\`, pane receives \`/compact\` + saved description, supervision loop starts.

## Non-goals

- No auto-pane-selection by task semantics. User names the pane.
- No sticky task_id / stable worktree naming — that's a bigger design change.
- No \`/supervise-pane\` standalone command — resume-pane already kicks off supervision via the existing \`ClaudeLaunch → SupervisePanes\` chain in the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)