### PR TITLE
docs: slim README, split features into docs/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,34 @@
 # amaebi
 
-A tiny, memory-efficient AI assistant for the terminal, backed by Amazon Bedrock and GitHub Copilot.
+A small, memory-efficient AI assistant for the terminal, backed by Amazon Bedrock and GitHub Copilot.
 
-**amaebi** (甘エビ, 小甜虾, sweet shrimp) runs as a lightweight daemon. It can run shell commands, read and edit files, interact with tmux panes, spawn parallel sub-agents, schedule autonomous cron jobs, and steer live AI responses mid-flight — all from a single binary under 7 MB.
+**amaebi** (甘エビ, sweet shrimp) runs as a lightweight daemon. It can run shell commands, read and edit files, drive tmux panes, spawn parallel sub-agents, schedule cron jobs, and steer live AI responses mid-flight — all from a single binary under 7 MB.
 
 ## Quick Start
 
 ```bash
-# Install Rust (if needed)
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
 # Build
 git clone https://github.com/yuankuns/amaebi.git
 cd amaebi
 cargo build --release
-
-# Authenticate with GitHub Copilot (skip if using Bedrock)
-./target/release/amaebi auth
-
-# Start the daemon (once; keep it running)
-./target/release/amaebi daemon &
-
-# Ask away
-./target/release/amaebi ask "what's using the most disk space?"
-
-# Or start an interactive chat session
-./target/release/amaebi chat
-```
-
-Add the binary to your PATH:
-
-```bash
 ln -sf $(pwd)/target/release/amaebi ~/.local/bin/amaebi
+
+# Authenticate (skip if using Bedrock; see docs/architecture.md)
+amaebi auth
+
+# Start the daemon (keep it running)
+amaebi daemon &
+
+# One-shot question
+amaebi ask "what's using the most disk space?"
+
+# Or an interactive session
+amaebi chat
 ```
 
----
+Requires Rust 1.85+ (install via [rustup](https://rustup.rs/)), and either a
+GitHub Copilot subscription or an Amazon Bedrock bearer token. tmux and Docker
+are optional.
 
 ## How It Works
 
@@ -53,331 +47,58 @@ amaebi splits into two processes connected by a Unix socket:
                                  │ read · edit   │
                                  │ spawn_agent   │
                                  └───────────────┘
-                                         │
-                              ┌──────────┴──────────┐
-                              ▼                     ▼
-                      ~/.amaebi/memory.db    ~/.amaebi/inbox.db
-                      (conversation memory)  (async task results)
 ```
 
-- **Client** (`amaebi ask` / `amaebi chat`): Short-lived or interactive process. Sends the prompt, streams the response to stdout, and reads stdin for mid-flight steering corrections.
-- **Daemon** (`amaebi daemon`): Persistent process. Manages API connections, token caching, tool execution, SQLite-backed session history, and the cron scheduler.
+The **client** (`ask` / `chat`) is short-lived: it streams output and reads
+stdin for mid-flight steering. The **daemon** (`amaebi daemon`) owns the API
+connection, session history, tool execution, cron scheduler, and pane /
+resource leases.
 
----
+See [docs/architecture.md](docs/architecture.md) for file layouts, database
+schemas, and the `/claude` request lifecycle.
 
-## Dual-Channel UX
+## Common Commands
 
-### Single-shot mode (`ask`)
-
-The CLI stays open and streams output live. You can type corrections mid-flight:
-
-```
-$ amaebi ask "refactor the auth module and add tests"
-[tool] read_file src/auth.rs
-[tool] shell_command cargo test
-[tool] edit_file src/auth.rs
-> wait, keep the old function signature      ← you type this mid-stream
-[steer] correction injected
-[tool] edit_file src/auth.rs
-Done. Refactored auth module. 3 new tests added, all passing.
-[Session: a1b2c3d4-e5f6-7890-abcd-ef1234567890]
-```
-
-- Type a line + Enter to inject a correction (steering). The model sees it before its next turn.
-- Press **Ctrl+D** to detach — the task continues in the background; result goes to `amaebi inbox`.
-- Press **Ctrl+C** twice to exit immediately.
-
-### Interactive chat mode (`chat`)
-
-A persistent REPL that keeps context across multiple prompts without re-invoking the binary:
-
-```
-$ amaebi chat
-> explain the retry logic in bedrock.rs
-[...response...]
-> how does it compare to the copilot implementation?
-[...response using the same in-memory context...]
-> /quit
-```
-
-- In-memory context is preserved between turns on the same connection (no per-turn DB round-trips).
-- All the same steering, steer, and detach mechanics work inside chat.
-- Session history is persisted to SQLite on every turn, so you can resume later with `ask --resume`.
-
-### Detached mode (`--detach`)
-
-```bash
-amaebi ask "run the full test suite and summarise failures" --detach
-# → [queued: a1b2c3d4]   exits in < 100 ms
-```
-
-The daemon runs the task autonomously. When it completes, the result is deposited into the inbox.
-
----
-
-## Session Management
-
-Every working directory gets a stable UUID stored in `~/.amaebi/sessions.json`. amaebi uses this UUID to isolate per-project conversation history — no manual setup required.
-
-### TTL-based implicit reset
-
-Sessions expire automatically after 30 minutes of inactivity. Come back after lunch and get a fresh context automatically, with no commands needed.
-
-TTL tiers are configurable in `~/.amaebi/config.json`:
-
-```json
-{
-  "ttl_minutes": {
-    "default": 30,
-    "/home/user/long-project": 120,
-    "ephemeral": 5,
-    "persistent": 1440
-  }
-}
-```
-
-### `--resume`: explicit full-history recall
-
-```bash
-amaebi ask --resume "continue the migration from yesterday"
-# Loads full chronological history for this directory's session UUID
-# (bypasses the normal sliding-window cap)
-
-amaebi ask --resume abc123de "what was the conclusion on that auth bug?"
-# Loads history for a specific UUID (cross-directory or archived session)
-```
-
-`--resume` and `--detach` are mutually exclusive.
-
-### Session subcommands
-
-```bash
-amaebi session show       # print the UUID for the current directory
-amaebi session new        # generate a fresh UUID (discard old context)
-amaebi session status     # list all directory → UUID mappings
-amaebi session set-tier <tier>   # set TTL tier (default|ephemeral|persistent)
-amaebi session clear      # evict expired sessions from sessions.json
-```
-
----
-
-## Commands
-
-### Core
-
-| Command | Description |
-|---------|-------------|
-| `amaebi auth` | Authenticate via GitHub Copilot device flow |
-| `amaebi daemon` | Start the background daemon |
+| Command | Purpose |
+|---------|---------|
 | `amaebi ask "<prompt>"` | Send a prompt and stream the reply |
-| `amaebi ask "<prompt>" --detach` | Submit as a background task |
-| `amaebi ask "<prompt>" --resume [uuid]` | Resume with full session history |
-| `amaebi chat` | Start an interactive multi-turn chat session |
-| `amaebi models` | List available models |
+| `amaebi chat` | Interactive multi-turn session ([docs](docs/chat.md)) |
+| `/claude "<task>"` | Launch a supervised Claude Code subprocess in tmux ([docs](docs/claude.md)) |
+| `amaebi dashboard` | Live TUI view of panes, sessions, inbox, cron ([docs](docs/dashboard.md)) |
+| `amaebi memory search <q>` | Full-text search of conversation memory |
+| `amaebi inbox list` | Read results from detached and cron tasks |
+| `amaebi cron add "<desc>" --cron "<expr>"` | Schedule a recurring autonomous task |
 
-### Inbox
+Run `amaebi --help` for the full subcommand list.
 
-Background tasks (detached runs and cron jobs) deposit their results here.
+## Feature Index
 
-```bash
-amaebi inbox list           # list unread reports
-amaebi inbox list --all     # include already-read reports
-amaebi inbox read <id>      # display a report and mark it read
-amaebi inbox mark-read      # mark all unread as read
-amaebi inbox clear          # delete all reports
-```
+- **[chat.md](docs/chat.md)** — `amaebi ask` and `amaebi chat`, session resume, steering, detached runs
+- **[claude.md](docs/claude.md)** — the `/claude` slash command, worktrees, flags (`--tag`, `--resume-pane`, `--resource`, etc.)
+- **[supervision.md](docs/supervision.md)** — WAIT / STEER / DONE model, timing knobs, release guarantees
+- **[resource-pool.md](docs/resource-pool.md)** — `~/.amaebi/resources.toml`, `--resource` semantics, env injection
+- **[dashboard.md](docs/dashboard.md)** — `amaebi dashboard` TUI
+- **[architecture.md](docs/architecture.md)** — two-process model, `~/.amaebi/` file inventory, request lifecycle
 
-A bell notification is printed to stderr at the start of every `amaebi ask` when unread reports are waiting:
+### Not yet covered by dedicated docs
 
-```
-[🔔 You have 2 unread cron reports. Run `amaebi inbox list` to read.]
-```
+- `amaebi cron` — 5-field UTC cron expressions; jobs run in the daemon, results land in the inbox
+- `amaebi memory` — SQLite-backed conversation history (FTS5)
+- `amaebi inbox` — mailbox for detached and cron task results
+- `amaebi session` — per-directory UUIDs and TTL tiers
+- `amaebi cache prune` — evict expired sessions
+- `amaebi acp` — ACP (Agent Client Protocol) agent over stdio for Zed / Claude Code integration
+- `amaebi models` — list available Bedrock/Copilot models
+- `amaebi tag list` / `release` — inspect and force-release task notebook leases
+- `amaebi resource list` — inspect the resource pool and lease state
 
-### Cron
-
-Schedule recurring autonomous tasks. The daemon fires them on a 1-minute tick; results go to the inbox.
-
-```bash
-amaebi cron add "check disk usage and warn if >90%" --cron "0 9 * * *"
-amaebi cron list
-amaebi cron delete <uuid>
-```
-
-Cron expressions are 5-field UTC (`min hour dom mon dow`). Supports `*`, ranges (`1-5`), steps (`*/2`), and comma lists.
-
-### Memory
-
-```bash
-amaebi memory list          # show the last 40 remembered messages
-amaebi memory search <query>  # full-text search (FTS5)
-amaebi memory count         # total number of stored memories
-amaebi memory clear         # delete all memories
-```
-
-### Cache
-
-```bash
-amaebi cache stats          # session count, memory entry count, disk usage
-amaebi cache prune          # evict expired sessions (respects TTL tiers)
-amaebi cache prune --aggressive   # remove all sessions regardless of TTL
-amaebi cache prune --dry-run      # preview without deleting
-```
-
-### ACP (Zed / Claude Code integration)
-
-```bash
-amaebi acp [--model <model>]
-```
-
-Runs amaebi as an [Agent Client Protocol](https://github.com/zed-industries/acp) agent over stdio, compatible with Zed, Claude Code, and any other ACP client. Memory reads/writes are routed through the daemon's Unix socket so only one process ever touches the SQLite databases.
-
----
-
-## Model Selection
-
-amaebi supports two providers. Prefix the model name with `provider/` to select one explicitly; without a prefix, Copilot is used.
-
-```bash
-# GitHub Copilot (default)
-amaebi ask --model gpt-4o "explain this error"
-amaebi ask --model copilot/claude-sonnet-4.6 "explain this error"
-
-# Amazon Bedrock
-amaebi ask --model bedrock/claude-sonnet-4.6 "explain this error"
-export AMAEBI_MODEL=bedrock/claude-sonnet-4.6
-
-# Environment variable
-export AMAEBI_MODEL=gpt-4o-mini
-amaebi ask "summarise this file"
-
-# Default: claude-sonnet-4.6
-```
-
-### Amazon Bedrock setup
-
-Set the bearer token and optionally the region before starting the daemon:
-
-```bash
-export AWS_BEARER_TOKEN_BEDROCK=<your-token>
-export AWS_REGION=us-east-1   # default if unset
-amaebi daemon &
-amaebi ask --model bedrock/claude-sonnet-4.6 "hello"
-```
-
----
-
-## Tools
-
-The agent autonomously selects from these tools during a task:
-
-| Tool | Description |
-|------|-------------|
-| `shell_command` | Run any shell command |
-| `read_file` | Read file contents |
-| `edit_file` | Write/overwrite a file |
-| `tmux_capture_pane` | Read the visible text of a tmux pane |
-| `tmux_send_keys` | Send keystrokes to a tmux pane |
-| `spawn_agent` | Launch a parallel sub-agent with its own workspace and tool context |
-
-### `spawn_agent`: parallel sub-agents
-
-The agent can fan out work across multiple independent sub-agents that run concurrently. Each sub-agent has its own sandbox, working directory, and tool context; results are collected and returned to the parent.
-
-```
-$ amaebi ask "review every file in src/ for security issues"
-[tool] spawn_agent {workspace: "src/auth.rs"}
-[tool] spawn_agent {workspace: "src/api.rs"}
-[tool] spawn_agent {workspace: "src/db.rs"}
-... all three run in parallel ...
-Summary: found 2 issues in auth.rs, 1 in db.rs.
-```
-
-### Docker sandbox
-
-Shell commands can be isolated in a Docker container:
-
-```bash
-export AMAEBI_SANDBOX=docker
-export AMAEBI_SANDBOX_IMAGE=amaebi-sandbox:bookworm-slim  # optional override
-amaebi daemon &
-```
-
-When the sandbox is active, `shell_command` runs inside the container instead of directly on the host. Sub-agents spawned via `spawn_agent` each get their own container.
-
----
-
-## Skills (Persistent Agent Instructions)
-
-amaebi injects files from `~/.amaebi/` into the agent's context at the start of every turn, letting you give the agent standing instructions without repeating yourself in every prompt.
-
-### Always-injected files
-
-These are loaded unconditionally before each turn:
-
-| File | Purpose |
-|------|---------|
-| `~/.amaebi/AGENTS.md` | Standing agent guidelines — coding style, workflow preferences, rules the agent must follow |
-| `~/.amaebi/SOUL.md` | Personality and tone directives |
-
-Example `~/.amaebi/AGENTS.md`:
-
-```markdown
-- Always run tests before editing production code.
-- Prefer small, focused commits over large sweeping changes.
-- When in doubt, ask before deleting files.
-```
-
-### On-demand operations docs
-
-These files are **not** preloaded (they can be large), but the agent receives their absolute paths so it can `read_file` them when the task requires it:
-
-| File | Purpose |
-|------|---------|
-| `~/.amaebi/OPERATIONS_INDEX.md` | Index of all operations documentation |
-| `~/.amaebi/DEPLOYMENT.md` | Deployment procedures |
-| `~/.amaebi/CONFIG_REFERENCE.md` | Configuration reference |
-| `~/.amaebi/RUNBOOK.md` | Incident runbook |
-
-Files that do not exist are silently skipped — create only the ones you need.
-
----
-
-## Data Files
-
-| Path | Purpose |
-|------|---------|
-| `~/.amaebi/sessions.json` | Directory → session UUID mapping (JSON, 0600) |
-| `~/.amaebi/memory.db` | Conversation history per session UUID (SQLite, WAL) |
-| `~/.amaebi/inbox.db` | Async task results from detached/cron runs (SQLite, WAL) |
-| `~/.amaebi/cron.db` | Scheduled cron job definitions (SQLite, WAL) |
-| `~/.amaebi/config.json` | Optional: TTL overrides per directory or tier |
-| `/tmp/amaebi.sock` | Unix domain socket for client–daemon IPC |
-
-All SQLite files use WAL mode and 0600 permissions. `sessions.json` is intentionally JSON (not SQLite) because every CLI invocation writes to it and it must tolerate concurrent readers without WAL overhead.
-
----
+See the `amaebi <subcommand> --help` output for flags.
 
 ## Debugging
 
 ```bash
-# Enable verbose daemon logs
-AMAEBI_LOG=debug amaebi daemon
-
-# Daemon logs go to stderr; redirect to a file if needed
 AMAEBI_LOG=debug amaebi daemon 2>daemon.log
 ```
-
----
-
-## Requirements
-
-- Rust 1.85+ (install via [rustup](https://rustup.rs/) — Ubuntu's packaged Rust is too old)
-- **GitHub Copilot** — a GitHub account with an active [Copilot](https://github.com/features/copilot) subscription (run `amaebi auth` to authenticate), **or**
-- **Amazon Bedrock** — set `AWS_BEARER_TOKEN_BEDROCK` (and optionally `AWS_REGION`)
-- tmux (optional — only needed for `tmux_capture_pane` / `tmux_send_keys` tools)
-- Docker (optional — only needed for the sandbox backend)
-
----
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ amaebi ask "what's using the most disk space?"
 amaebi chat
 ```
 
-Requires Rust 1.85+ (install via [rustup](https://rustup.rs/)), and either a
-GitHub Copilot subscription or an Amazon Bedrock bearer token. tmux and Docker
-are optional.
+Requires a recent stable Rust toolchain (install via
+[rustup](https://rustup.rs/)), and either a GitHub Copilot subscription or an
+Amazon Bedrock bearer token. tmux and Docker are optional.
 
 ## How It Works
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ All SQLite files use WAL mode and 0600 permissions.
 
 ### SQLite vs. JSON
 
-Source of truth is SQLite for `memory_db`, `inbox.db`, `cron.db`, and
+Source of truth is SQLite for `memory.db`, `inbox.db`, `cron.db`, and
 `tasks.db`. JSON is reserved for files that must tolerate frequent concurrent
 readers without WAL overhead:
 
@@ -75,7 +75,7 @@ readers without WAL overhead:
 
 Atomic writes use `rename(2)` after staging to a temp file in the same
 directory; no `tempfile` crate usage. The project convention (see
-`/home/yuankuns/amaebi/CLAUDE.md`) is: state goes into SQLite unless the
+[CLAUDE.md](../CLAUDE.md)) is: state goes into SQLite unless the
 concurrent-reader pattern demands JSON.
 
 ## Worktree layout
@@ -144,11 +144,11 @@ The daemon accepts `provider/model` strings and dispatches to one of two
 provider backends (`src/provider.rs`):
 
 - `bedrock/<model>` or a known Bedrock alias → `src/bedrock.rs`
-- `copilot/<model>` or a bare Copilot model → `src/copilot.rs`
+- `copilot/<model>` → `src/copilot.rs`
 
 Unprefixed names first consult `~/.amaebi/config.json` user aliases, then
-the built-in Bedrock alias table (`src/provider.rs:64`), falling back to
-Copilot.
+the built-in Bedrock alias table (`src/provider.rs:64`), and otherwise
+default to Bedrock (see `resolve_with_aliases` in `src/provider.rs`).
 
 The default (`DEFAULT_MODEL` at `src/provider.rs:105`) is
 `claude-sonnet-4.6[1m]`. The `[1m]` suffix opts into Bedrock's 1M-context

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,185 @@
+# Architecture
+
+A deeper look at how the pieces fit together. See the top-level README for
+the one-paragraph summary.
+
+## Two-process model
+
+```
+┌──────────┐    Unix socket      ┌───────────────┐    HTTPS/SSE    ┌──────────────────┐
+│  Client  │ ◄─────────────────► │    Daemon     │ ◄─────────────► │  Copilot API  or │
+│ amaebi   │  /tmp/amaebi.sock   │  (persistent) │                 │  Amazon Bedrock  │
+│ ask/chat │                     └───────────────┘                 └──────────────────┘
+└──────────┘                             │
+                                         ▼
+                                 ┌───────────────┐
+                                 │ Tool Executor │
+                                 │ shell · tmux  │
+                                 │ read · edit   │
+                                 │ spawn_agent   │
+                                 └───────────────┘
+```
+
+The **client** is one of:
+
+- `amaebi ask` — short-lived; one request, stream the reply, exit.
+- `amaebi chat` — interactive REPL on a long-lived socket connection.
+- `amaebi acp` — ACP stdio agent for Zed / Claude Code integration. Routes
+  memory reads and writes through the daemon socket so only the daemon ever
+  writes to SQLite.
+
+The **daemon** (`amaebi daemon`) is a single persistent process. It owns:
+
+- The HTTPS connection to Bedrock or the Copilot API, including token
+  caching.
+- The tool executor (shell, read/edit file, tmux control, spawn_agent).
+- SQLite connections for `memory.db`, `inbox.db`, `cron.db`, `tasks.db`.
+- The cron scheduler (1-minute tick).
+- The supervision loop for `/claude` runs (see
+  [supervision.md](supervision.md)).
+- Pane and resource leases.
+
+The socket is `/tmp/amaebi.sock` by default (`DEFAULT_SOCKET` in
+`src/cli.rs:3`). One daemon per user.
+
+## `~/.amaebi/` file inventory
+
+| Path | Format | Purpose |
+|------|--------|---------|
+| `memory.db` | SQLite WAL | Per-session conversation history, FTS5-indexed |
+| `inbox.db` | SQLite WAL | Results from detached and cron tasks |
+| `cron.db` | SQLite WAL | Scheduled cron job definitions + `last_run` |
+| `tasks.db` | SQLite WAL | Task notebook leases and verdict history (`--tag`) |
+| `sessions.json` | JSON, 0600 | Directory → session UUID mapping |
+| `tmux-state.json` | JSON, flocked | Pane leases (status, tag, worktree, heartbeat) |
+| `resource-state.json` | JSON, flocked | Resource lease table |
+| `resources.toml` | TOML | Resource pool definition (hand-edited) |
+| `config.json` | JSON | TTL overrides + model aliases |
+| `AGENTS.md` | Markdown | Standing agent guidelines (injected each turn) |
+| `SOUL.md` | Markdown | Personality directives (injected each turn) |
+| `worktrees/` | dir | Per-task git worktrees for `/claude` |
+
+All SQLite files use WAL mode and 0600 permissions.
+
+### SQLite vs. JSON
+
+Source of truth is SQLite for `memory_db`, `inbox.db`, `cron.db`, and
+`tasks.db`. JSON is reserved for files that must tolerate frequent concurrent
+readers without WAL overhead:
+
+- `sessions.json` — written by every CLI invocation; a lightweight
+  non-authoritative directory→UUID cache.
+- `tmux-state.json` — protected by `flock` on `tmux-state.lock`; readable by
+  the dashboard and by every `/claude` acquisition check.
+- `resource-state.json` — protected by `flock` on `resource-state.lock`.
+
+Atomic writes use `rename(2)` after staging to a temp file in the same
+directory; no `tempfile` crate usage. The project convention (see
+`/home/yuankuns/amaebi/CLAUDE.md`) is: state goes into SQLite unless the
+concurrent-reader pattern demands JSON.
+
+## Worktree layout
+
+```
+~/.amaebi/worktrees/<repo>/<tag>-<uuid8>/
+```
+
+- `<repo>` — basename of the originating git repo root.
+- `<tag>` — the `/claude --tag` value, or an auto-generated short label.
+- `<uuid8>` — 8 random alphanumeric chars (`src/daemon.rs:2919`) so parallel
+  tasks with the same tag never collide.
+
+The worktree is created on a new branch named `<tag>-<uuid8>`. If the user
+passes `--worktree <existing-path>` the auto-create is skipped.
+
+## `/claude` request lifecycle
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│  Client:  parse  /claude flags                                    │
+│             ↓                                                     │
+│           GenerateTag (Haiku, if --tag not given)                 │
+│             ↓                                                     │
+│           send Request::ClaudeLaunch                              │
+└──────────────────────────┬────────────────────────────────────────┘
+                           │ Unix socket frame
+                           ▼
+┌───────────────────────────────────────────────────────────────────┐
+│  Daemon:                                                          │
+│                                                                   │
+│    validate flags  (--resume-pane vs --worktree / --resource)     │
+│      ↓                                                            │
+│    acquire task notebook lease   (tasks.db, if --tag)             │
+│      ↓                                                            │
+│    acquire pane lease            (tmux-state.json)                │
+│      ↓                                                            │
+│    create worktree               (unless --worktree given)        │
+│      ↓                                                            │
+│    acquire resource leases       (resource-state.json, all-or-    │
+│                                   nothing, canonical order)      │
+│      ↓                                                            │
+│    render env vars + prompt_hint; export into pane shell          │
+│      ↓                                                            │
+│    spawn `claude` in pane, inject task description                │
+│      ↓                                                            │
+│    enter supervision loop        (WAIT / STEER / DONE)            │
+│      ↓                                                            │
+│    on any exit:                                                   │
+│      release_supervised_panes()                                   │
+│      release_task_leases_for_holder()                             │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+Validation at the client (parse-time) rejects impossible combinations early:
+`--resume-pane` + `--worktree`, and `--resume-pane` + `--resource` (see
+`src/client.rs:433` and `src/client.rs:446`). The daemon re-validates and
+rolls back partial acquisitions if any later step fails.
+
+Cleanup at supervision exit is unconditional. See [supervision.md](
+supervision.md) for the release guarantees.
+
+## Model routing
+
+The daemon accepts `provider/model` strings and dispatches to one of two
+provider backends (`src/provider.rs`):
+
+- `bedrock/<model>` or a known Bedrock alias → `src/bedrock.rs`
+- `copilot/<model>` or a bare Copilot model → `src/copilot.rs`
+
+Unprefixed names first consult `~/.amaebi/config.json` user aliases, then
+the built-in Bedrock alias table (`src/provider.rs:64`), falling back to
+Copilot.
+
+The default (`DEFAULT_MODEL` at `src/provider.rs:105`) is
+`claude-sonnet-4.6[1m]`. The `[1m]` suffix opts into Bedrock's 1M-context
+beta. Copilot ignores the suffix.
+
+## Concurrency and leases
+
+- **Pane leases** (`src/pane_lease.rs`) — 24 h TTL, flocked JSON, one writer
+  at a time. Supervision heartbeats refresh the lease; daemon crashes let the
+  TTL reclaim path take over.
+- **Resource leases** (`src/resource_lease.rs`) — same TTL
+  (`LEASE_TTL_SECS = 86_400` at `src/resource_lease.rs:59`). All-or-nothing
+  acquisition in canonical `(class, name)` order so two callers cannot
+  deadlock.
+- **Task notebook leases** (`src/tasks.rs`) — one live lease per
+  `(repo_dir, tag)` pair, bound to the supervision holder id.
+
+All three follow the same pattern: acquire at entry, release on every exit
+path, TTL reclaim if the holder crashes.
+
+## Client protocol (summary)
+
+The socket speaks newline-delimited JSON. Requests and responses are
+typed enums defined in `src/ipc.rs`. The main request types:
+
+- `Ask { prompt, session_id, model, ... }` — one-shot or chat turn.
+- `ClaudeLaunch { tasks, session_id, repo_dir }` — launch one or more
+  supervised Claude Code panes.
+- `SupervisePanes { panes, model }` — re-attach supervision to existing
+  panes (used by the `chat` REPL).
+- `Memory { op, ... }` — memory reads/writes (routed via the daemon so only
+  one process ever writes to `memory.db`).
+
+Responses are streamed as a sequence of frames ending in `Response::Done`.

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -114,9 +114,7 @@ correction.
 
 The prompt input uses `rustyline` for line editing — arrow keys, Emacs
 bindings, CJK-aware cursor movement, and persistent history across
-sessions. This replaced a hand-rolled editor; see commit `0bb236a` and the
-memory note at
-`~/.claude/projects/-home-yuankuns-amaebi/memory/feedback_prefer_libraries.md`.
+sessions. This replaced a hand-rolled editor; see commit `0bb236a`.
 
 ## Session identity
 

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -1,0 +1,136 @@
+# amaebi ask & amaebi chat
+
+Two ways to talk to the daemon.
+
+- `amaebi ask "<prompt>"` — one-shot. Streams the reply, exits when the task
+  finishes.
+- `amaebi chat [<prompt>]` — interactive REPL. Stays open until you hit Ctrl-D
+  or type an empty line.
+
+Both share the same session UUID per working directory, so a `chat` started in
+`~/projectX` and a later `ask` in the same directory see the same history
+(subject to the session TTL, see `amaebi session --help`).
+
+## Basic usage
+
+```bash
+amaebi ask "explain the retry logic in bedrock.rs"
+amaebi chat
+# > explain the retry logic in bedrock.rs
+# [...response...]
+# > how does it compare to the copilot implementation?
+```
+
+## Model override
+
+```bash
+amaebi ask --model bedrock/claude-sonnet-4.6 "hello"
+amaebi chat --model copilot/gpt-4o
+```
+
+The default is `claude-sonnet-4.6[1m]` (see `src/provider.rs:105`). The `[1m]`
+suffix opts into Bedrock's 1M-context beta. Copilot ignores the suffix.
+
+Resolution order: `--model` flag → `AMAEBI_MODEL` env → default.
+
+### Model aliases
+
+`~/.amaebi/config.json` can define short aliases:
+
+```json
+{
+  "model_aliases": {
+    "opus": "bedrock/claude-opus-4.7",
+    "fast": "copilot/gpt-4o-mini"
+  }
+}
+```
+
+Aliases are resolved in one hop (no chaining). Built-in aliases in
+`src/provider.rs` (e.g. `claude-sonnet-4.6`) take precedence on name conflict.
+
+## Detached runs (`ask --detach`)
+
+```bash
+amaebi ask "run the full test suite and summarise failures" --detach
+# → [queued: a1b2c3d4]   exits in < 100 ms
+```
+
+The daemon continues the task autonomously. When it finishes, the result lands
+in `amaebi inbox`. `--detach` and `--resume` are mutually exclusive.
+
+## Session resume
+
+Resume a prior session for this directory with full chronological history
+(bypasses the normal sliding-window cap):
+
+```bash
+amaebi ask --resume "continue the migration from yesterday"
+amaebi chat -r
+```
+
+Bare `-r` / `--resume` with no value opens an interactive picker listing this
+directory's recent sessions, newest first. Pick a number or press Enter to
+cancel.
+
+Pass a specific UUID (or a prefix ≥ 4 chars) with `=` syntax so it is not
+confused with the prompt positional:
+
+```bash
+amaebi ask -r=abc123de "what was the conclusion on that auth bug?"
+amaebi chat --resume=abc123de
+```
+
+The TTY check in `src/session.rs:414` rejects bare `--resume` when stdin/stdout
+is not a terminal (no picker possible).
+
+## Mid-response steering
+
+Both `ask` and `chat` read stdin while the model streams. Type a line + Enter
+and the correction is injected before the model's next turn:
+
+```
+$ amaebi ask "refactor the auth module and add tests"
+[tool] read_file src/auth.rs
+[tool] shell_command cargo test
+> wait, keep the old function signature      ← you type this mid-stream
+[steer] correction injected
+[tool] edit_file src/auth.rs
+Done.
+```
+
+In `chat`, Ctrl-C during a response does the same thing: it interrupts
+generation and drops you back at the `>` prompt where you can type a
+correction.
+
+## Exit
+
+- `ask`: Ctrl-D detaches the stream (task continues in the background, result
+  goes to inbox). Ctrl-C twice exits immediately.
+- `chat`: empty line or Ctrl-D exits. First Ctrl-C interrupts the current
+  response; second Ctrl-C exits.
+
+## History editor
+
+The prompt input uses `rustyline` for line editing — arrow keys, Emacs
+bindings, CJK-aware cursor movement, and persistent history across
+sessions. This replaced a hand-rolled editor; see commit `0bb236a` and the
+memory note at
+`~/.claude/projects/-home-yuankuns-amaebi/memory/feedback_prefer_libraries.md`.
+
+## Session identity
+
+Every working directory gets a stable UUID stored in `~/.amaebi/sessions.json`
+(JSON, 0600). The daemon keys `memory.db` by that UUID so per-project history
+never leaks across projects.
+
+```bash
+amaebi session show         # UUID for cwd
+amaebi session new          # forget the current context; start fresh
+amaebi session status       # list every dir → UUID mapping
+amaebi session set-tier persistent  # 24h TTL for this directory
+```
+
+Sessions expire after 30 minutes of inactivity by default. Override per tier
+or per directory in `~/.amaebi/config.json` (see the `ttl_minutes` field at
+`src/config.rs:45`).

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -1,0 +1,198 @@
+# /claude — supervised Claude Code subprocesses
+
+`/claude` is a slash command (not a subcommand: you type it inside `amaebi
+chat` or pass it as the prompt to `amaebi ask`). It does four things:
+
+1. Creates a git worktree under `~/.amaebi/worktrees/<repo>/<tag>-<uuid8>/`.
+2. Allocates a tmux pane and starts `claude` (the Claude Code TUI) inside it.
+3. Injects the task description into the pane as the opening prompt.
+4. Runs a supervision loop (see [supervision.md](supervision.md)) that polls
+   the pane, calls the LLM for a WAIT / STEER / DONE verdict, and acts on it.
+
+Parsing lives in `src/client.rs:280` (`parse_claude`); launch handling is in
+`src/daemon.rs` (`handle_claude_launch`).
+
+## Quick examples
+
+```text
+/claude "fix the flaky test in tests/auth_test.rs"
+/claude "investigate the memory leak" "add a regression test"     # two parallel tasks
+/claude --tag kernel-opt "optimise the attention kernel"
+/claude --resume-pane %41                                          # reuse existing pane
+/claude --resource sim-9902 "run the new testbench"
+```
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--worktree <path>` | Use an existing worktree instead of auto-creating one |
+| `--cwd <path>` | Client working directory (used to locate the git repo for auto-worktree) |
+| `--no-enter` | Inject the task description but do not press Enter |
+| `--tag <name>` | Persistent task notebook identifier |
+| `--resume-pane <pane_id>` | Reuse an existing pane (e.g. `%41`) via `/compact + inject` |
+| `--resource <spec>` | Acquire a resource lease and inject its env vars |
+| `--resource-timeout <secs>` | How long to wait for a busy resource before failing |
+
+Flags may appear in any order. Everything after `--` is treated as a task
+description.
+
+### `--worktree <path>`
+
+Explicit worktree path. Skips the auto-create step. The path is canonicalised
+at parse time (`src/client.rs:340`) so relative and symlinked paths work.
+
+Mutually exclusive with `--resume-pane`: reusing a pane inherits its existing
+worktree, so an explicit `--worktree` would conflict.
+
+### `--cwd <path>`
+
+The client's working directory, used by the daemon to locate the enclosing git
+repo when auto-creating a worktree. Defaults to wherever you ran `amaebi`.
+
+### `--no-enter`
+
+Inject the task description into the pane but don't press Enter. Useful when
+you want to edit the prompt interactively before Claude starts.
+
+### `--tag <name>` (PR #128)
+
+Opt the pane into the **task notebook**, a persistent `(repo_dir, tag)` keyed
+record in `~/.amaebi/tasks.db`. Every supervision verdict (`WAIT`, `STEER`,
+`DONE`, summary text) is appended; the task description (`<desc>`) is
+persisted on first launch.
+
+Later runs with the same tag recover the description and recent verdicts:
+
+```text
+# First launch: record the desc, start fresh
+/claude --tag refactor-auth "refactor the auth module, keep signatures stable"
+
+# Days later, from a crashed pane or new terminal:
+/claude --tag refactor-auth
+# Daemon re-injects the stored desc and prior verdicts into the supervision
+# prompt, so the new Claude pane knows what was already tried.
+```
+
+Exactly one live session per `(repo_dir, tag)` at a time — the notebook holds
+a 24 h lease. Inspect or force-release via:
+
+```bash
+amaebi tag list
+amaebi tag release <tag>
+```
+
+### `--resume-pane <pane_id>` (PR #124)
+
+Reuse the `claude` already running in a tmux pane instead of launching a new
+one. The daemon sends `/compact` to clear Claude's context, then injects the
+new task description. This is the tier-1 reuse path: no new worktree, no
+30-second `claude` startup.
+
+```text
+/claude --resume-pane %41 "now run the benchmarks on the optimised kernel"
+```
+
+Pane ids come from `amaebi dashboard` (Panes panel) or `tmux list-panes -F
+'#{pane_id}'`.
+
+Mutually exclusive at parse time with both `--worktree` and `--resource` (see
+`src/client.rs:433` and `src/client.rs:446`):
+
+- `--worktree` would conflict with the pane's existing worktree.
+- `--resource` cannot inject env vars into a running shell (the Claude TUI
+  intercepts every keystroke as chat input). Until PR α lands, the combination
+  returns a parse error.
+
+Task description is optional with `--resume-pane`: if omitted, the daemon
+re-uses the description from the pane's previous lease.
+
+Only one task per `--resume-pane` invocation — one pane, one task.
+
+### `--resource <spec>` (PR #126)
+
+Acquire a lease from the resource pool (see
+[resource-pool.md](resource-pool.md)). Three spec forms:
+
+| Spec | Meaning |
+|------|---------|
+| `sim-9902` | Named — acquire this specific resource |
+| `class:simulator` | Class — any idle resource of class `simulator` |
+| `any:simulator` | Class alias (`any:` and `class:` are equivalent) |
+
+Parsing lives in `src/resource_lease.rs:196` (`ResourceRequest::parse`). Repeat
+`--resource` for multiple resources; acquisition is **all-or-nothing** with
+canonical ordering (see `src/resource_lease.rs:27`) so concurrent callers
+cannot deadlock on partial holds.
+
+On success the daemon:
+
+1. Marks each lease `Busy` in `~/.amaebi/resource-state.json`.
+2. Renders `env` entries from `resources.toml` (with `{name}` and
+   `{metadata_key}` placeholders) and exports them into the pane shell
+   before `claude` launches.
+3. Prepends the resource's `prompt_hint` to the task description.
+
+```text
+/claude --resource sim-9902 --resource class:gpu "run the full benchmark"
+```
+
+### `--resource-timeout <secs>`
+
+Wait up to N seconds for a busy resource to free up, then fail. Default (no
+flag / 0) is fail-fast. The daemon uses `tokio::sync::Notify` to wake waiters
+when leases are released.
+
+## The tier-1 reuse path
+
+When `--resume-pane` is given, the daemon takes a fast path:
+
+1. Look up the pane in `~/.amaebi/tmux-state.json` — must exist and be live.
+2. Send `/compact` to the pane. Claude Code compresses its context and
+   returns to a prompt.
+3. Inject the new task description.
+4. Resume supervision under the same pane lease.
+
+No worktree creation, no new `claude` process spawn, no API key dance. Use
+this for iterative refinement: "run the benchmarks now", "try the other
+branch".
+
+## Where worktrees live
+
+```
+~/.amaebi/worktrees/<repo>/<tag>-<uuid8>/
+```
+
+- `<repo>` is derived from the repo root basename.
+- `<tag>` is the `--tag` value (or a short label auto-generated by the
+  `GenerateTag` daemon round-trip, which asks a small model to distil a tag
+  from the description).
+- `<uuid8>` is a random 8-char suffix so repeated tasks with the same tag do
+  not collide (`src/daemon.rs:2919`).
+
+The worktree is created on a new branch named `<tag>-<uuid8>`. If you pass
+`--worktree <existing-path>` the daemon skips the create step.
+
+## Combining flags
+
+```text
+# Named resource + tag, two independent tasks
+/claude --tag perf --resource sim-9902 "profile the hot path" "write the report"
+
+# Class-based acquisition with a wait
+/claude --resource class:gpu --resource-timeout 600 "train the small model"
+
+# Resume a pane, no new task desc (reuses the one from the prior launch)
+/claude --resume-pane %41
+```
+
+The usage string printed on a parse error lives at `src/client.rs:290` — read
+it for the current canonical grammar.
+
+## Exit and cleanup
+
+When supervision exits (DONE, timeout, interrupt, model error, client
+disconnect), the daemon runs `release_supervised_panes` and
+`release_task_leases_for_holder` (see `src/daemon.rs:2250`). This is
+unconditional: panes never stay stuck `Busy` past the supervision lifetime,
+and tag leases are freed so the next run with the same tag is not blocked.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,68 @@
+# amaebi dashboard
+
+Live TUI aggregating pane, session, inbox, cron, and resource state. Read-only
+— does not touch the daemon via IPC, does not modify any on-disk file.
+
+```bash
+amaebi dashboard
+```
+
+Implementation: `src/dashboard.rs`, entry point at `src/dashboard.rs:511`.
+
+## Refresh
+
+- Auto-refresh every 2 seconds (`REFRESH` constant at `src/dashboard.rs:39`).
+- Press `r` to force an immediate re-read.
+
+Every tick re-reads the underlying files from scratch: `sessions.json`,
+`tmux-state.json`, `resource-state.json`, `inbox.db`, `cron.db`,
+`memory.db`. Sources that are missing or fail to open render as empty — the
+dashboard works on a fresh install.
+
+## Keys
+
+| Key | Action |
+|-----|--------|
+| `q` / `Q` | Exit |
+| `Esc` | Exit |
+| `Ctrl-C` | Exit |
+| `r` / `R` | Force re-read |
+
+No mouse interaction. No navigation between panels — it is strictly a
+read-only monitor.
+
+## Panels
+
+| Panel | Source | Shows |
+|-------|--------|-------|
+| Environment | runtime | cwd, git branch, sandbox mode |
+| Task summary | aggregated | Pane counts (busy / idle / starting), cron counts, unread inbox |
+| Panes | `~/.amaebi/tmux-state.json` | Every known pane with status, tag, and age |
+| Sessions | `memory.db` | Newest turn per session UUID (prompt snippet, cap 80 chars) |
+| Resources | `~/.amaebi/resource-state.json` + `resources.toml` | Every resource with class, status, holder *(requires PR β merged for the dedicated resource panel; currently resources appear in the Activity stream)* |
+| Inbox | `inbox.db` | Recent arrivals (unread first) |
+| Cron | `cron.db` | `last_run` events and schedules |
+| Activity | unified | Merged event stream, newest first, capped at 20 entries (`ACTIVITY_CAP` at `src/dashboard.rs:40`) |
+
+The activity stream is the most useful panel day-to-day: it merges pane
+state changes, session updates, inbox arrivals, and cron `last_run` events
+into one time-ordered tail.
+
+## Typical use
+
+- During a long `/claude --tag kernel-opt "…"` run, keep the dashboard open in
+  a second pane to watch the supervision verdicts accumulate and see when the
+  Activity stream marks the task DONE.
+- After a cron tick, check the Inbox counter for new reports.
+- While debugging the resource pool, watch the Panes panel to see which pane
+  is holding which resource.
+
+## Limitations
+
+- Read-only. You cannot kill panes, release leases, or mark inbox items read
+  from the dashboard. Use the corresponding subcommands (`amaebi tag
+  release`, `amaebi inbox read`, etc.).
+- Best on an 80×24 or larger terminal. The three vertical sections
+  (environment, task summary, activity) will clip on very small windows.
+- Does not show the daemon's live LLM token stream — supervision output only
+  appears in the client that initiated `/claude`.

--- a/docs/resource-pool.md
+++ b/docs/resource-pool.md
@@ -1,0 +1,156 @@
+# Resource pool
+
+> **Note:** Sections marked *(requires PR α merged)* describe behaviour from
+> the in-flight PR α. Until α lands, `--resume-pane` combined with
+> `--resource` returns a parse error at `src/client.rs:446`, and there is no
+> AGENTS.md injection from `resources.toml`.
+
+Parallel `/claude` sessions often need to share externally-arbitrated
+resources — GPU slots, simulator ports, serial devices — where naive
+concurrency would break things. The resource pool provides leased, all-or-
+nothing acquisition with env-var injection.
+
+## Two files
+
+| File | Role | Format |
+|------|------|--------|
+| `~/.amaebi/resources.toml` | Pool definition (static) | TOML, hand-edited |
+| `~/.amaebi/resource-state.json` | Lease table (runtime) | JSON, flocked |
+
+Lock file: `~/.amaebi/resource-state.lock` (exclusive `flock` via `fs2`).
+
+## `resources.toml` format
+
+One entry per resource:
+
+```toml
+[[resource]]
+name = "sim-9902"
+class = "simulator"
+
+[resource.metadata]
+host = "sim-host-02"
+port = "9902"
+
+[resource.env]
+SIM_HOST = "{host}"
+SIM_PORT = "{port}"
+SIM_NAME = "{name}"
+
+prompt_hint = """
+You have been assigned simulator {name} at {host}:{port}.
+Export SIM_HOST and SIM_PORT before running the testbench, and release the
+port when you finish.
+"""
+
+[[resource]]
+name = "sim-9903"
+class = "simulator"
+
+[resource.metadata]
+host = "sim-host-02"
+port = "9903"
+
+[resource.env]
+SIM_HOST = "{host}"
+SIM_PORT = "{port}"
+```
+
+Fields (`src/resource_lease.rs:66`):
+
+- `name` — unique identifier. Duplicates fail validation at load time.
+- `class` — grouping key for class-based acquisition.
+- `metadata` — machine-readable key/value; feeds placeholder substitution in
+  `env` and `prompt_hint`.
+- `env` — environment variables to export into the pane shell. Values may
+  reference `{metadata_key}` and `{name}`.
+- `prompt_hint` — text prepended to the task description. *(requires PR α
+  merged)* The same text is also written to `<worktree>/AGENTS.md` on first
+  launch, in a marker-bracketed block so user content is preserved.
+
+Missing file is equivalent to an empty pool (no error; see
+`src/resource_lease.rs:94`).
+
+## `--resource` spec forms
+
+Three forms, parsed by `ResourceRequest::parse` (`src/resource_lease.rs:196`):
+
+| Spec | Request kind | Behaviour |
+|------|--------------|-----------|
+| `sim-9902` | `Named` | Acquire this specific resource; fail/wait if busy |
+| `class:simulator` | `Class` | Acquire any idle resource of class `simulator` |
+| `any:simulator` | `Class` (alias) | Same as `class:` |
+
+The explicit `class:` / `any:` prefix is required: a pool can legitimately
+contain both a resource named `gpu` and a class named `gpu`, and the parser
+refuses to guess.
+
+## All-or-nothing acquisition
+
+`acquire_all` (`src/resource_lease.rs`) either returns every requested lease
+or rolls back partial holds. Requests are processed in canonical `(class,
+name)` order so two concurrent callers cannot interleave into a cycle.
+
+```text
+/claude --resource sim-9902 --resource class:gpu "run the benchmark"
+```
+
+If `sim-9902` is free but every GPU is busy, neither is acquired and the
+caller either fails (no timeout) or waits (`--resource-timeout`). Waiters are
+woken via `tokio::sync::Notify` when leases are released.
+
+## Env var injection
+
+On successful acquisition the daemon:
+
+1. Renders the `env` map for each lease, substituting `{name}` and
+   `{metadata_key}` placeholders.
+2. Exports the resulting variables into the pane shell **before** `claude`
+   launches. (`src/daemon.rs:1658` renders the prompt hint; the env pass
+   happens just upstream.)
+
+Example: with the TOML above, `/claude --resource sim-9902` gives the pane
+shell:
+
+```bash
+export SIM_HOST=sim-host-02
+export SIM_PORT=9902
+export SIM_NAME=sim-9902
+```
+
+These persist for the pane's lifetime. They cannot be applied to an
+already-running `claude` — which is why `--resume-pane` is rejected in
+combination with `--resource` (see `src/client.rs:446`).
+
+## 24-hour TTL and orphan detection
+
+Every `Busy` lease carries a `heartbeat_at` timestamp. If it is not refreshed
+within `LEASE_TTL_SECS` (86,400 s = 24 h, `src/resource_lease.rs:59`) the
+lease is treated as effective-`Idle` by the next acquirer — `effective_status`
+at `src/resource_lease.rs:159` does the check. This is how a crashed daemon's
+leases are eventually reclaimed.
+
+`amaebi resource list` shows every resource with its class, effective status,
+and current holder (pane id + tag + session). Entries present in
+`resource-state.json` but missing from `resources.toml` are printed as
+`orphaned: not in resources.toml`.
+
+## AGENTS.md injection *(requires PR α merged)*
+
+When PR α lands, the first `/claude --resource <spec>` in a worktree will
+write the resource's `prompt_hint` into `<worktree>/AGENTS.md` inside a
+marker-bracketed block. Subsequent `/compact` cycles inside Claude Code
+preserve `AGENTS.md` verbatim, so the assigned resource information survives
+context compression — something the prompt-hint prepend alone does not
+guarantee.
+
+The marker block is delimited so that user content in `AGENTS.md` above or
+below the block is left untouched. Re-launching in the same worktree with a
+different resource rewrites only the marked section.
+
+## `--resume-pane` + `--resource` *(requires PR α merged)*
+
+Currently a parse error (see `src/client.rs:446`). PR α introduces a
+re-acquire-on-resume path that re-claims the pane's prior resource set
+without attempting env-var injection (the prior `export`s are still in the
+shell).

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -1,0 +1,108 @@
+# Supervision loop
+
+Every `/claude` launch (see [claude.md](claude.md)) is followed by a
+supervision loop in the daemon. The loop runs until the task is done, times
+out, or is interrupted. Its job is to read the pane, decide whether the
+Claude subprocess is making progress, and nudge it when it isn't.
+
+Implementation: `handle_supervision` / `handle_supervision_inner` in
+`src/daemon.rs:2207`.
+
+## WAIT / STEER / DONE
+
+Each iteration the supervision LLM sees the pane contents plus the task
+notebook preamble (for `--tag` runs) and must return exactly one of:
+
+| Verdict | Meaning | Effect |
+|---------|---------|--------|
+| `WAIT` | Still working, check again later | Sleep, re-snapshot on next tick |
+| `STEER: <pane_id>: <message>` | Pane is stuck or off-track | `tmux_send_keys` the message into the pane |
+| `DONE: <summary>` | Task is complete | Stream the summary to the client, exit |
+
+The prompt that asks for this verdict is built from the pane capture plus the
+notebook preamble (`build_notebook_context`, `src/daemon.rs:2305`). The
+completion is capped at `MAX_SUPERVISION_TOKENS` — enough for a short verdict,
+not enough for a long narrative.
+
+## Timing
+
+All durations are in `handle_supervision_inner`:
+
+| Knob | Default | Env override | Purpose |
+|------|---------|--------------|---------|
+| Poll-interval ceiling | 5 min | `AMAEBI_SUPERVISION_INTERVAL_SECS` | Maximum wait between LLM calls |
+| Idle threshold | 10 s | (compile-time constant `IDLE_SECS`) | Pane must be unchanged this long before the LLM is called |
+| Idle poll period | 2 s | (compile-time constant `IDLE_POLL_SECS`) | How often to snapshot the pane while waiting for idle |
+| Hard timeout | 10 h | `AMAEBI_SUPERVISION_TIMEOUT_SECS` | Wall-clock ceiling; after this, supervision exits regardless |
+
+The 5-minute ceiling (`src/daemon.rs:2418`) is the *maximum* gap between LLM
+calls. Each iteration also waits for 10 seconds of pane stability
+(`src/daemon.rs:2431`) before taking a snapshot — this avoids calling the LLM
+every 2-5 seconds during active tool output. Net effect: supervision LLM cost
+drops ~70-80 % in typical sessions.
+
+The hard timeout (`src/daemon.rs:2437`) protects against runaway tasks. If
+supervision is still polling after 10 hours, it gives up, writes a summary,
+and releases the pane.
+
+## What STEER does
+
+STEER verdicts are formatted as `STEER: <pane_id>: <message>`. The daemon
+parses the pane id, resolves it to a live tmux target, and sends the message
+via `tmux send-keys`, including Enter so Claude processes it. The pane sees
+the message as if you typed it.
+
+Steering is used when the LLM determines Claude is stuck (waiting at a
+confirmation prompt, looping on the same failing command, or chasing a wrong
+hypothesis). The supervision prompt is explicitly instructed to prefer WAIT
+over STEER when in doubt, to avoid thrashing.
+
+## What DONE does
+
+On DONE, the daemon:
+
+1. Streams the `<summary>` text to the client as `Response::Text` frames.
+2. For `--tag` runs, writes a resume hint (`src/daemon.rs:2230`):
+   ```
+   [supervision] to resume any of these panes:
+     pane %41 (tag=kernel-opt)
+       continue task:  /claude --tag kernel-opt
+       reuse pane:     /claude --resume-pane %41
+   ```
+3. Writes `Response::Done` and closes the frame stream.
+4. Runs the cleanup block (release panes + task leases).
+
+## How to interrupt
+
+- **Ctrl-C twice in `chat`**: the first Ctrl-C interrupts the current response
+  (including supervision). The second Ctrl-C exits the `chat` process.
+- **Client disconnect**: closing the client socket is treated as an interrupt.
+  The daemon drains the current iteration, exits supervision, and runs
+  cleanup.
+- **`AMAEBI_SUPERVISION_TIMEOUT_SECS`**: hard wall-clock ceiling.
+
+## Release guarantees
+
+Cleanup is **unconditional**. Every exit path — DONE, STEER-failure, timeout,
+Ctrl-C interrupt, model error, client disconnect, or an unhandled inner `Err`
+— runs the wrapper at `src/daemon.rs:2250`:
+
+```rust
+release_supervised_panes(&panes).await;
+release_task_leases_for_holder(state, &holder).await;
+```
+
+This means:
+
+- tmux pane leases never stay `Busy` past the supervision lifetime. The 24 h
+  lease TTL (`src/pane_lease.rs`) is only a safety net for daemon crashes.
+- Task notebook leases (`~/.amaebi/tasks.db`) are freed so the next
+  `/claude --tag <same-tag>` is not rejected as a duplicate holder.
+- Resource leases (`src/resource_lease.rs:59`, `LEASE_TTL_SECS`) are released
+  via the pane cleanup — the resource lifetime is tied to the pane that holds
+  it.
+
+If the daemon itself crashes mid-supervision, the TTL-based reclaim path takes
+over: heartbeats are stale, the lease is marked effective-Idle, and the next
+acquirer can take over (see `effective_status` at
+`src/resource_lease.rs:159`).


### PR DESCRIPTION
## Motivation

`README.md` at 384 lines is already long and several features
from the 2026-01 onwards feature wave — `--tag`, `--resume-pane`,
`--resource`, `amaebi dashboard`, `amaebi tag`, `amaebi resource`,
model aliases, 1M context, ACP mode — have no documentation.
Rather than make README 800+ lines, split into a slim landing
README plus a `docs/` directory of per-feature deep dives.

## Scope

- **README.md** shrunk to ~100 lines: what, install, quick start,
  how it works, common commands, full feature index with links
  to `docs/*.md`.
- **`docs/` directory** with 6 files covering the top features:
  `chat.md`, `claude.md` (biggest — all flags incl. new ones),
  `supervision.md`, `resource-pool.md`, `dashboard.md`,
  `architecture.md`.
- Forward references to **PR α** (AGENTS.md injection,
  `--resume-pane + --resource`) and **PR β** (dashboard
  Resources panel) are marked "requires PR α/β merged".
  After those PRs land this PR's docs describe current behavior
  accurately; until then, they're a snapshot of the near-term
  intent.
- Every `src/foo.rs:N` reference verified via the citation-check
  loop documented in the PR's `Manual e2e` section.

## Manual e2e

Docs-only; no runtime behavior changed.

1. Review the new `README.md` for a coherent quick start.
2. Open each `docs/*.md`; confirm no broken cross-links.
3. Run the citation-check and confirm zero stale line references:

   ```bash
   for f in docs/*.md; do
     grep -oE 'src/[a-zA-Z_]+\.rs:[0-9]+' "$f" | while read ref; do
       file="\${ref%:*}"
       line="\${ref#*:}"
       if ! sed -n "\${line}p" "\$file" >/dev/null 2>&1 || [ -z "\$(sed -n "\${line}p" "\$file")" ]; then
         echo "STALE CITATION: \$f references \$ref"
       fi
     done
   done
   ```

## Rollback

Docs-only PR. `git revert` restores the old README; no data or
user config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)