### PR TITLE
chore(versioning): derive Cargo.toml from feat/fix commits + CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history — scripts/next-version.sh walks every commit on
+          # the branch to derive the expected Cargo.toml version.
+          fetch-depth: 0
+
+      - name: Version bump check
+        # Verifies that `Cargo.toml` was bumped according to the rule in
+        # CLAUDE.md: each `feat(...)` on master bumps MINOR (PATCH=0),
+        # each `fix(...)` bumps PATCH; MAJOR is human-controlled.  Fails
+        # the build if Cargo.toml disagrees with the history scan.
+        run: scripts/next-version.sh --check
 
       - name: Build dev image (if missing)
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,16 @@
   3. `cargo clippy -- -D warnings` - Ensure there are zero clippy warnings.
 - Do not push code if `cargo fmt --check` or `cargo clippy` fails. GitHub Actions CI will reject it.
 
+## Versioning
+- `Cargo.toml` `version` is `MAJOR.MINOR.PATCH`.  Rule:
+  - `feat(...)` commit on master → MINOR +1, PATCH := 0
+  - `fix(...)` commit on master → PATCH +1
+  - Anything else (`refactor`, `chore`, `docs`, `test`, `spike`, merges…) → no bump
+  - MAJOR is never bumped automatically; a human edits `Cargo.toml` when a release warrants MAJOR+1 (big refactor, architecture shift, storage format change, etc.).
+- Each PR author bumps `Cargo.toml` in the PR itself.  Run `scripts/next-version.sh` to see what the version should be, then edit `Cargo.toml`.
+- CI runs `scripts/next-version.sh --check` on every PR and red-fails if `Cargo.toml` disagrees with what the commit history implies.
+- When MAJOR is bumped, tag the merge commit on master: `git tag vN.0.0 && git push origin vN.0.0`.
+
 ## Architecture
 - SQLite is the source of truth for `memory_db`, `inbox.db`, and `cron.db`. Do not use `.jsonl` or `.json` files for state storage. Avoid `tempfile` atomic writes for data that belongs in SQLite.
   - Exception: `~/.amaebi/sessions.json` is a lightweight non-authoritative directory→UUID mapping cache. It is intentionally JSON (not SQLite) because it is written by every CLI invocation and must tolerate concurrent readers without WAL overhead.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "0.2.0"
+version = "0.49.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "0.2.0"
+version = "0.49.0"
 edition = "2021"
 
 [[bin]]

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Derive the project version from git history on the current branch.
+#
+# Rule (see CLAUDE.md):
+#   - Baseline: 0.0.0
+#   - Walk commits in chronological order:
+#       feat(...): MINOR += 1, PATCH := 0
+#       fix(...):  PATCH += 1
+#       anything else: ignored
+#   - MAJOR is never bumped automatically; a human bumps `Cargo.toml`
+#     manually when they decide a release warrants MAJOR+1.  Once MAJOR
+#     is > 0 in `Cargo.toml`, the scanner uses it verbatim as the floor:
+#     only MINOR/PATCH are derived from history SINCE the commit that
+#     last changed MAJOR in `Cargo.toml`.
+#
+# Usage:
+#   scripts/next-version.sh            # print the expected version
+#   scripts/next-version.sh --check    # exit 1 if Cargo.toml disagrees
+#
+# The script only reads git; it never writes to the repo.
+
+set -euo pipefail
+
+die() { echo "next-version: $*" >&2; exit 1; }
+
+# --- locate repo root (script may be called from anywhere) ---
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || die "not a git repo"
+cd "$repo_root"
+
+cargo_toml="$repo_root/Cargo.toml"
+[[ -f "$cargo_toml" ]] || die "Cargo.toml not found at $cargo_toml"
+
+# --- read MAJOR.MINOR.PATCH from Cargo.toml (first `version = "X.Y.Z"` line) ---
+cargo_version=$(awk -F'"' '/^version = "/ { print $2; exit }' "$cargo_toml")
+[[ -n "$cargo_version" ]] || die "could not parse version from $cargo_toml"
+
+if [[ ! "$cargo_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    die "Cargo.toml version '$cargo_version' is not MAJOR.MINOR.PATCH"
+fi
+cargo_major=${BASH_REMATCH[1]}
+cargo_minor=${BASH_REMATCH[2]}
+cargo_patch=${BASH_REMATCH[3]}
+
+# --- pick the scan window ---
+# When MAJOR == 0 we scan the full history.  Otherwise we find the latest
+# commit that touched the MAJOR digit in Cargo.toml and only count commits
+# after it — that way a human-chosen MAJOR bump resets the counters.
+if [[ "$cargo_major" == "0" ]]; then
+    base_range=""   # scan everything
+else
+    # Find the most recent commit whose diff of Cargo.toml changed the
+    # leading MAJOR digit.  `git log -L` would be overkill; a simple
+    # `git log -G'^version = "N\.'` over `Cargo.toml` is enough.
+    base_commit=$(git log -n 1 --format=%H -G"^version = \"${cargo_major}\." -- Cargo.toml 2>/dev/null || true)
+    if [[ -z "$base_commit" ]]; then
+        # MAJOR > 0 but no commit ever introduced that MAJOR — treat as
+        # "starting fresh from this MAJOR": no history counts, so the
+        # expected version is MAJOR.0.0.
+        echo "${cargo_major}.0.0"
+        if [[ "${1:-}" == "--check" ]]; then
+            if [[ "$cargo_version" != "${cargo_major}.0.0" ]]; then
+                echo "next-version: Cargo.toml=$cargo_version but expected ${cargo_major}.0.0" >&2
+                exit 1
+            fi
+        fi
+        exit 0
+    fi
+    base_range="${base_commit}..HEAD"
+fi
+
+# --- scan commit subjects, chronological order ---
+# Conventional-commit prefixes we care about.  Accept both `feat(scope):`
+# and `feat:` forms.  Everything else is ignored (refactor, chore, docs,
+# test, spike, merge commits, ...).
+minor=0
+patch=0
+while IFS= read -r subject; do
+    case "$subject" in
+        feat\(*\):*|feat:*)
+            minor=$((minor + 1))
+            patch=0
+            ;;
+        fix\(*\):*|fix:*)
+            patch=$((patch + 1))
+            ;;
+    esac
+done < <(git log $base_range --reverse --format=%s)
+
+expected="${cargo_major}.${minor}.${patch}"
+
+if [[ "${1:-}" == "--check" ]]; then
+    if [[ "$cargo_version" != "$expected" ]]; then
+        cat >&2 <<EOF
+next-version: Cargo.toml version mismatch.
+  Cargo.toml says: $cargo_version
+  History implies: $expected
+  (MAJOR=$cargo_major fixed by Cargo.toml; MINOR/PATCH derived from
+   commit history — feat bumps MINOR, fix bumps PATCH.)
+Fix: edit Cargo.toml to '$expected', or if this PR should bump MAJOR,
+     also edit Cargo.toml MAJOR and re-run this check.
+EOF
+        exit 1
+    fi
+    echo "OK $expected"
+else
+    echo "$expected"
+fi


### PR DESCRIPTION
## Summary
- Adds `scripts/next-version.sh` that scans master's commit history and derives the expected `Cargo.toml` version (feat→MINOR+1/PATCH=0, fix→PATCH+1, MAJOR stays human-controlled).
- Wires `scripts/next-version.sh --check` into CI so every PR must keep `Cargo.toml` in sync with the history rule.
- Back-fills `Cargo.toml`/`Cargo.lock` to `0.49.0` to match the rule applied to existing master commits; documents the rule in `CLAUDE.md`.

## Test plan
- [x] `scripts/next-version.sh` prints `0.49.0` on current master
- [x] `scripts/next-version.sh --check` passes with `Cargo.toml` at `0.49.0`
- [x] `scripts/next-version.sh --check` fails with a clear error when `Cargo.toml` disagrees
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)