### PR TITLE
fix(tmux): split tmux_send_keys into send_text + send_key; 5s render-sleep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.4.64"
+version = "2026.4.65"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.4.63"
+version = "2026.4.64"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.4.63"
+version = "2026.4.64"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.4.64"
+version = "2026.4.65"
 edition = "2021"
 
 [[bin]]

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -16,7 +16,7 @@ notebook preamble (for `--tag` runs) and must return exactly one of:
 | Verdict | Meaning | Effect |
 |---------|---------|--------|
 | `WAIT` | Still working, check again later | Sleep, re-snapshot on next tick |
-| `STEER: <pane_id>: <message>` | Pane is stuck or off-track | `tmux_send_keys` the message into the pane |
+| `STEER: <pane_id>: <message>` | Pane is stuck or off-track | `tmux_send_text` the message into the pane |
 | `DONE: <summary>` | Task is complete | Stream the summary to the client, exit |
 
 The prompt that asks for this verdict is built from the pane capture plus the

--- a/src/client.rs
+++ b/src/client.rs
@@ -824,7 +824,8 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                                 "shell_command" => eprint!("{}", render_markdown(&format!("```bash\n$ {detail}\n```\n"))),
                                 "read_file" => eprintln!("📄 {detail}"),
                                 "edit_file" => eprintln!("✏️  {detail}"),
-                                "tmux_send_keys" => eprintln!("⌨️  send-keys: {detail}"),
+                                "tmux_send_text" => eprintln!("⌨️  send-text: {detail}"),
+                                "tmux_send_key" => eprintln!("⌨️  send-key: {detail}"),
                                 "tmux_capture_pane" => eprintln!("🖥️  capture: {detail}"),
                                 _ => eprintln!("🔧 {name}: {detail}"),
                             }
@@ -1795,7 +1796,8 @@ pub async fn run_resume(
                                 "shell_command" => eprint!("{}", render_markdown(&format!("```bash\n$ {detail}\n```\n"))),
                                 "read_file" => eprintln!("📄 {detail}"),
                                 "edit_file" => eprintln!("✏️  {detail}"),
-                                "tmux_send_keys" => eprintln!("⌨️  send-keys: {detail}"),
+                                "tmux_send_text" => eprintln!("⌨️  send-text: {detail}"),
+                                "tmux_send_key" => eprintln!("⌨️  send-key: {detail}"),
                                 "tmux_capture_pane" => eprintln!("🖥️  capture: {detail}"),
                                 _ => eprintln!("🔧 {name}: {detail}"),
                             }
@@ -2013,7 +2015,8 @@ async fn flush_steer_buffer(
                     "shell_command" => eprintln!("```bash\n$ {detail}\n```"),
                     "read_file" => eprintln!("📄 {detail}"),
                     "edit_file" => eprintln!("✏️  {detail}"),
-                    "tmux_send_keys" => eprintln!("⌨️  send-keys: {detail}"),
+                    "tmux_send_text" => eprintln!("⌨️  send-text: {detail}"),
+                    "tmux_send_key" => eprintln!("⌨️  send-key: {detail}"),
                     "tmux_capture_pane" => eprintln!("🖥️  capture: {detail}"),
                     _ => eprintln!("🔧 {name}: {detail}"),
                 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1713,10 +1713,13 @@ async fn handle_claude_launch(
         // with `send-keys -l --`, then send Enter as a separate key press.
         //
         // Timing: 1 s pause before the first send (bash init), 5 s before
-        // subsequent sends (e.g. claude startup), then 1 s after each text
-        // injection before pressing Enter.  No prompt-polling — simple
-        // fixed delays are robust against prompt character variations
-        // (❯, >, $, etc.).
+        // subsequent sends (e.g. claude startup), then
+        // `tools::TEXT_RENDER_SLEEP_SECS` after each text injection before
+        // pressing Enter (shared with `send_pane_keys` / `tmux_send_text`
+        // so every paste path uses the same render-delay — 1 s was not
+        // enough for multi-KB markdown and dropped Enters).  No prompt-
+        // polling — simple fixed delays are robust against prompt
+        // character variations (❯, >, $, etc.).
         let send_result = tokio::task::spawn_blocking(move || {
             for (idx, (keys, press_enter)) in key_sequence.iter().enumerate() {
                 // Before the very first send: let the new pane's shell
@@ -4001,9 +4004,10 @@ async fn flush_pending_unsolicited(
 const MAX_PROMPT_CHARS: usize = 4_000;
 /// Maximum chars stored for an assistant response in session history.
 const MAX_RESPONSE_CHARS: usize = 8_000;
-/// Maximum Unicode scalars kept in the `shell_command` preview returned by
-/// [`summarise_tool_detail`] before appending `…`.  Kept at module scope so
-/// regression tests can reference it without duplicating the `80` literal.
+/// Maximum Unicode scalars kept in the `shell_command` / `tmux_send_text`
+/// preview returned by [`summarise_tool_detail`] before appending `…`.
+/// Kept at module scope so regression tests can reference it without
+/// duplicating the `80` literal.
 const SHELL_DETAIL_MAX_CHARS: usize = 80;
 
 /// Truncate `s` to at most `max` Unicode scalar values (including the marker).
@@ -4041,6 +4045,20 @@ fn should_persist_tool_output(tool_name: &str) -> bool {
     tool_name != "read_file"
 }
 
+/// Bound a preview string to [`SHELL_DETAIL_MAX_CHARS`] Unicode scalars,
+/// appending `…` when truncation occurred.
+///
+/// Walks `char_indices` once to find the byte offset of the `(MAX+1)`-th
+/// scalar (guaranteed to be a char boundary), so it is safe against
+/// multi-byte UTF-8 — a raw `&s[..80]` byte slice would panic when byte 80
+/// lands inside a multi-byte sequence.
+fn truncate_detail_preview(s: &str) -> String {
+    match s.char_indices().nth(SHELL_DETAIL_MAX_CHARS) {
+        Some((byte_idx, _)) => format!("{}…", &s[..byte_idx]),
+        None => s.to_string(),
+    }
+}
+
 /// Build a short human-readable detail string for a tool call, used in
 /// `Response::ToolUse` frames so the client can render something like
 /// `shell_command: ls -la`.
@@ -4048,27 +4066,16 @@ fn should_persist_tool_output(tool_name: &str) -> bool {
 /// Must operate on Unicode scalar boundaries: shell commands routinely contain
 /// non-ASCII text (Chinese comments, em-dashes) and a raw byte slice like
 /// `&s[..80]` panics when the truncation index falls inside a multi-byte UTF-8
-/// sequence.  The `shell_command` branch truncates at 80 chars, appending `…`
-/// when the original was longer; other tools return their primary argument
-/// verbatim.
+/// sequence.  The `shell_command` and `tmux_send_text` branches truncate at
+/// 80 chars, appending `…` when the original was longer (and `tmux_send_text`
+/// additionally flattens newlines so multi-line pastes don't break the CLI's
+/// single-line renderer); other tools return their primary argument verbatim.
 fn summarise_tool_detail(tool_name: &str, args: &serde_json::Value) -> String {
     match tool_name {
         "shell_command" => args
             .get("command")
             .and_then(|v| v.as_str())
-            .map(|s| {
-                // `char_indices().nth(N)` walks the string once and returns
-                // the byte offset of the (N+1)-th Unicode scalar, which is by
-                // construction a char boundary.  Slicing at that byte offset
-                // is safe and avoids the double-iteration / allocation of the
-                // prior `chars().nth` + `chars().take(N).collect()` approach.
-                // `None` means the string has ≤ SHELL_DETAIL_MAX_CHARS chars
-                // and fits verbatim.
-                match s.char_indices().nth(SHELL_DETAIL_MAX_CHARS) {
-                    Some((byte_idx, _)) => format!("{}…", &s[..byte_idx]),
-                    None => s.to_string(),
-                }
-            })
+            .map(truncate_detail_preview)
             .unwrap_or_default(),
         "read_file" | "edit_file" => args
             .get("path")
@@ -4078,8 +4085,20 @@ fn summarise_tool_detail(tool_name: &str, args: &serde_json::Value) -> String {
         "tmux_send_text" => args
             .get("text")
             .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_string(),
+            .map(|s| {
+                // Multi-KB markdown pastes are the common case for
+                // tmux_send_text; injecting the whole body into the tool
+                // detail spams logs/client output and the raw `\n` bytes
+                // break the CLI's single-line tool-use renderer.  Flatten
+                // whitespace first, then bound the preview to the same
+                // char limit as shell_command.
+                let flat: String = s
+                    .chars()
+                    .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+                    .collect();
+                truncate_detail_preview(&flat)
+            })
+            .unwrap_or_default(),
         "tmux_send_key" => args
             .get("key")
             .and_then(|v| v.as_str())
@@ -7691,6 +7710,38 @@ mod tests {
         let args = serde_json::json!({ "path": "/tmp/foo.rs" });
         assert_eq!(summarise_tool_detail("read_file", &args), "/tmp/foo.rs");
         assert_eq!(summarise_tool_detail("edit_file", &args), "/tmp/foo.rs");
+    }
+
+    #[test]
+    fn summarise_tool_detail_tmux_send_text_short_returned_verbatim() {
+        let args = serde_json::json!({ "text": "hello world" });
+        assert_eq!(
+            summarise_tool_detail("tmux_send_text", &args),
+            "hello world"
+        );
+    }
+
+    #[test]
+    fn summarise_tool_detail_tmux_send_text_long_truncates() {
+        // Multi-KB paste is the common real-world case — confirm the
+        // preview is bounded to SHELL_DETAIL_MAX_CHARS + ellipsis instead
+        // of spamming the whole body into logs / tool-use frames.
+        let text: String = "a".repeat(2_000);
+        let args = serde_json::json!({ "text": text });
+        let detail = summarise_tool_detail("tmux_send_text", &args);
+        assert_eq!(detail.chars().count(), SHELL_DETAIL_MAX_CHARS + 1);
+        assert!(detail.ends_with('…'));
+    }
+
+    #[test]
+    fn summarise_tool_detail_tmux_send_text_flattens_newlines() {
+        // Raw newlines would break the CLI's single-line tool-use renderer;
+        // flatten to spaces so the preview stays on one visual line.
+        let args = serde_json::json!({ "text": "line one\nline two\rline three" });
+        let detail = summarise_tool_detail("tmux_send_text", &args);
+        assert!(!detail.contains('\n'));
+        assert!(!detail.contains('\r'));
+        assert_eq!(detail, "line one line two line three");
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2086,12 +2086,17 @@ async fn wait_for_pane_idle(
 /// Send literal text + Enter to a tmux pane (best-effort).
 ///
 /// Sends the text with `send-keys -l --` (literal, no keyname interpretation),
-/// pauses for 1 s to let the receiving TUI's paste buffer drain, then sends
+/// pauses to let the receiving TUI's paste buffer drain, then sends
 /// Enter as a separate key press.  The pause matches the `handle_claude_launch`
 /// injection path (daemon.rs:1081) and exists because Claude Code's TUI can
 /// swallow or defer the trailing Enter when it arrives before the pasted text
 /// has been rendered into the input field — which manifests as a STEER
 /// message appearing in the pane input but never submitting.
+///
+/// The sleep duration is kept in sync with the LLM-facing `tmux_send_text`
+/// tool via [`crate::tools::TEXT_RENDER_SLEEP_SECS`]; the previous 1 s value
+/// was not enough for multi-KB markdown pastes and caused dropped Enters.
+///
 /// Returns `true` when BOTH the literal text injection and the trailing
 /// Enter press reported success to tmux.  Any tmux failure (exit-code non-
 /// zero, or spawn error) yields `false` so callers can accurately report
@@ -2113,8 +2118,10 @@ fn send_pane_keys(pane_id: &str, text: &str) -> bool {
             false
         }
     };
-    // Let the TUI process the pasted text before pressing Enter.
-    std::thread::sleep(std::time::Duration::from_secs(1));
+    // Shared with `tmux_send_text` so both paste paths use the same render-delay.
+    std::thread::sleep(std::time::Duration::from_secs(
+        crate::tools::TEXT_RENDER_SLEEP_SECS,
+    ));
     let enter_ok = match std::process::Command::new("tmux")
         .args(["send-keys", "-t", pane_id, "Enter"])
         .status()
@@ -4063,8 +4070,13 @@ fn summarise_tool_detail(tool_name: &str, args: &serde_json::Value) -> String {
             .and_then(|v| v.as_str())
             .unwrap_or_default()
             .to_string(),
-        "tmux_send_keys" => args
-            .get("keys")
+        "tmux_send_text" => args
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        "tmux_send_key" => args
+            .get("key")
             .and_then(|v| v.as_str())
             .unwrap_or_default()
             .to_string(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1774,8 +1774,13 @@ async fn handle_claude_launch(
                 }
                 if *press_enter {
                     // Wait for the TUI to render and accept the pasted text,
-                    // then press Enter.
-                    std::thread::sleep(std::time::Duration::from_secs(1));
+                    // then press Enter.  Shared with `send_pane_keys` /
+                    // `tmux_send_text` via `TEXT_RENDER_SLEEP_SECS` so every
+                    // paste path uses the same render-delay; 1 s was not
+                    // enough for multi-KB markdown and dropped Enters.
+                    std::thread::sleep(std::time::Duration::from_secs(
+                        crate::tools::TEXT_RENDER_SLEEP_SECS,
+                    ));
                     let out = std::process::Command::new("tmux")
                         .args(["send-keys", "-t", &send_pane, "Enter"])
                         .output()?;
@@ -2087,14 +2092,14 @@ async fn wait_for_pane_idle(
 ///
 /// Sends the text with `send-keys -l --` (literal, no keyname interpretation),
 /// pauses to let the receiving TUI's paste buffer drain, then sends
-/// Enter as a separate key press.  The pause matches the `handle_claude_launch`
-/// injection path (daemon.rs:1081) and exists because Claude Code's TUI can
-/// swallow or defer the trailing Enter when it arrives before the pasted text
-/// has been rendered into the input field — which manifests as a STEER
-/// message appearing in the pane input but never submitting.
+/// Enter as a separate key press.  The pause exists because Claude Code's
+/// TUI can swallow or defer the trailing Enter when it arrives before the
+/// pasted text has been rendered into the input field — which manifests
+/// as a STEER message appearing in the pane input but never submitting.
 ///
-/// The sleep duration is kept in sync with the LLM-facing `tmux_send_text`
-/// tool via [`crate::tools::TEXT_RENDER_SLEEP_SECS`]; the previous 1 s value
+/// This helper and the `handle_claude_launch` literal-paste path share the
+/// same render delay via [`crate::tools::TEXT_RENDER_SLEEP_SECS`], kept in
+/// sync with the LLM-facing `tmux_send_text` tool; the previous 1 s value
 /// was not enough for multi-KB markdown pastes and caused dropped Enters.
 ///
 /// Returns `true` when BOTH the literal text injection and the trailing

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -115,7 +115,8 @@ impl ToolExecutor for LocalExecutor {
                 shell_command(args, self.sandbox.as_deref(), self.default_cwd.as_deref()).await
             }
             "tmux_capture_pane" => tmux_capture_pane(args).await,
-            "tmux_send_keys" => tmux_send_keys(args).await,
+            "tmux_send_text" => tmux_send_text(args).await,
+            "tmux_send_key" => tmux_send_key(args).await,
             "tmux_wait" => tmux_wait(args).await,
             "wait_for_file" => wait_for_file(args).await,
             "tmux_rename_pane" => tmux_rename_pane(args).await,
@@ -216,49 +217,79 @@ async fn tmux_capture_pane(args: serde_json::Value) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-/// Build the argument list for `tmux send-keys`.
+/// Seconds to wait between sending a literal text paste and the
+/// trailing `Enter`, giving the receiving TUI time to render the paste.
+/// 5s covers Claude Code TUI markdown layout at typical paste sizes;
+/// the old 1s-or-none behavior raced the renderer and dropped Enters.
+pub const TEXT_RENDER_SLEEP_SECS: u64 = 5;
+
+/// Send a block of text into a tmux pane and submit it.
 ///
-/// Extracted as a pure function so the argument-construction logic can be
-/// unit-tested without requiring a real tmux session.
-fn tmux_send_keys_argv(target: &str, keys: &str, press_enter: bool) -> Vec<String> {
-    let mut args = vec![
-        "send-keys".to_string(),
-        "-t".to_string(),
-        target.to_string(),
-        keys.to_string(),
-    ];
-    // Avoid a double Enter when the caller explicitly sends the "Enter" key name.
-    // e.g. keys="Enter", enter=true (default) presses Enter once, not twice.
-    if press_enter && keys != "Enter" {
-        args.push("Enter".to_string());
-    }
-    args
-}
-
-/// Send keystrokes to a tmux pane (for interactive programs).
-async fn tmux_send_keys(args: serde_json::Value) -> Result<String> {
-    let keys = args["keys"]
+/// Uses `tmux send-keys -l --` (literal mode) so the bytes are sent
+/// verbatim — `Enter`, `C-c`, `\n`, and any other escape-like substring
+/// inside `text` are NOT interpreted as tmux key names.  After the text
+/// is injected we sleep `TEXT_RENDER_SLEEP_SECS` so the receiving TUI
+/// (Claude Code, shells, etc.) can finish rendering before the trailing
+/// `Enter` arrives — otherwise the Enter can be dropped or fire on an
+/// empty input field.
+///
+/// For single control keys (`C-c`, `Escape`, `q`, arrow keys), use
+/// `tmux_send_key` instead: no literal flag, no sleep, no Enter.
+async fn tmux_send_text(args: serde_json::Value) -> Result<String> {
+    let text = args["text"]
         .as_str()
-        .context("tmux_send_keys: missing string argument 'keys'")?;
+        .context("tmux_send_text: missing string argument 'text'")?;
     let target = args["target"].as_str().unwrap_or("%0");
-    // Default true: append an Enter keystroke so text is submitted.
-    // Set enter=false for single keypresses (q, Escape, C-c, arrow keys, etc.)
-    // to avoid an unintended trailing Enter.
-    let press_enter = args["enter"].as_bool().unwrap_or(true);
 
-    let argv = tmux_send_keys_argv(target, keys, press_enter);
-    let output = Command::new("tmux")
-        .args(&argv)
+    // `-l --` forces literal mode and defends against payloads starting with `-`.
+    let send = Command::new("tmux")
+        .args(["send-keys", "-t", target, "-l", "--", text])
         .output()
         .await
-        .context("spawning tmux send-keys")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("tmux send-keys failed: {stderr}");
+        .context("spawning tmux send-keys (text)")?;
+    if !send.status.success() {
+        let stderr = String::from_utf8_lossy(&send.stderr);
+        anyhow::bail!("tmux send-keys (text) failed: {stderr}");
     }
 
-    Ok(format!("sent keys to pane {target}"))
+    tokio::time::sleep(std::time::Duration::from_secs(TEXT_RENDER_SLEEP_SECS)).await;
+
+    let enter = Command::new("tmux")
+        .args(["send-keys", "-t", target, "Enter"])
+        .output()
+        .await
+        .context("spawning tmux send-keys (Enter)")?;
+    if !enter.status.success() {
+        let stderr = String::from_utf8_lossy(&enter.stderr);
+        anyhow::bail!("tmux send-keys (Enter) failed: {stderr}");
+    }
+
+    Ok(format!("sent {} bytes to pane {target}", text.len()))
+}
+
+/// Send a single tmux key (or key combo) to a pane.
+///
+/// `key` is passed straight to `tmux send-keys` WITHOUT `-l`, so tmux's
+/// key-name parser interprets it: `C-c`, `Escape`, `Up`, `q`, `Enter`,
+/// etc. all work.  No Enter is appended and no sleep runs — use
+/// `tmux_send_text` for prompt-like text + submit flows.
+async fn tmux_send_key(args: serde_json::Value) -> Result<String> {
+    let key = args["key"]
+        .as_str()
+        .context("tmux_send_key: missing string argument 'key'")?;
+    let target = args["target"].as_str().unwrap_or("%0");
+
+    let out = Command::new("tmux")
+        .args(["send-keys", "-t", target, key])
+        .output()
+        .await
+        .context("spawning tmux send-keys (key)")?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        anyhow::bail!("tmux send-keys (key) failed: {stderr}");
+    }
+
+    Ok(format!("sent key {key:?} to pane {target}"))
 }
 
 /// Poll a tmux pane until its output has been stable for `idle_secs`, then
@@ -727,33 +758,57 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
         serde_json::json!({
             "type": "function",
             "function": {
-                "name": "tmux_send_keys",
-                "description": "Send keystrokes to a tmux pane and press Enter to submit \
-                                (default). Use for interactive programs (e.g. answering \
-                                prompts, sending messages to another agent). Set enter=false \
-                                to type text without submitting. For background tasks prefer \
-                                shell_command.",
+                "name": "tmux_send_text",
+                "description": "Send a block of text to a tmux pane and submit it.  Use this \
+                                when you want to paste a prompt / command / message into an \
+                                interactive TUI (like Claude Code, a REPL, a shell).  The \
+                                text is sent literally (escape sequences and key names inside \
+                                the text are NOT interpreted), followed by a 5-second wait so \
+                                the receiving TUI can finish rendering, followed by Enter to \
+                                submit.  For single control keys like C-c, Escape, arrow \
+                                keys, or q, use tmux_send_key instead.",
                 "parameters": {
                     "type": "object",
                     "properties": {
-                        "keys": {
-                            "type": "string",
-                            "description": "Text to type (e.g. 'hello world'). \
-                                            For single keypresses such as 'q', 'Escape', \
-                                            'C-c', or arrow keys, set enter=false to avoid \
-                                            an unintended trailing Enter keystroke."
-                        },
                         "target": {
                             "type": "string",
-                            "description": "tmux target pane. Defaults to %0."
+                            "description": "tmux pane target (e.g. '%3' or 'session:0.1'). \
+                                            Defaults to '%0'."
                         },
-                        "enter": {
-                            "type": "boolean",
-                            "description": "Press Enter after sending keys (default true). \
-                                            Set false for control keys or partial input."
+                        "text": {
+                            "type": "string",
+                            "description": "The text to paste into the pane.  Will be \
+                                            followed by an automatic Enter after a \
+                                            render-delay."
                         }
                     },
-                    "required": ["keys"]
+                    "required": ["text"]
+                }
+            }
+        }),
+        serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "tmux_send_key",
+                "description": "Send a single tmux key (or key combo) to a pane.  Examples: \
+                                'C-c' (Ctrl-C), 'Escape', 'Up', 'q', 'Enter', 'C-m'.  Does \
+                                NOT append an Enter or sleep — use tmux_send_text for \
+                                prompt-style paste + submit flows.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "type": "string",
+                            "description": "tmux pane target (e.g. '%3' or 'session:0.1'). \
+                                            Defaults to '%0'."
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "A tmux key name (e.g. 'C-c', 'Escape', 'Up', \
+                                            'Enter') or printable character."
+                        }
+                    },
+                    "required": ["key"]
                 }
             }
         }),
@@ -1039,7 +1094,8 @@ mod tests {
         for name in [
             "shell_command",
             "tmux_capture_pane",
-            "tmux_send_keys",
+            "tmux_send_text",
+            "tmux_send_key",
             "tmux_wait",
             "wait_for_file",
             "read_file",
@@ -1559,54 +1615,49 @@ mod tests {
         assert!(result.starts_with("timeout:"), "got: {result}");
     }
 
-    // ---- tmux_send_keys enter parameter ------------------------------------
+    // ---- tmux_send_text / tmux_send_key split ------------------------------
 
     #[test]
-    fn tmux_send_keys_schema_has_enter_field() {
+    fn tmux_send_text_schema_exists_and_takes_text() {
         let schemas = tool_schemas(true);
         let schema = schemas
             .iter()
-            .find(|s| s["function"]["name"] == "tmux_send_keys")
-            .expect("tmux_send_keys schema must exist");
+            .find(|s| s["function"]["name"] == "tmux_send_text")
+            .expect("tmux_send_text schema must exist");
         let props = &schema["function"]["parameters"]["properties"];
         assert!(
-            !props["enter"].is_null(),
-            "tmux_send_keys schema must expose 'enter' property"
+            props.get("text").is_some(),
+            "tmux_send_text must expose 'text'"
         );
-        assert_eq!(
-            props["enter"]["type"].as_str(),
-            Some("boolean"),
-            "'enter' property must be boolean"
+        assert!(
+            props.get("enter").is_none(),
+            "tmux_send_text must NOT expose 'enter' (split tool replaces mode flag)"
         );
     }
 
     #[test]
-    fn tmux_send_keys_argv_appends_enter_by_default() {
-        // Default (press_enter=true) appends "Enter" as a separate arg.
-        let argv = tmux_send_keys_argv("%0", "hello world", true);
-        assert_eq!(argv.last().map(|s| s.as_str()), Some("Enter"));
-        assert!(argv.contains(&"hello world".to_string()));
+    fn tmux_send_key_schema_exists_and_takes_key() {
+        let schemas = tool_schemas(true);
+        let schema = schemas
+            .iter()
+            .find(|s| s["function"]["name"] == "tmux_send_key")
+            .expect("tmux_send_key schema must exist");
+        let props = &schema["function"]["parameters"]["properties"];
+        assert!(
+            props.get("key").is_some(),
+            "tmux_send_key must expose 'key'"
+        );
     }
 
     #[test]
-    fn tmux_send_keys_argv_no_enter_when_disabled() {
-        let argv = tmux_send_keys_argv("%0", "hello", false);
-        assert!(!argv.contains(&"Enter".to_string()));
-    }
-
-    #[test]
-    fn tmux_send_keys_argv_no_double_enter_when_keys_is_enter() {
-        // keys="Enter" + press_enter=true should produce only one "Enter" in argv.
-        let argv = tmux_send_keys_argv("%0", "Enter", true);
-        let enter_count = argv.iter().filter(|a| a.as_str() == "Enter").count();
-        assert_eq!(enter_count, 1, "must send exactly one Enter: {argv:?}");
-    }
-
-    #[test]
-    fn tmux_send_keys_argv_control_key_no_trailing_enter() {
-        // C-c with enter=false must not append Enter (would confuse the program).
-        let argv = tmux_send_keys_argv("%0", "C-c", false);
-        assert!(!argv.contains(&"Enter".to_string()));
+    fn tmux_send_keys_schema_removed() {
+        let schemas = tool_schemas(true);
+        assert!(
+            schemas
+                .iter()
+                .all(|s| s["function"]["name"] != "tmux_send_keys"),
+            "legacy tmux_send_keys schema must be removed"
+        );
     }
 
     #[tokio::test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -271,8 +271,10 @@ async fn tmux_send_text(args: serde_json::Value) -> Result<String> {
 ///
 /// `key` is passed straight to `tmux send-keys` WITHOUT `-l`, so tmux's
 /// key-name parser interprets it: `C-c`, `Escape`, `Up`, `q`, `Enter`,
-/// etc. all work.  No Enter is appended and no sleep runs — use
-/// `tmux_send_text` for prompt-like text + submit flows.
+/// etc. all work.  `--` is still passed before `key` so a payload that
+/// starts with `-` can't be misread as a `send-keys` option flag.  No
+/// Enter is appended and no sleep runs — use `tmux_send_text` for
+/// prompt-like text + submit flows.
 async fn tmux_send_key(args: serde_json::Value) -> Result<String> {
     let key = args["key"]
         .as_str()
@@ -280,7 +282,7 @@ async fn tmux_send_key(args: serde_json::Value) -> Result<String> {
     let target = args["target"].as_str().unwrap_or("%0");
 
     let out = Command::new("tmux")
-        .args(["send-keys", "-t", target, key])
+        .args(["send-keys", "-t", target, "--", key])
         .output()
         .await
         .context("spawning tmux send-keys (key)")?;


### PR DESCRIPTION
## Motivation

`tmux_send_keys` with a multi-KB paste + trailing Enter races
Claude Code TUI's renderer: the Enter arrives before the paste is
rendered into the input box, and either (a) the Enter fires on an
empty input (swallowed), or (b) the pasted text lands AFTER the
Enter and becomes a new message instead of a submitted prompt.
User hit this repeatedly; STEERs sat unsubmitted in pane %54 until
they manually hit Enter.

The existing supervision `send_pane_keys` already knew about this
race and used `send -l -- text` then sleep 1s then Enter.  1s was
not enough for ~2KB markdown, and the LLM-facing tool did not even
have the two-step pattern — it was a one-shot `send-keys <text> Enter`.

## Scope

- Split `tmux_send_keys` into:
  - `tmux_send_text { target, text }` — always literal + 5s sleep + Enter.
  - `tmux_send_key  { target, key  }` — always pass-through; no literal flag, no Enter, no sleep.
  Drops the `enter: bool` mode flag entirely.
- Supervision's `send_pane_keys` sleep bumped 1s → 5s via a shared
  `TEXT_RENDER_SLEEP_SECS` constant in `src/tools.rs` so both paste
  paths stay aligned.
- Tool schemas, tests, client render branches, daemon tool-detail
  routing, and `docs/supervision.md` all updated.  No more
  `tmux_send_keys` references in `src/`, `tests/`, or `docs/`.

## Manual e2e

(CI cannot run this — there is no tmux server in the CI image.)

1. `cargo build --release` from this branch; restart the daemon.
2. From a chat: `/claude "paste a 2KB markdown blob from a file then press enter automatically"`.
3. Observe the pane — the text appears in Claude Code's input box
   and is submitted without manual intervention.  Before this fix,
   the Enter would race and the text would sit unsubmitted.
4. Separately, test `tmux_send_key`: have the LLM cancel a running
   command with `{"key": "C-c"}` — no Enter appended, no 5s hang.

## Rollback

Revert restores the old single-tool interface and 1s sleep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)