### PR TITLE
feat(supervision): 10-min heartbeat + 30-min client watchdog; remove 12h deadline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.4.59"
+version = "2026.4.60"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.4.59"
+version = "2026.4.60"
 edition = "2021"
 
 [[bin]]

--- a/src/agent_server.rs
+++ b/src/agent_server.rs
@@ -341,6 +341,11 @@ impl acp::Agent for AmaebiAgent {
                     // ACP mode never sends ClaudeLaunch/GenerateTag.
                     tracing::debug!("unexpected pane/tag scheduler response in ACP mode");
                 }
+                Response::Heartbeat { .. } => {
+                    // ACP mode never runs supervision; explicit arm keeps
+                    // future enum additions a compile error.
+                    tracing::debug!("unexpected Heartbeat in ACP mode");
+                }
             }
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -889,6 +889,12 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                     Response::ModelSwitched { .. } => {
                         // ask mode has no persistent model variable to update.
                     }
+                    Response::Heartbeat { .. } => {
+                        // Supervision-only frame; never emitted on the Chat
+                        // path but keep an explicit arm so future enum
+                        // additions still force a compile error here.
+                        tracing::debug!("ignoring Heartbeat outside supervision loop");
+                    }
                 }
             }
 
@@ -1167,20 +1173,31 @@ pub async fn run_chat_loop(
                     write_half.write_all(req_line.as_bytes()).await?;
 
                     // Stream supervision output exactly like a Chat response.
-                    // We always arm a timeout so the client never hangs if the
-                    // daemon silently drops. Default: 12 h (slightly above the
-                    // daemon's 10 h default; both are configurable via env vars);
-                    // shortened to 5 s once an interrupt has been sent.
-                    let mut interrupt_sent = false;
-                    let supervision_deadline =
-                        tokio::time::Instant::now() + Duration::from_secs(12 * 60 * 60);
+                    // There is no client-side business timeout — supervision
+                    // length is a daemon concept (`AMAEBI_SUPERVISION_TIMEOUT_SECS`,
+                    // default 24 h) and mirroring it here via an env var would
+                    // silently desync whenever client + daemon run in different
+                    // shells.  Instead the client runs a 30-min watchdog: if
+                    // the daemon stops sending ANY frame (text, heartbeat,
+                    // done), assume it's stuck and end the session so the TUI
+                    // does not hang forever.  The daemon emits `Heartbeat`
+                    // every 10 min (see `HEARTBEAT_INTERVAL_SECS` in daemon.rs)
+                    // so a normal supervision — which sleeps ~5 min between
+                    // LLM calls — always has at most a 10-min frame gap.
+                    const WATCHDOG_INTERVAL_SECS: u64 = 30 * 60;
+                    // Pinned (not per-iteration) so a heartbeat arriving
+                    // during the 5 s drain does not push the deadline back —
+                    // we promise the user a bounded wait after Ctrl-C.
+                    let mut interrupt_drain_deadline: Option<tokio::time::Instant> = None;
                     'supervision: loop {
-                        let timeout_at = if interrupt_sent {
-                            // After interrupt, give daemon 5 s to respond with Done.
-                            tokio::time::Instant::now() + Duration::from_secs(5)
-                        } else {
-                            supervision_deadline
-                        };
+                        // Recomputed every iteration: any arriving frame (or
+                        // sigint) re-enters the loop and resets the watchdog.
+                        let watchdog_at = tokio::time::Instant::now()
+                            + Duration::from_secs(WATCHDOG_INTERVAL_SECS);
+                        let interrupt_sent = interrupt_drain_deadline.is_some();
+                        // Fallback to `watchdog_at` when the arm is disabled so
+                        // `sleep_until` still receives a valid Instant.
+                        let interrupt_drain_at = interrupt_drain_deadline.unwrap_or(watchdog_at);
                         tokio::select! {
                             biased;
 
@@ -1190,32 +1207,40 @@ pub async fn run_chat_loop(
                                     frame.push('\n');
                                     let _ = write_half.write_all(frame.as_bytes()).await;
                                 }
-                                interrupt_sent = true;
+                                interrupt_drain_deadline = Some(
+                                    tokio::time::Instant::now() + Duration::from_secs(5),
+                                );
                                 // Continue looping to drain remaining frames.
                             }
 
-                            _ = tokio::time::sleep_until(timeout_at) => {
-                                // Timed out: either post-interrupt 5 s drain or the
-                                // supervision hard ceiling.  The daemon may still be
-                                // running its supervision loop, so reusing this socket
-                                // for further Chat requests would desync the protocol.
-                                // Terminate the session cleanly instead.
-                                //
-                                // Flush any partially buffered markdown first so we
-                                // do not lose the last chunk the daemon had streamed
-                                // before we gave up waiting.  `break 'session`
-                                // bypasses the post-supervision-loop flush, so it
-                                // has to happen here.
+                            _ = tokio::time::sleep_until(interrupt_drain_at), if interrupt_sent => {
+                                // Post-interrupt 5 s drain: daemon should have
+                                // responded with Done by now; if not, give up
+                                // cleanly so the socket does not stay half-
+                                // alive for another Chat request (which would
+                                // desync the frame protocol).
                                 if let Some(remaining) = md_buf.flush_all() {
                                     let out = render_markdown(&remaining);
                                     stdout.write_all(out.as_bytes()).await?;
                                 }
-                                let reason = if interrupt_sent {
-                                    "[supervision] daemon did not stop within 5 s after interrupt; ending session.\n"
-                                } else {
-                                    "[supervision] hard timeout reached; ending session.\n"
-                                };
-                                stdout.write_all(reason.as_bytes()).await?;
+                                stdout
+                                    .write_all(b"[supervision] daemon did not stop within 5 s after interrupt; ending session.\n")
+                                    .await?;
+                                stdout.flush().await?;
+                                break 'session;
+                            }
+
+                            _ = tokio::time::sleep_until(watchdog_at), if !interrupt_sent => {
+                                // 30 min without any frame — treat daemon as
+                                // stuck (process alive but supervision task
+                                // deadlocked, etc.) and end the session.
+                                if let Some(remaining) = md_buf.flush_all() {
+                                    let out = render_markdown(&remaining);
+                                    stdout.write_all(out.as_bytes()).await?;
+                                }
+                                stdout
+                                    .write_all(b"[supervision] no frames from daemon for 30 min; assuming stuck daemon and ending session.\n")
+                                    .await?;
                                 stdout.flush().await?;
                                 break 'session;
                             }
@@ -1232,6 +1257,31 @@ pub async fn run_chat_loop(
                                             stdout.write_all(out.as_bytes()).await?;
                                             stdout.flush().await?;
                                         }
+                                    }
+                                    Response::Heartbeat { elapsed_secs, turn } => {
+                                        // Status line on stderr so it never
+                                        // interleaves with streamed stdout
+                                        // markdown.  Overwrites itself with `\r`
+                                        // so scrollback stays clean — the
+                                        // 5-min WAIT/STEER/DONE headers are
+                                        // already there for history.
+                                        let mins = elapsed_secs / 60;
+                                        let hours = mins / 60;
+                                        let rem_mins = mins % 60;
+                                        let msg = if hours > 0 {
+                                            format!(
+                                                "\r[supervision alive — turn #{turn}, {hours}h{rem_mins}m elapsed]"
+                                            )
+                                        } else {
+                                            format!(
+                                                "\r[supervision alive — turn #{turn}, {mins}m elapsed]"
+                                            )
+                                        };
+                                        let _ = tokio::io::stderr().write_all(msg.as_bytes()).await;
+                                        let _ = tokio::io::stderr().flush().await;
+                                        // Fall through — next select! iteration
+                                        // recomputes `watchdog_at`, so receiving
+                                        // this heartbeat resets the watchdog.
                                     }
                                     Response::Done => {
                                         if let Some(remaining) = md_buf.flush_all() {
@@ -1789,6 +1839,11 @@ pub async fn run_resume(
                     }
                     Response::ModelSwitched { .. } => {
                         // resume mode has no persistent model variable to update.
+                    }
+                    Response::Heartbeat { .. } => {
+                        // Supervision-only frame; never emitted on the
+                        // Resume path.
+                        tracing::debug!("ignoring Heartbeat outside supervision loop");
                     }
                 }
             }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2219,11 +2219,68 @@ async fn handle_supervision(
     state: &Arc<DaemonState>,
     session_id: Option<String>,
 ) -> Result<()> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     // Holder id used for task notebook leases: prefer the session UUID
     // (stable per supervision request), fall back to the first pane id.
     let holder = supervision_holder_id(&panes, session_id.as_deref());
 
-    let result = handle_supervision_inner(writer, frame_rx, &panes, model, state, session_id).await;
+    // Shared turn counter: the inner loop bumps this on every iteration;
+    // the heartbeat task reads it so stalled supervision is diagnosable.
+    let turn_counter = Arc::new(AtomicU64::new(0));
+
+    // Spawn the heartbeat emitter.  Kept entirely in the wrapper so every
+    // inner exit path (DONE, STEER, timeout, interrupt, model error,
+    // client disconnect, inner Err) cancels it symmetrically — same
+    // pattern as `release_supervised_panes`.
+    let heartbeat_writer = Arc::clone(writer);
+    let heartbeat_start = std::time::Instant::now();
+    let heartbeat_turn = Arc::clone(&turn_counter);
+    let heartbeat_task = tokio::spawn(async move {
+        let mut ticker =
+            tokio::time::interval(std::time::Duration::from_secs(HEARTBEAT_INTERVAL_SECS));
+        // After a suspend (SIGSTOP, laptop sleep, heavy scheduler lag) the
+        // interval would otherwise fire a backlog burst of heartbeats as it
+        // "catches up" — which is both pointless and would swamp the client.
+        // Skip behavior drops the backlog and resumes at the next boundary.
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Skip the immediate fire `tokio::time::interval` emits on first tick
+        // so the first heartbeat lands one interval into the session.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let elapsed_secs = heartbeat_start.elapsed().as_secs();
+            let turn = heartbeat_turn.load(Ordering::Relaxed);
+            let mut w = heartbeat_writer.lock().await;
+            if write_frame(&mut *w, &Response::Heartbeat { elapsed_secs, turn })
+                .await
+                .is_err()
+            {
+                // Writer closed — client disconnected; stop heartbeating.
+                break;
+            }
+        }
+    });
+
+    let result = handle_supervision_inner(
+        writer,
+        frame_rx,
+        &panes,
+        model,
+        state,
+        session_id,
+        &turn_counter,
+    )
+    .await;
+
+    // Stop the heartbeat before we write the resume hint + Done so those
+    // terminal frames are not interleaved with a ticking heartbeat.
+    // `abort()` only requests cancellation; awaiting the JoinHandle ensures
+    // the task has actually unwound (including releasing the writer mutex)
+    // before we go on to emit the final Done frame.  The JoinError we
+    // expect here is cancellation, not a panic — swallow it.
+    heartbeat_task.abort();
+    let _ = heartbeat_task.await;
 
     // Unified resume hint + Done.  Inner no longer writes
     // Response::Done itself; this wrapper writes the hint first (so
@@ -2616,10 +2673,19 @@ async fn render_hard_constraints(panes: &[crate::ipc::SupervisionTarget]) -> Str
     out
 }
 
+/// How often `handle_supervision` emits a [`Response::Heartbeat`] frame on
+/// the supervision socket.  Chosen so a stuck daemon trips the client's
+/// 30-minute watchdog within ~30 minutes even on a pane that would
+/// otherwise produce no other frames (WAIT/STEER/DONE headers only land
+/// every `AMAEBI_SUPERVISION_INTERVAL_SECS`, defaulting to 5 minutes).
+const HEARTBEAT_INTERVAL_SECS: u64 = 10 * 60;
+
 /// Inner body of [`handle_supervision`]; see that function's doc for context.
 ///
 /// Takes `panes` by reference so the outer wrapper retains ownership and can
-/// pass it to [`release_supervised_panes`] after this returns.
+/// pass it to [`release_supervised_panes`] after this returns.  `turn_counter`
+/// is incremented on every iteration so the wrapper's heartbeat task can
+/// report the current turn number.
 async fn handle_supervision_inner(
     writer: &Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
     frame_rx: &mut tokio::sync::mpsc::Receiver<String>,
@@ -2627,6 +2693,7 @@ async fn handle_supervision_inner(
     model: String,
     state: &Arc<DaemonState>,
     session_id: Option<String>,
+    turn_counter: &Arc<std::sync::atomic::AtomicU64>,
 ) -> Result<()> {
     // Notebook leases are acquired in `handle_claude_launch` BEFORE any
     // pane/worktree/claude work so a tag-conflict rejection never
@@ -2768,6 +2835,7 @@ async fn handle_supervision_inner(
         }
 
         turn += 1;
+        turn_counter.store(turn, std::sync::atomic::Ordering::Relaxed);
         let elapsed_mins = supervision_start.elapsed().as_secs() / 60;
 
         // --- Capture pane snapshots (full for LLM, tail for display) ---

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -295,6 +295,14 @@ pub enum Response {
     },
     /// Reply to [`Request::GenerateTag`] carrying the resolved tag.
     TagGenerated { tag: String },
+    /// Daemon-side liveness signal emitted every `HEARTBEAT_INTERVAL_SECS`
+    /// by the heartbeat task spawned in `handle_supervision` (the wrapper,
+    /// not `handle_supervision_inner`, so cancellation is guaranteed on
+    /// every exit path).  Carries (elapsed supervision seconds, current
+    /// turn number) so a stuck pane can be diagnosed even when no
+    /// WAIT/STEER/DONE was produced recently.  The client treats any
+    /// heartbeat as a watchdog reset; rendering it is optional.
+    Heartbeat { elapsed_secs: u64, turn: u64 },
     /// The [`Request::ClaudeLaunch`] was rejected because adding the requested
     /// panes would exceed the configured maximum.
     CapacityError {
@@ -606,6 +614,7 @@ mod tests {
             r#"{"type":"pane_assigned","tag":"pr-1","pane_id":"%3","session_id":"uuid-abc"}"#,
             r#"{"type":"capacity_error","requested":3,"max_panes":16,"current_busy":14}"#,
             r#"{"type":"model_switched","model":"bedrock/claude-opus-4.7"}"#,
+            r#"{"type":"heartbeat","elapsed_secs":600,"turn":2}"#,
         ];
         for frame in frames {
             let r: Response = serde_json::from_str(frame).unwrap();
@@ -623,6 +632,7 @@ mod tests {
                     | Response::PaneAssigned { .. }
                     | Response::CapacityError { .. }
                     | Response::ModelSwitched { .. }
+                    | Response::Heartbeat { .. }
             ));
         }
     }
@@ -862,6 +872,27 @@ mod tests {
 
         let back: Response = serde_json::from_str(&json).unwrap();
         assert!(matches!(back, Response::PaneAssigned { .. }));
+    }
+
+    #[test]
+    fn response_heartbeat_round_trip() {
+        let r = Response::Heartbeat {
+            elapsed_secs: 123,
+            turn: 7,
+        };
+        let s = serde_json::to_string(&r).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+        assert_eq!(v["type"], "heartbeat");
+        assert_eq!(v["elapsed_secs"], 123);
+        assert_eq!(v["turn"], 7);
+        let back: Response = serde_json::from_str(&s).unwrap();
+        assert!(matches!(
+            back,
+            Response::Heartbeat {
+                elapsed_secs: 123,
+                turn: 7
+            }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

User reports `/claude` supervision was cut off at ~12 h with
`[supervision] hard timeout reached; ending session.` even though the
daemon default is 24 h (PR #135).  Root cause: `src/client.rs` hard-
coded a 12 h client-side deadline independent of the daemon's actual
timeout.

Architectural issue: timeout is a daemon concept (it owns lease TTLs,
LLM budgets, the whole lifecycle).  Mirroring in the client via a
shared env var fails when client + daemon run in different shells.
Pure passive waiting hangs the client forever if the daemon goes
half-dead (process alive, supervision task deadlocked).

Fix via **daemon heartbeat + client watchdog**:

- Daemon emits `Response::Heartbeat { elapsed_secs, turn }` every
  10 min from a background task spawned in `handle_supervision`.
  Cancelled unconditionally in the wrapper on every inner exit path
  (DONE, STEER, timeout, interrupt, model error, client disconnect,
  inner Err) — same pattern as `release_supervised_panes`.
- Client runs a 30-min watchdog on any received frame (text /
  heartbeat / done).  If nothing arrives in 30 min, assume the daemon
  is stuck and end the session cleanly.  Post-interrupt 5 s drain
  deadline is pinned at interrupt-send time so heartbeats arriving
  mid-drain cannot push it back.
- Client renders the heartbeat as a one-line status overwrite on
  stderr (`\r[supervision alive — turn #N, Xh Ym elapsed]`) — useful
  progress indicator, doesn't clutter scrollback.

## Scope

- `src/ipc.rs`: new `Response::Heartbeat { elapsed_secs, turn }`.
- `src/daemon.rs`: heartbeat task in `handle_supervision`, turn
  counter threaded via `Arc<AtomicU64>`, `heartbeat_task.abort()` in
  wrapper.
- `src/client.rs`: watchdog replaces `supervision_deadline`;
  heartbeat arm added to the supervision streaming loop.
- `src/agent_server.rs` + other exhaustive match sites: explicit
  `Heartbeat` arms so future enum additions keep failing compilation.
- `Cargo.toml`: 2026.4.59 → 2026.4.60.

## Manual e2e (not runnable in CI)

1. `pkill -f 'amaebi.*daemon'` then `cargo build --release` from this
   branch.  Start daemon fresh.
2. From chat: `/claude --tag heartbeat-test "simple task, just wait"`.
3. Observe `[supervision alive — turn #N, Xm elapsed]` lines appear
   on stderr every 10 min.
4. Wait 12 h; confirm **no** `hard timeout reached` message — removed
   in this PR.
5. Simulate stuck daemon from another terminal:
   `kill -STOP $(pgrep -f 'amaebi.*daemon')`.  Client should print
   `no frames from daemon for 30 min; assuming stuck daemon and
   ending session.` after 30 min.  Then `kill -CONT` to recover.

## Rollback

Revert restores the 12 h client deadline.  No data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)