### PR TITLE
fix(supervision): lazy-init tasks_db before verdict persist/read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "0.50.2"
+version = "0.50.3"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "0.50.2"
+version = "0.50.3"
 edition = "2021"
 
 [[bin]]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2325,6 +2325,13 @@ async fn build_notebook_context(
     let state_cl = Arc::clone(state);
     let panes_cl: Vec<crate::ipc::SupervisionTarget> = panes.to_vec();
     let rendered = tokio::task::spawn_blocking(move || -> Result<String> {
+        // Lazy-open the DB if no prior code path did.  Resume-pane launches
+        // skip the tag-acquisition block in `handle_claude_launch`, so on
+        // the first supervision turn for a resumed tagged pane the handle
+        // may still be `None` — which would silently drop this pane's own
+        // prior verdict/desc history from the notebook preamble.
+        // `ensure_tasks_db` is idempotent.
+        ensure_tasks_db(&state_cl)?;
         let guard = state_cl
             .tasks_db
             .lock()
@@ -3045,6 +3052,12 @@ async fn handle_supervision_inner(
             let repo_dir_log = repo_dir.clone();
             let tag_log = tag.clone();
             match tokio::task::spawn_blocking(move || -> Result<()> {
+                // Lazy-open the DB if no prior code path did.  Resume-pane
+                // launches skip the tag-acquisition block in
+                // `handle_claude_launch` that normally opens it, so when a
+                // resumed pane produces the first verdict the handle may
+                // still be `None`.  `ensure_tasks_db` is idempotent.
+                ensure_tasks_db(&state_cl)?;
                 let guard = state_cl
                     .tasks_db
                     .lock()
@@ -8584,5 +8597,30 @@ prompt_hint = "use sim-9900 (port {port}) only"
         assert_eq!(default_secs, lease_ttl_secs);
         assert_eq!(crate::resource_lease::LEASE_TTL_SECS, lease_ttl_secs);
         assert_eq!(crate::tasks::LEASE_TTL_SECS as u64, lease_ttl_secs);
+    }
+
+    /// Regression: the supervision verdict-persist path must lazy-open
+    /// `tasks.db` when the daemon only ever served resume-pane launches
+    /// (which skip the tag-acquisition block that normally opens it).
+    /// Verifies `ensure_tasks_db` opens the handle on first call, then
+    /// is a cheap no-op on every subsequent call — so sprinkling it at
+    /// the top of every tasks_db consumer is safe.
+    #[test]
+    fn ensure_tasks_db_is_idempotent_and_lazy() {
+        // A daemon that has only served resume-pane launches reaches the
+        // verdict-persist / notebook-context sites with `tasks_db == None`,
+        // because the tag-acquisition block in `handle_claude_launch`
+        // (the sole prior opener) is gated on `resume_pane.is_none()`.
+        // Both sites must therefore call `ensure_tasks_db` unconditionally,
+        // which only works if the second call is a safe no-op.
+        let _guard = crate::test_utils::with_temp_home();
+        let state = test_minimal_daemon_state();
+        assert!(state.tasks_db.lock().unwrap().is_none());
+
+        ensure_tasks_db(&state).expect("first ensure_tasks_db opens DB");
+        assert!(state.tasks_db.lock().unwrap().is_some());
+
+        ensure_tasks_db(&state).expect("second ensure_tasks_db is a no-op");
+        assert!(state.tasks_db.lock().unwrap().is_some());
     }
 }


### PR DESCRIPTION
## Motivation

Daemon log has been spamming every 5 minutes for hours:

```
WARN failed to persist verdict error=tasks_db not initialised
     repo_dir=/home/yuankuns/libraries.ai.cutlass.internal
     tag=fmha4-varlen-pages
```

Root cause: `ensure_tasks_db` was only called from the
tag-acquisition block inside `handle_claude_launch`, and that
block is gated by `.filter(|t| t.resume_pane.is_none())`.  Any
daemon whose lifetime only ever served `--resume-pane` launches
therefore kept `state.tasks_db == None` forever.  Supervision
later tried to persist a verdict row, hit `None`, logged the
warn, and silently dropped the row.

The notebook-context read path (`build_notebook_context`) has
the same bug — it degraded gracefully to an empty preamble,
hiding the resumed pane's own prior verdict/desc history from
the supervision LLM.

## Scope

- `handle_supervision_inner`'s verdict-persist `spawn_blocking`
  now calls `ensure_tasks_db(&state_cl)?` at the top.
- `build_notebook_context`'s `spawn_blocking` does the same, so
  resumed tagged panes see their own history on the first turn.
- `ensure_tasks_db` is already idempotent (early-return when the
  handle is `Some`), so adding it at these sites is safe
  regardless of which path opens the DB first.
- Out of scope: `release_task_leases_for_holder` checks for
  `None` and returns early, which is the correct behavior there
  (nothing to release if never opened).
- Regression test proving `ensure_tasks_db` is lazy on the first
  call and a no-op on the second.

## Manual e2e

1. `pkill -f 'amaebi.*daemon'` to kill any running daemon.
2. Start a fresh daemon and run
   `/claude --tag fmha4-varlen-pages --resume-pane %54 "continue"`.
3. Wait for one supervision turn (~5 min or force idle).
4. Tail daemon log: the verdict now writes into `tasks.db`, no
   more `failed to persist verdict` warn.
5. `amaebi tag list` shows a new verdict row for
   `fmha4-varlen-pages`.

## Rollback

Revert is trivial.  The old behavior silently drops verdict rows
for resumed tagged panes rather than crashing, so rollback is
data-lossy but not destructive.

Generated with [Claude Code](https://claude.com/claude-code)