### PR TITLE
feat(supervision): drift-detection rework — structured verdict + git evidence + event-stream history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.4.66"
+version = "2026.4.67"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.4.65"
+version = "2026.4.66"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.4.67"
+version = "2026.4.68"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.4.65"
+version = "2026.4.66"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.4.67"
+version = "2026.4.68"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.4.66"
+version = "2026.4.67"
 edition = "2021"
 
 [[bin]]

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -57,11 +57,26 @@ Verdict semantics:
 | `DONE` | Explicit completion signal + diff covers the deliverables + Claude is idle | Stream summary to the client, exit |
 
 Assembly: `build_supervision_user_content` (prompt) and
-`parse_supervision_verdict` (response), both in `src/daemon.rs`. An
-unparseable response degrades to a WAIT whose rationale carries the raw
-text, so a misbehaving model never silently skips a tick. The completion
-is capped at `MAX_SUPERVISION_TOKENS` — enough for the JSON object, not
-enough for a long narrative.
+`parse_supervision_verdict` (response), both in `src/daemon.rs`. The
+completion is capped at `MAX_SUPERVISION_TOKENS` — enough for the JSON
+object, not enough for a long narrative.
+
+**Server-side schema enforcement (Bedrock).** On supported Claude
+models (Opus 4.6 / 4.7, Sonnet 4.6), the schema in
+`SUPERVISION_VERDICT_SCHEMA` is passed to ConverseStream via
+`outputConfig.textFormat = { type: "json_schema", ... }` (field added
+in `aws-sdk-bedrockruntime` 1.124.0, 2026-02-04). Bedrock guarantees
+the model's text output conforms to the schema — no code fences, no
+prose prefix, no field omission. The schema and `VerdictRecord` are
+pinned together by a drift-guard test so adding a field to one without
+the other fails CI.
+
+On unsupported models (older Claude, Copilot, Nova, …) the feature is
+silently skipped and the path relies on the prompt's shape instructions
+plus `parse_supervision_verdict`'s tolerant parser, which strips code
+fences, accepts missing optional fields, and degrades an unparseable
+response to a WAIT with the raw text in `rationale` so a misbehaving
+model never silently skips a tick.
 
 ## Timing
 

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -43,7 +43,9 @@ as `true`; ignoring the STEER is `false`; no prior STEER exists yet is
 `null`. This field drives the **hard-boundary escalation** described
 below.
 
-All five fields land in `~/.amaebi/tasks.db` for every tick, so drift
+The full `VerdictRecord` (all fields above, plus
+`claude_responded_to_last_steer` — see the hard-boundary section) is
+JSON-serialised into `~/.amaebi/tasks.db` for every tick, so drift
 trajectories can be reconstructed across resumes. Rows written before
 this schema existed read back with `verdict="LEGACY"` and the raw string
 in `rationale` — no migration required.

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -32,9 +32,16 @@ and returns a single JSON object:
   "observed_action": "<what actually changed on disk this turn>",
   "verdict":         "WAIT" | "STEER" | "DONE",
   "rationale":       "<one sentence why>",
-  "steer_message":   "<only present when verdict=STEER>"
+  "steer_message":   "<only present when verdict=STEER>",
+  "claude_responded_to_last_steer": true | false | null
 }
 ```
+
+`claude_responded_to_last_steer` judges whether Claude acted on the most
+recent prior STEER — reading, thinking, or course-correcting all count
+as `true`; ignoring the STEER is `false`; no prior STEER exists yet is
+`null`. This field drives the **hard-boundary escalation** described
+below.
 
 All five fields land in `~/.amaebi/tasks.db` for every tick, so drift
 trajectories can be reconstructed across resumes. Rows written before
@@ -95,6 +102,51 @@ hypothesis) or has drifted off the task (touching files outside scope,
 silently reinterpreting the goal). The supervision prompt explicitly
 prefers STEER over WAIT when in doubt — a wrong STEER costs one
 keystroke, a missed STEER costs hours of wrong work.
+
+## Hard boundary: ESC + forced message after K ignored STEERs
+
+A plain STEER only works if Claude reads it. When Claude ignores
+`SUPERVISION_DRIFT_BLOCK_K` consecutive STEERs — judged by the
+supervisor's `claude_responded_to_last_steer: false` on each turn — the
+daemon escalates:
+
+1. **ESC keystroke** (`\x1b`) into the pane via `tmux send-keys`, which
+   cancels Claude's current tool call without exiting the TUI.
+2. **Forced message** injected as a new user turn, quoting the recent
+   ignored STEERs verbatim and re-stating the original task:
+   ```
+   Stop.  You have ignored the supervisor repeatedly.  Return to the original task.
+
+   Original task: <desc>
+
+   Recent steering you did not act on:
+     - <steer 1>
+     - <steer 2>
+     - <steer 3>
+
+   Re-read the task above and resume work on it now.
+   ```
+3. A dedicated notebook row is written: `rationale` starts with
+   `HARD_BOUNDARY: K=N drift escalation`, so prior-session history
+   (event stream) surfaces escalations distinctly.
+4. Counter + quoted-STEER FIFO are reset. The forced message is itself
+   a STEER; if Claude ignores it too, the counter accumulates fresh.
+
+`K` is a compile-time constant (`SUPERVISION_DRIFT_BLOCK_K` in
+`src/daemon.rs`), currently `3`. It is not surfaced as an env var — the
+right value depends on how the supervisor calibrates "responded" and is
+a tuning knob, not an operator parameter.
+
+The counter resets on any non-STEER verdict, on a STEER marked
+`responded=true`, and on a STEER the daemon could not dispatch (tmux
+failure — not Claude's fault). Scattered unresponsive STEERs separated
+by WAIT therefore never accumulate; only a *consecutive* run trips the
+boundary.
+
+The hard boundary does **not** roll back files (no `git checkout --`) or
+exit supervision. It is a soft-block: Claude is interrupted and
+re-prompted with the original task, but the loop continues so legitimate
+follow-up work can resume.
 
 ## What DONE does
 

--- a/docs/supervision.md
+++ b/docs/supervision.md
@@ -8,21 +8,53 @@ Claude subprocess is making progress, and nudge it when it isn't.
 Implementation: `handle_supervision` / `handle_supervision_inner` in
 `src/daemon.rs:2207`.
 
-## WAIT / STEER / DONE
+## Structured verdict (drift-detection rework)
 
-Each iteration the supervision LLM sees the pane contents plus the task
-notebook preamble (for `--tag` runs) and must return exactly one of:
+Each iteration the supervisor LLM sees:
 
-| Verdict | Meaning | Effect |
-|---------|---------|--------|
-| `WAIT` | Still working, check again later | Sleep, re-snapshot on next tick |
-| `STEER: <pane_id>: <message>` | Pane is stuck or off-track | `tmux_send_text` the message into the pane |
-| `DONE: <summary>` | Task is complete | Stream the summary to the client, exit |
+1. Task description pinned at the top
+2. Hard constraints from any resource leases the pane holds
+3. Task notebook preamble (for `--tag` runs) as an **event stream** — non-WAIT
+   rounds kept verbatim, runs of identical-signature WAITs folded into
+   `[N ticks] sustained WAIT: …` markers so a 24 h session doesn't drown
+   real drift events in hundreds of `reading files` lines
+4. **Filesystem ground truth** — per-pane `git diff` / `git status --short`
+   (from the pane's worktree) so the supervisor can compare Claude's
+   self-narration against what actually changed on disk
+5. In-session verdict history + the most recent STEER
+6. The current pane snapshots
 
-The prompt that asks for this verdict is built from the pane capture plus the
-notebook preamble (`build_notebook_context`, `src/daemon.rs:2305`). The
-completion is capped at `MAX_SUPERVISION_TOKENS` — enough for a short verdict,
-not enough for a long narrative.
+and returns a single JSON object:
+
+```json
+{
+  "stated_intent":   "<what Claude claims to be doing, distilled from pane>",
+  "observed_action": "<what actually changed on disk this turn>",
+  "verdict":         "WAIT" | "STEER" | "DONE",
+  "rationale":       "<one sentence why>",
+  "steer_message":   "<only present when verdict=STEER>"
+}
+```
+
+All five fields land in `~/.amaebi/tasks.db` for every tick, so drift
+trajectories can be reconstructed across resumes. Rows written before
+this schema existed read back with `verdict="LEGACY"` and the raw string
+in `rationale` — no migration required.
+
+Verdict semantics:
+
+| Verdict | Condition | Effect |
+|---------|-----------|--------|
+| `WAIT` | `stated_intent` and `observed_action` consistent, in scope, progressing | Re-snapshot on next tick |
+| `STEER` | Any drift signal: self-narration disagrees with diff, touched files outside task scope, hard-constraint violation, stuck at a prompt | `tmux send-keys` the `steer_message` into the pane |
+| `DONE` | Explicit completion signal + diff covers the deliverables + Claude is idle | Stream summary to the client, exit |
+
+Assembly: `build_supervision_user_content` (prompt) and
+`parse_supervision_verdict` (response), both in `src/daemon.rs`. An
+unparseable response degrades to a WAIT whose rationale carries the raw
+text, so a misbehaving model never silently skips a tick. The completion
+is capped at `MAX_SUPERVISION_TOKENS` — enough for the JSON object, not
+enough for a long narrative.
 
 ## Timing
 
@@ -30,34 +62,39 @@ All durations are in `handle_supervision_inner`:
 
 | Knob | Default | Env override | Purpose |
 |------|---------|--------------|---------|
-| Poll-interval ceiling | 5 min | `AMAEBI_SUPERVISION_INTERVAL_SECS` | Maximum wait between LLM calls |
-| Idle threshold | 10 s | (compile-time constant `IDLE_SECS`) | Pane must be unchanged this long before the LLM is called |
+| Poll-interval ceiling | 24 h | `AMAEBI_SUPERVISION_INTERVAL_SECS` | Rarely reached; the idle threshold is the real trigger. Kept as an escape hatch for manual rate-limiting. |
+| Idle threshold | 10 s | (compile-time constant `IDLE_SECS`) | Pane must be unchanged this long before the LLM is called — the primary pacing knob |
 | Idle poll period | 2 s | (compile-time constant `IDLE_POLL_SECS`) | How often to snapshot the pane while waiting for idle |
 | Hard timeout | 24 h | `AMAEBI_SUPERVISION_TIMEOUT_SECS` | Wall-clock ceiling; after this, supervision exits regardless.  Matches the pane, resource, and task-notebook lease TTLs (all 24 h) so supervision never outlives the leases it holds. |
 
-The 5-minute ceiling (`src/daemon.rs:2418`) is the *maximum* gap between LLM
-calls. Each iteration also waits for 10 seconds of pane stability
-(`src/daemon.rs:2431`) before taking a snapshot — this avoids calling the LLM
-every 2-5 seconds during active tool output. Net effect: supervision LLM cost
-drops ~70-80 % in typical sessions.
+The drift-detection rework dropped the prior 5-minute ceiling: Claude
+pauses briefly between tool calls even during active work, so a short
+ceiling would let the supervisor judge only after Claude was genuinely
+stuck — too late to catch drift in flight. Defaulting the ceiling to
+the full supervision timeout means a supervision turn fires as soon as
+the pane has been stable for `IDLE_SECS` (10 s), which is the real
+trigger we want. Effect (catching drift) is explicitly prioritised over
+cost (extra LLM calls).
 
-The hard timeout (`src/daemon.rs:2437`) protects against runaway tasks. If
-supervision is still polling after 24 hours, it emits a single
-`[supervision] timeout after …` message and exits; the normal cleanup path
-then releases the pane and any resource/task leases.  No DONE summary is
-produced on this path — those only come from a `DONE:` verdict.
+The hard timeout protects against runaway tasks. If supervision is still
+polling after 24 hours, it emits a single `[supervision] timeout after …`
+message and exits; the normal cleanup path then releases the pane and any
+resource/task leases. No DONE summary is produced on this path — those
+only come from a `DONE` verdict.
 
 ## What STEER does
 
-STEER verdicts are formatted as `STEER: <pane_id>: <message>`. The daemon
-parses the pane id, resolves it to a live tmux target, and sends the message
-via `tmux send-keys`, including Enter so Claude processes it. The pane sees
-the message as if you typed it.
+When the supervisor returns `verdict: "STEER"`, the daemon injects the
+`steer_message` into the first supervised pane via `tmux send-keys`,
+including Enter so Claude processes it. The pane sees the message as if
+you typed it.
 
 Steering is used when the LLM determines Claude is stuck (waiting at a
-confirmation prompt, looping on the same failing command, or chasing a wrong
-hypothesis). The supervision prompt is explicitly instructed to prefer WAIT
-over STEER when in doubt, to avoid thrashing.
+confirmation prompt, looping on the same failing command, chasing a wrong
+hypothesis) or has drifted off the task (touching files outside scope,
+silently reinterpreting the goal). The supervision prompt explicitly
+prefers STEER over WAIT when in doubt — a wrong STEER costs one
+keystroke, a missed STEER costs hours of wrong work.
 
 ## What DONE does
 

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -65,6 +65,19 @@ else
             tab = index($0, "\t")
             subj = substr($0, tab + 1)
 
+            # Skip merge commits outright.  They never bump N (they are
+            # not feat/fix/docs) and — critically — they must not
+            # advance the (year, month) either.  GitHub synthesises a
+            # preview merge commit for every pull-request CI run with a
+            # timestamp of "now in UTC"; without this guard, a PR that
+            # ran even a second into a new month would roll the calver
+            # forward to that month even though no real commit on the
+            # branch falls there.  PR #143 broke exactly this way on
+            # 2026-05-01.
+            if (subj ~ /^Merge /) {
+                next
+            }
+
             if (y != year || m != month) {
                 year = y; month = m; n = 0
             }

--- a/src/bedrock.rs
+++ b/src/bedrock.rs
@@ -675,6 +675,80 @@ pub(crate) fn supports_1m_context(model_id: &str) -> bool {
         || model_id.starts_with("us.anthropic.claude-opus-4-6")
 }
 
+/// Returns true for Bedrock Claude models that reliably honor the
+/// `outputConfig.textFormat = { type: "json_schema", ... }` structured-output
+/// field added to ConverseStream in `aws-sdk-bedrockruntime` 1.124.0
+/// (2026-02-04).
+///
+/// Same allowlist as adaptive thinking — the feature is on the server
+/// side but practical support in Claude's response behavior tracks the
+/// same recent models (Opus 4.6 / 4.7, Sonnet 4.6).  Older Claude 4.x
+/// and 3.x models are left on the prompt-based JSON path to avoid
+/// surprising 400s.
+pub(crate) fn supports_structured_output(model_id: &str) -> bool {
+    model_id.starts_with("us.anthropic.claude-opus-4-7")
+        || model_id.starts_with("us.anthropic.claude-opus-4-6")
+        || model_id.starts_with("us.anthropic.claude-sonnet-4-6")
+}
+
+/// Describes a JSON schema the caller wants Bedrock to enforce on the
+/// model's text output.  Serialised into the request body under
+/// `outputConfig.textFormat` per the smithy model in
+/// `aws-sdk-bedrockruntime/src/types/_output_format.rs`.
+///
+/// The `schema` string is a stringified JSON schema document (not a
+/// nested JSON value — the SDK field type is `String`, confirmed in
+/// `JsonSchemaDefinition::schema`).  `name` and `description` are
+/// optional metadata that surface in tool/panel UIs.
+pub(crate) struct OutputSchema<'a> {
+    pub schema_json: &'a str,
+    pub name: Option<&'a str>,
+    pub description: Option<&'a str>,
+}
+
+/// Build the `outputConfig` body field when `schema` is present AND the
+/// target model is on the `supports_structured_output` allowlist.
+/// Returns `None` otherwise so the caller can simply omit the field.
+///
+/// Wire shape (from `protocol_serde/shape_output_format*.rs`):
+///
+/// ```json
+/// "outputConfig": {
+///   "textFormat": {
+///     "type": "json_schema",
+///     "structure": {
+///       "jsonSchema": {
+///         "schema": "<stringified JSON schema>",
+///         "name": "...",
+///         "description": "..."
+///       }
+///     }
+///   }
+/// }
+/// ```
+fn build_output_config(
+    model_id: &str,
+    schema: Option<&OutputSchema<'_>>,
+) -> Option<serde_json::Value> {
+    let schema = schema?;
+    if !supports_structured_output(model_id) {
+        return None;
+    }
+    let mut json_schema = serde_json::json!({ "schema": schema.schema_json });
+    if let Some(n) = schema.name {
+        json_schema["name"] = serde_json::Value::String(n.to_owned());
+    }
+    if let Some(d) = schema.description {
+        json_schema["description"] = serde_json::Value::String(d.to_owned());
+    }
+    Some(serde_json::json!({
+        "textFormat": {
+            "type": "json_schema",
+            "structure": { "jsonSchema": json_schema }
+        }
+    }))
+}
+
 /// Build the `additionalModelRequestFields` map for a Bedrock request.
 ///
 /// Merges all per-model feature flags (adaptive thinking, 1M context) into a
@@ -710,6 +784,7 @@ async fn send_with_retry(
     tools: &[serde_json::Value],
     max_tokens: usize,
     use_1m: bool,
+    output_schema: Option<&OutputSchema<'_>>,
 ) -> Result<reqwest::Response> {
     let parts = to_bedrock_request(messages);
     let bedrock_tools = to_bedrock_tools(tools);
@@ -731,6 +806,10 @@ async fn send_with_retry(
     let amrf = build_additional_model_request_fields(model_id, use_1m);
     if !amrf.is_empty() {
         body["additionalModelRequestFields"] = serde_json::Value::Object(amrf);
+    }
+
+    if let Some(output_config) = build_output_config(model_id, output_schema) {
+        body["outputConfig"] = output_config;
     }
 
     let url = converse_stream_endpoint(region, model_id);
@@ -1083,12 +1162,21 @@ where
 /// Reads `AWS_BEARER_TOKEN_BEDROCK` and `AWS_REGION` from the environment.
 /// Text chunks are forwarded to `writer` as `Response::Text` frames as they
 /// arrive.  Returns a [`CopilotResponse`] describing the full turn result.
+///
+/// When `output_schema` is `Some` and the target model is on
+/// [`supports_structured_output`], Bedrock enforces the schema on the
+/// model's text output server-side — removing the need for
+/// prompt-based "output JSON only" instructions and brittle regex
+/// post-processing on the client.  For unsupported models the field
+/// is silently omitted so the call still succeeds with a prompt-only
+/// JSON contract.
 pub async fn stream_chat<W>(
     http: &reqwest::Client,
     spec: &crate::provider::ModelSpec,
     messages: &[Message],
     tools: &[serde_json::Value],
     max_tokens: usize,
+    output_schema: Option<&OutputSchema<'_>>,
     writer: &mut W,
 ) -> Result<CopilotResponse>
 where
@@ -1102,6 +1190,7 @@ where
         model = %spec.display_name,
         model_id = %spec.model_id,
         use_1m = spec.use_1m,
+        structured_output = output_schema.is_some(),
         region = %region,
         "sending Bedrock ConverseStream request"
     );
@@ -1115,6 +1204,7 @@ where
         tools,
         max_tokens,
         spec.use_1m,
+        output_schema,
     )
     .await?;
     parse_converse_stream(resp, writer).await
@@ -1269,6 +1359,93 @@ mod tests {
             "no adaptive thinking for sonnet-4"
         );
         assert!(amrf.contains_key("anthropic_beta"), "1M beta present");
+    }
+
+    // ---- supports_structured_output + build_output_config -----------------
+
+    #[test]
+    fn structured_output_supported_models() {
+        assert!(supports_structured_output("us.anthropic.claude-opus-4-7"));
+        assert!(supports_structured_output(
+            "us.anthropic.claude-opus-4-6-v1"
+        ));
+        assert!(supports_structured_output(
+            "us.anthropic.claude-sonnet-4-6-v1:0"
+        ));
+    }
+
+    #[test]
+    fn structured_output_unsupported_models() {
+        // Older Claude 4.x and anything not on the allowlist.
+        assert!(!supports_structured_output(
+            "us.anthropic.claude-opus-4-5-20251101-v1:0"
+        ));
+        assert!(!supports_structured_output(
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        ));
+        assert!(!supports_structured_output(
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        ));
+        assert!(!supports_structured_output(
+            "us.anthropic.claude-sonnet-4-20250514-v1:0"
+        ));
+        assert!(!supports_structured_output("gpt-4o"));
+        assert!(!supports_structured_output(""));
+    }
+
+    #[test]
+    fn output_config_none_when_schema_absent() {
+        let cfg = build_output_config("us.anthropic.claude-opus-4-7", None);
+        assert!(cfg.is_none());
+    }
+
+    #[test]
+    fn output_config_none_for_unsupported_model() {
+        let schema = OutputSchema {
+            schema_json: "{}",
+            name: None,
+            description: None,
+        };
+        let cfg = build_output_config("us.anthropic.claude-haiku-4-5", Some(&schema));
+        assert!(
+            cfg.is_none(),
+            "unsupported model must silently drop outputConfig"
+        );
+    }
+
+    #[test]
+    fn output_config_wire_shape_matches_sdk_model() {
+        // Wire shape cross-checked against `aws-sdk-bedrockruntime`'s
+        // `protocol_serde/shape_output_format*.rs` — structure must be
+        // `outputConfig.textFormat.{type, structure.jsonSchema.{schema, name, description}}`
+        // with `schema` as a STRINGIFIED JSON document (not a nested object).
+        let schema_doc = r#"{"type":"object","properties":{"verdict":{"type":"string"}}}"#;
+        let schema = OutputSchema {
+            schema_json: schema_doc,
+            name: Some("SupervisionVerdict"),
+            description: Some("Structured verdict output"),
+        };
+        let cfg = build_output_config("us.anthropic.claude-opus-4-7", Some(&schema))
+            .expect("supported model must emit outputConfig");
+        let text_format = &cfg["textFormat"];
+        assert_eq!(text_format["type"], "json_schema");
+        let json_schema = &text_format["structure"]["jsonSchema"];
+        assert_eq!(json_schema["schema"], schema_doc);
+        assert_eq!(json_schema["name"], "SupervisionVerdict");
+        assert_eq!(json_schema["description"], "Structured verdict output");
+    }
+
+    #[test]
+    fn output_config_omits_optional_metadata() {
+        let schema = OutputSchema {
+            schema_json: "{}",
+            name: None,
+            description: None,
+        };
+        let cfg = build_output_config("us.anthropic.claude-opus-4-7", Some(&schema)).unwrap();
+        let json_schema = &cfg["textFormat"]["structure"]["jsonSchema"];
+        assert!(json_schema.get("name").is_none());
+        assert!(json_schema.get("description").is_none());
     }
 
     // ---- to_bedrock_request: message conversion ---------------------------

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2733,6 +2733,30 @@ async fn build_notebook_context(
 /// notebook can store (stated_intent, observed_action, verdict,
 /// rationale) per turn and reconstruct the drift trajectory across
 /// long runs.  See [`tasks::VerdictRecord`].
+/// JSON schema for the supervisor's per-turn verdict.  Passed to Bedrock
+/// via `outputConfig.textFormat` so supported Claude models emit a
+/// schema-compliant JSON object server-side (no code fences, no prose
+/// prefix, no field omission).  Unsupported models + the Copilot path
+/// fall back to the prompt's shape instructions and the tolerant
+/// `parse_supervision_verdict` below.
+///
+/// Mirrors [`tasks::VerdictRecord`]; if that struct gains or renames a
+/// field the schema must change in lockstep — a unit test below pins the
+/// two to the same key set.
+pub(crate) const SUPERVISION_VERDICT_SCHEMA: &str = r#"{
+    "type": "object",
+    "properties": {
+        "stated_intent":   { "type": "string" },
+        "observed_action": { "type": "string" },
+        "verdict":         { "type": "string", "enum": ["WAIT", "STEER", "DONE"] },
+        "rationale":       { "type": "string" },
+        "steer_message":   { "type": ["string", "null"] },
+        "claude_responded_to_last_steer": { "type": ["boolean", "null"] }
+    },
+    "required": ["stated_intent", "observed_action", "verdict", "rationale"],
+    "additionalProperties": false
+}"#;
+
 const SUPERVISION_SYSTEM_PROMPT: &str = concat!(
     "You are supervising a Claude Code session executing a specific task in a ",
     "tmux pane.  Your PRIMARY duty is to keep Claude on the task as stated.  ",
@@ -3566,12 +3590,21 @@ async fn handle_supervision_inner(
         // We write our own formatted one-line status after parsing the response.
         let response_text = {
             let mut sink = tokio::io::sink();
-            match invoke_model(
+            let verdict_schema = crate::bedrock::OutputSchema {
+                schema_json: SUPERVISION_VERDICT_SCHEMA,
+                name: Some("SupervisionVerdict"),
+                description: Some(
+                    "Structured per-turn verdict from the supervision LLM, \
+                     mirroring tasks::VerdictRecord.",
+                ),
+            };
+            match invoke_model_with_schema(
                 state,
                 &model,
                 &messages,
                 &[],
                 MAX_SUPERVISION_TOKENS,
+                Some(&verdict_schema),
                 &mut sink,
             )
             .await
@@ -5533,12 +5566,42 @@ async fn invoke_model<W>(
 where
     W: AsyncWriteExt + Unpin,
 {
+    invoke_model_with_schema(
+        state,
+        model,
+        messages,
+        tools,
+        max_completion_tokens,
+        None,
+        writer,
+    )
+    .await
+}
+
+/// Same as [`invoke_model`], but optionally passes a JSON schema down to
+/// Bedrock so the model's text output is server-enforced to match.  The
+/// Copilot path ignores the schema (it has no equivalent field) and
+/// leaves JSON compliance to the prompt.
+#[allow(clippy::too_many_arguments)]
+async fn invoke_model_with_schema<W>(
+    state: &DaemonState,
+    model: &str,
+    messages: &[Message],
+    tools: &[serde_json::Value],
+    max_completion_tokens: usize,
+    output_schema: Option<&crate::bedrock::OutputSchema<'_>>,
+    writer: &mut W,
+) -> Result<copilot::CopilotResponse>
+where
+    W: AsyncWriteExt + Unpin,
+{
     let spec = crate::provider::resolve(model);
     tracing::debug!(
         provider = %spec.provider,
         model_id = %spec.model_id,
         display = %spec.display_name,
         use_1m = spec.use_1m,
+        structured_output = output_schema.is_some(),
         "invoke_model: resolved provider"
     );
 
@@ -5550,6 +5613,7 @@ where
                 messages,
                 tools,
                 max_completion_tokens,
+                output_schema,
                 writer,
             )
             .await
@@ -5571,6 +5635,9 @@ where
                 )
                 .await?;
             }
+            // Copilot has no Bedrock-equivalent structured-output field; the
+            // prompt-only JSON contract + `parse_supervision_verdict`
+            // fallback path remains the contract on that side.
             invoke_copilot(
                 state,
                 &spec.model_id,
@@ -9850,5 +9917,63 @@ prompt_hint = "use sim-9900 (port {port}) only"
 
         ensure_tasks_db(&state).expect("second ensure_tasks_db is a no-op");
         assert!(state.tasks_db.lock().unwrap().is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // SUPERVISION_VERDICT_SCHEMA drift guard
+    //
+    // The JSON schema string lives in daemon.rs; the canonical Rust shape
+    // lives in tasks::VerdictRecord.  These must stay aligned — a new
+    // VerdictRecord field that the schema does not list will be stripped by
+    // Bedrock's structured-output enforcement, silently dropping information
+    // the rest of the code relies on.  Pin the two together with a
+    // compile-time roundtrip + key-set check.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn supervision_verdict_schema_is_valid_json() {
+        let parsed: serde_json::Value = serde_json::from_str(SUPERVISION_VERDICT_SCHEMA)
+            .expect("SUPERVISION_VERDICT_SCHEMA must be valid JSON");
+        assert_eq!(parsed["type"], "object");
+        assert!(
+            parsed["properties"].is_object(),
+            "schema must declare an object with properties"
+        );
+    }
+
+    #[test]
+    fn supervision_verdict_schema_keys_cover_verdict_record_fields() {
+        // If this fails, VerdictRecord grew (or renamed) a field and the
+        // schema was not updated.  Either add the field to the schema's
+        // `properties` (and `required` if mandatory) or rename it
+        // symmetrically.  Silent drift will lose data on the wire.
+        let schema: serde_json::Value = serde_json::from_str(SUPERVISION_VERDICT_SCHEMA).unwrap();
+        let schema_keys: std::collections::BTreeSet<String> = schema["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect();
+
+        // Serialise a fully-populated VerdictRecord and compare key sets.
+        let rec = tasks::VerdictRecord {
+            stated_intent: "i".into(),
+            observed_action: "o".into(),
+            verdict: tasks::VerdictKind::Steer,
+            rationale: "r".into(),
+            steer_message: Some("s".into()),
+            claude_responded_to_last_steer: Some(true),
+            timestamp: 0,
+        };
+        let v = serde_json::to_value(&rec).unwrap();
+        let record_keys: std::collections::BTreeSet<String> =
+            v.as_object().unwrap().keys().cloned().collect();
+
+        assert_eq!(
+            schema_keys, record_keys,
+            "schema properties must match VerdictRecord serialised keys exactly \
+             (missing in schema = field will be stripped by Bedrock; missing in \
+             record = dead schema entry)"
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2042,6 +2042,184 @@ fn capture_pane_text(pane_id: &str) -> String {
     }
 }
 
+/// Ground-truth evidence for one supervised pane: what Claude actually
+/// changed on disk, independent of what it narrates in the pane.
+///
+/// Populated once per supervision tick by [`capture_git_evidence`].  An
+/// empty record (all fields empty) means either the pane has no
+/// worktree bound (legacy `--resume-pane` launches) or the git calls
+/// failed; the supervisor prompt renders it as "no filesystem diff".
+#[derive(Debug, Clone, Default)]
+struct GitEvidence {
+    /// Output of `git diff --stat HEAD` trimmed to [`MAX_GIT_EVIDENCE_BYTES`].
+    stat: String,
+    /// Output of `git diff HEAD` trimmed to [`MAX_GIT_EVIDENCE_BYTES`].
+    patch: String,
+    /// Output of `git status --short`.
+    status: String,
+    /// True when any of the git calls had to be truncated — prompt
+    /// renderer surfaces this so the LLM knows the diff is partial.
+    truncated: bool,
+}
+
+/// Upper bound on each git field before truncation kicks in.  50 KB is
+/// enough to carry a substantive refactor diff (~1500 changed lines)
+/// without swamping the LLM prompt; larger diffs are truncated and the
+/// [`GitEvidence::truncated`] flag is set so the supervisor knows.
+const MAX_GIT_EVIDENCE_BYTES: usize = 50 * 1024;
+
+/// Run `git diff` and `git status --short` in `worktree` and assemble a
+/// [`GitEvidence`] snapshot.  Each git invocation is capped at 3 s so a
+/// hung filesystem cannot stall the supervision loop.
+///
+/// Call from `spawn_blocking` — the git calls are synchronous.
+fn capture_git_evidence(worktree: &str) -> GitEvidence {
+    fn run(worktree: &str, args: &[&str]) -> Option<String> {
+        let out = std::process::Command::new("git")
+            .args(["-C", worktree])
+            .args(args)
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            tracing::debug!(
+                worktree,
+                args = ?args,
+                stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                "git evidence call non-zero exit",
+            );
+            return None;
+        }
+        Some(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+
+    fn cap(s: String, truncated: &mut bool) -> String {
+        if s.len() > MAX_GIT_EVIDENCE_BYTES {
+            *truncated = true;
+            let cut = s
+                .char_indices()
+                .take_while(|(i, _)| *i < MAX_GIT_EVIDENCE_BYTES)
+                .last()
+                .map(|(i, c)| i + c.len_utf8())
+                .unwrap_or(MAX_GIT_EVIDENCE_BYTES);
+            format!("{}\n… (truncated)", &s[..cut])
+        } else {
+            s
+        }
+    }
+
+    let mut truncated = false;
+    GitEvidence {
+        stat: run(worktree, &["diff", "--stat", "HEAD"])
+            .map(|s| cap(s, &mut truncated))
+            .unwrap_or_default(),
+        patch: run(worktree, &["diff", "HEAD"])
+            .map(|s| cap(s, &mut truncated))
+            .unwrap_or_default(),
+        status: run(worktree, &["status", "--short"])
+            .map(|s| cap(s, &mut truncated))
+            .unwrap_or_default(),
+        truncated,
+    }
+}
+
+/// Render a [`GitEvidence`] block for one pane.  Returns empty string
+/// when every field is empty (pane has no worktree bound, or git failed
+/// on every call).
+fn render_git_evidence(pane_id: &str, evidence: &GitEvidence) -> String {
+    if evidence.stat.trim().is_empty()
+        && evidence.patch.trim().is_empty()
+        && evidence.status.trim().is_empty()
+    {
+        return String::new();
+    }
+    let mut out = format!("── Filesystem ground truth — pane {pane_id} ──\n");
+    if evidence.truncated {
+        out.push_str("(one or more git outputs truncated to fit; rely on --stat for coverage)\n");
+    }
+    if !evidence.status.trim().is_empty() {
+        out.push_str("git status --short:\n");
+        for line in evidence.status.lines() {
+            out.push_str("  ");
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    if !evidence.stat.trim().is_empty() {
+        out.push_str("git diff --stat HEAD:\n");
+        for line in evidence.stat.lines() {
+            out.push_str("  ");
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    if !evidence.patch.trim().is_empty() {
+        out.push_str("git diff HEAD:\n");
+        out.push_str(&evidence.patch);
+        if !evidence.patch.ends_with('\n') {
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Collect and render git evidence for every supervised pane that has
+/// a known worktree.  Returns the concatenated, ready-to-insert block
+/// for [`build_supervision_user_content`], or an empty string if no
+/// pane has evidence to show.
+///
+/// Worktree lookup goes through `pane_lease::read_state()` rather than
+/// a dedicated IPC field so legacy supervision payloads keep working
+/// unchanged: a pane without a worktree in `tmux-state.json` simply
+/// contributes nothing.
+///
+/// Per-pane git calls run in parallel via `spawn_blocking` so a slow
+/// filesystem on one pane doesn't serialise the others.
+async fn collect_git_evidence(panes: &[crate::ipc::SupervisionTarget]) -> String {
+    let state = match tokio::task::spawn_blocking(pane_lease::read_state).await {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "supervision: failed to read pane state for git evidence");
+            return String::new();
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "supervision: pane-state read task panicked");
+            return String::new();
+        }
+    };
+
+    let mut tasks = Vec::new();
+    for target in panes {
+        let Some(lease) = state.get(&target.pane_id) else {
+            continue;
+        };
+        let Some(worktree) = lease.worktree.clone() else {
+            continue;
+        };
+        let pane_id = target.pane_id.clone();
+        tasks.push(tokio::task::spawn_blocking(move || {
+            let evidence = capture_git_evidence(&worktree);
+            (pane_id, evidence)
+        }));
+    }
+
+    let mut out = String::new();
+    for handle in tasks {
+        match handle.await {
+            Ok((pane_id, evidence)) => {
+                let block = render_git_evidence(&pane_id, &evidence);
+                if !block.is_empty() {
+                    out.push_str(&block);
+                    out.push('\n');
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "git-evidence task panicked");
+            }
+        }
+    }
+    out
+}
+
 /// Wait until the target pane's output has been stable for `idle_secs`, or
 /// until `timeout` elapses, then return the final snapshot.
 ///
@@ -2205,13 +2383,17 @@ async fn release_supervised_panes(panes: &[crate::ipc::SupervisionTarget]) {
 /// Handle `Request::SupervisePanes`: run a Rust polling loop that captures pane
 /// content, calls the LLM for analysis (no tools), and acts on the response.
 ///
-/// The loop iterates with a 5-minute ceiling between turns (override with
-/// `AMAEBI_SUPERVISION_INTERVAL_SECS`), but each iteration additionally waits
-/// for the pane to go idle before snapshotting.  Each turn the LLM returns
-/// exactly one of:
-/// - `WAIT` — still working, check again
-/// - `STEER: <pane_id>: <message>` — send a correction to the pane
-/// - `DONE: <summary>` — task is complete; stream the summary and exit
+/// Each iteration waits for the pane to stabilise for `IDLE_SECS` and then
+/// snapshots.  There is no short per-turn ceiling any more (the effect-over-cost
+/// rework removed it): the LLM is invoked as soon as Claude pauses, so drift is
+/// caught in-flight rather than after a multi-minute gap.  The ceiling falls
+/// back to the hard supervision timeout; `AMAEBI_SUPERVISION_INTERVAL_SECS`
+/// remains as an escape hatch for manual rate-limiting.
+///
+/// Each turn the LLM returns a JSON object with `stated_intent`,
+/// `observed_action`, `verdict` (one of `WAIT | STEER | DONE`), `rationale`,
+/// and an optional `steer_message`.  See [`SUPERVISION_SYSTEM_PROMPT`] for the
+/// exact contract.
 ///
 /// The loop can also be interrupted by an `Interrupt` frame arriving on
 /// `frame_rx`, or hit the hard wall-clock ceiling.  Default matches the
@@ -2332,6 +2514,72 @@ async fn handle_supervision(
     result
 }
 
+/// Render a list of structured [`tasks::VerdictRecord`]s as an
+/// **event stream**: every non-WAIT round appears verbatim, and WAIT
+/// runs are folded when consecutive turns share the same
+/// (stated_intent, observed_action) signature.  This replaces the
+/// fixed "last N" window — a 24 h run can produce hundreds of
+/// nearly-identical `WAIT: reading files` rows that would drown out
+/// real drift events if all of them were carried into the prompt.
+///
+/// Rules:
+/// - A WAIT round is *kept* verbatim when its (stated_intent,
+///   observed_action) differs from the previous kept line.  The first
+///   of a run is always kept; subsequent identical-signature WAITs
+///   are absorbed into a single `[N ticks] sustained: …` marker.
+/// - A STEER or DONE round is always kept verbatim.
+/// - A LEGACY row (written before the structured schema existed) is
+///   kept verbatim — we don't know how to compare signatures, so
+///   treat each as its own event.
+///
+/// Output is oldest-first, one line per event, suitable for direct
+/// inclusion in the supervisor prompt.
+pub(crate) fn render_event_stream_history(records: &[tasks::VerdictRecord]) -> String {
+    if records.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    let mut pending_wait: Option<(&tasks::VerdictRecord, usize)> = None;
+
+    fn flush_wait(out: &mut String, pending: Option<(&tasks::VerdictRecord, usize)>) {
+        if let Some((rec, count)) = pending {
+            if count == 1 {
+                out.push_str(&format!("  - {}\n", rec.to_line()));
+            } else {
+                let intent = if rec.stated_intent.is_empty() {
+                    rec.rationale.clone()
+                } else {
+                    rec.stated_intent.clone()
+                };
+                out.push_str(&format!("  - [{count} ticks] sustained WAIT: {intent}\n"));
+            }
+        }
+    }
+
+    for rec in records {
+        match rec.verdict {
+            tasks::VerdictKind::Wait => match pending_wait.as_mut() {
+                Some((prev, count))
+                    if prev.stated_intent == rec.stated_intent
+                        && prev.observed_action == rec.observed_action =>
+                {
+                    *count += 1;
+                }
+                _ => {
+                    flush_wait(&mut out, pending_wait.take());
+                    pending_wait = Some((rec, 1));
+                }
+            },
+            _ => {
+                flush_wait(&mut out, pending_wait.take());
+                out.push_str(&format!("  - {}\n", rec.to_line()));
+            }
+        }
+    }
+    flush_wait(&mut out, pending_wait.take());
+    out
+}
+
 /// Stable identifier stored as `task_notes.content` on the `kind='lease'`
 /// row so cleanup can find exactly the leases this supervision request
 /// owns.
@@ -2446,20 +2694,16 @@ async fn build_notebook_context(
 
             let latest = tasks::latest_desc(conn, repo_dir, tag)?
                 .unwrap_or_else(|| "(none recorded)".to_string());
-            let verdicts = tasks::recent_verdicts(conn, repo_dir, tag)?;
+            let all = tasks::all_verdict_records(conn, repo_dir, tag)?;
+            let rendered = render_event_stream_history(&all);
 
             out.push_str(&format!("=== Task notebook for tag '{tag}' ===\n"));
             out.push_str(&format!("Desc (most recent on record): {latest}\n"));
-            if verdicts.is_empty() {
+            if rendered.trim().is_empty() {
                 out.push_str("No prior supervision verdicts for this tag.\n");
             } else {
-                out.push_str(&format!(
-                    "Recent verdicts from prior supervision sessions ({}, oldest first):\n",
-                    verdicts.len()
-                ));
-                for v in &verdicts {
-                    out.push_str(&format!("  - {v}\n"));
-                }
+                out.push_str("Prior supervision verdicts (event stream — WAIT runs folded):\n");
+                out.push_str(&rendered);
             }
             out.push_str("=== End task notebook ===\n\n");
         }
@@ -2483,6 +2727,12 @@ async fn build_notebook_context(
 /// is listed before WAIT/DONE; and the tie-break is explicitly "prefer
 /// STEER" rather than "default to WAIT" (a missed STEER costs hours, a
 /// stray STEER costs one keystroke).
+///
+/// Output format: strict JSON (no prose preamble) with four fields plus
+/// an optional steer_message.  The structured shape is required so the
+/// notebook can store (stated_intent, observed_action, verdict,
+/// rationale) per turn and reconstruct the drift trajectory across
+/// long runs.  See [`tasks::VerdictRecord`].
 const SUPERVISION_SYSTEM_PROMPT: &str = concat!(
     "You are supervising a Claude Code session executing a specific task in a ",
     "tmux pane.  Your PRIMARY duty is to keep Claude on the task as stated.  ",
@@ -2491,39 +2741,305 @@ const SUPERVISION_SYSTEM_PROMPT: &str = concat!(
     "appears, STEER immediately; do not wait for another turn to \"see if it self-corrects\".\n",
     "\n",
     "Each turn you see: the original task description (pinned at the top), any hard ",
-    "constraints, the last few verdicts you issued, and the current pane contents.  ",
-    "You respond with EXACTLY ONE of:\n",
+    "constraints, the per-pane filesystem ground truth (git diff / status — what Claude ",
+    "ACTUALLY changed), prior verdicts on this task, the most recent STEER, and the ",
+    "current pane contents (what Claude says it is doing).  Your job is to compare ",
+    "the self-narration against the ground truth: drift is precisely when they diverge.\n",
     "\n",
-    "STEER: <pane_id>: <message to send>\n",
-    "  Use STEER when ANY of the following holds:\n",
-    "  - Claude is at an idle prompt and asked a question or offered options — answer.\n",
-    "  - Claude's current action contradicts a hard constraint (wrong resource, wrong ",
-    "    container, wrong branch, forbidden command).  Name the specific constraint ",
-    "    in the STEER message.\n",
-    "  - Claude drifted from the task: switched approach without checking in, skipped ",
-    "    a requirement, reinterpreted the goal, or is working on a tangent.\n",
-    "  - Claude reports partial completion and the task description is not fully done.\n",
-    "  - Claude is stuck on an error and a concrete hint will unblock it.\n",
-    "  When in doubt between STEER and WAIT, prefer STEER — a wrong STEER costs one ",
-    "  keystroke, a missed STEER costs hours of wrong work.\n",
+    "Output format — STRICT JSON, nothing else.  No prose preamble, no markdown fences. ",
+    "Return a single JSON object with these fields:\n",
     "\n",
-    "WAIT: <one sentence — what is Claude currently doing?>\n",
-    "  Use WAIT only when Claude is visibly, measurably making progress on the ORIGINAL ",
-    "  task, respecting hard constraints, and has not asked a question.  Long builds, ",
-    "  sim runs, and test executions are normal — WAIT is correct there.\n",
+    "  {\n",
+    "    \"stated_intent\":   \"<one sentence — what is Claude claiming to do right now?>\",\n",
+    "    \"observed_action\": \"<one sentence — what changed on disk this turn, per the git evidence?>\",\n",
+    "    \"verdict\":         \"WAIT\" | \"STEER\" | \"DONE\",\n",
+    "    \"rationale\":       \"<one sentence — why this verdict?>\",\n",
+    "    \"steer_message\":   \"<only present when verdict=STEER: the message to send to the pane; must name the drift concretely>\"\n",
+    "  }\n",
     "\n",
-    "DONE: <paragraph summary of what was accomplished>\n",
-    "  The task is FULLY complete.  Require ALL of:\n",
-    "  1. Pane shows an explicit completion signal — a finished report, passing tests,\n",
-    "     a merged PR URL, 'done', '✓', 'all tests passed', or similar.\n",
-    "  2. That completion directly covers the task description given at session start\n",
-    "     (not a sub-step, not unrelated output).\n",
-    "  3. Claude is no longer working (idle prompt or returned to shell).\n",
-    "  An idle prompt alone is NOT sufficient — Claude may be waiting for user input ",
-    "  (prefer STEER) or may have been interrupted (prefer WAIT and re-check).\n",
+    "Verdict rules:\n",
     "\n",
-    "Your response must start with STEER:, WAIT:, or DONE: — nothing else before it.",
+    "  STEER — send a corrective message into the pane.  Use when ANY of:\n",
+    "    - stated_intent and observed_action disagree (classic drift: says reading X, edited Y).\n",
+    "    - Claude touched files outside the task's apparent scope.\n",
+    "    - Claude contradicts a hard constraint (wrong resource, wrong container, wrong branch).\n",
+    "    - Claude is at an idle prompt and asked a question.\n",
+    "    - Claude reports partial completion but the task description is not fully done.\n",
+    "    - Claude is stuck on an error and a concrete hint will unblock it.\n",
+    "    steer_message MUST be non-empty and name the specific drift (\"you said A, modified B/C\").\n",
+    "\n",
+    "  WAIT — do nothing this turn.  Use ONLY when ALL of:\n",
+    "    - stated_intent and observed_action are consistent.\n",
+    "    - observed_action is inside the task's apparent scope.\n",
+    "    - Claude is visibly making progress on the ORIGINAL task.\n",
+    "    - No hard constraint is violated.\n",
+    "    Long builds, sim runs, and test executions qualify — WAIT is correct there.\n",
+    "\n",
+    "  DONE — task is FULLY complete.  Require ALL of:\n",
+    "    1. Pane shows an explicit completion signal (finished report, passing tests,\n",
+    "       merged PR URL, 'done', '✓', 'all tests passed', or similar).\n",
+    "    2. That completion covers the task description given at session start\n",
+    "       (not a sub-step, not unrelated output).\n",
+    "    3. The git diff covers the task's deliverables (e.g. a 'fix the flaky test' task\n",
+    "       must show a diff in the test file OR the file being tested).\n",
+    "    4. Claude is no longer working.\n",
+    "    An idle prompt alone is NOT sufficient.\n",
+    "\n",
+    "When in doubt between STEER and WAIT, prefer STEER — a wrong STEER costs one ",
+    "keystroke, a missed STEER costs hours of wrong work.\n",
+    "\n",
+    "The first non-whitespace character of your response MUST be `{` and the last MUST be `}`.",
 );
+
+/// Outcome of parsing one supervision model response.
+///
+/// `done_summary`: `Some(text)` when the verdict is DONE; caller uses
+/// it as the final text frame and exits the loop.
+///
+/// `dispatch`: `Some(_)` only when the verdict is STEER AND the target
+/// pane id + message are non-empty AND the pane is in the supervised
+/// set.  A malformed STEER downgrades to a WAIT-style record with a
+/// diagnostic rationale rather than raising.
+struct SupervisionParsed {
+    record: tasks::VerdictRecord,
+    /// User-facing line printed to the chat stream ("  → WAIT: …\n", etc.)
+    display: String,
+    /// DONE summary text when the verdict is DONE.
+    done_summary: Option<String>,
+    /// Dispatch target for STEER verdicts.
+    dispatch: Option<SteerDispatch>,
+}
+
+struct SteerDispatch {
+    pane_id: String,
+    message: String,
+}
+
+/// Parse the supervisor LLM's response into a [`SupervisionParsed`].
+///
+/// Tolerates:
+/// - JSON wrapped in ``` code fences (some models add them despite the
+///   instruction).
+/// - Extra whitespace and trailing prose before/after the object.
+/// - Unknown / missing fields (default via serde).
+///
+/// A completely unparseable response produces a WAIT-style record with
+/// the raw text captured in `rationale`, so the loop never stalls on
+/// model misbehaviour.  A STEER naming an unknown pane is downgraded
+/// to WAIT with `rationale` explaining the pane mismatch — same policy
+/// as the legacy string-format parser.
+fn parse_supervision_verdict(
+    raw: &str,
+    panes: &[crate::ipc::SupervisionTarget],
+) -> SupervisionParsed {
+    let body = extract_json_object(raw);
+    let parsed: Option<tasks::VerdictRecord> =
+        body.as_deref().and_then(|b| serde_json::from_str(b).ok());
+
+    let Some(mut record) = parsed else {
+        // Unparseable: treat as a bare WAIT with the raw text as
+        // rationale.  No pane action.  This keeps a flaky model from
+        // masking real drift with a silent WAIT — the rationale makes
+        // the failure visible in the notebook history.
+        let record = tasks::VerdictRecord {
+            stated_intent: String::new(),
+            observed_action: String::new(),
+            verdict: tasks::VerdictKind::Wait,
+            rationale: format!(
+                "(unparseable verdict — treating as WAIT) raw: {}",
+                raw.trim().chars().take(200).collect::<String>()
+            ),
+            steer_message: None,
+            timestamp: 0,
+        };
+        return SupervisionParsed {
+            display: format!("  → {}\n", record.to_line()),
+            record,
+            done_summary: None,
+            dispatch: None,
+        };
+    };
+
+    match record.verdict {
+        tasks::VerdictKind::Done => {
+            let summary = if record.rationale.trim().is_empty() {
+                "(no summary)".to_string()
+            } else {
+                record.rationale.clone()
+            };
+            SupervisionParsed {
+                display: format!("  → DONE\n\n{summary}\n"),
+                done_summary: Some(summary),
+                record,
+                dispatch: None,
+            }
+        }
+        tasks::VerdictKind::Steer => {
+            // A STEER verdict must name a pane and carry a non-empty
+            // message.  When the JSON omits `steer_message` we fall
+            // back to the rationale — a weak but better-than-nothing
+            // signal to Claude.
+            let message = record
+                .steer_message
+                .as_deref()
+                .filter(|m| !m.trim().is_empty())
+                .map(str::to_owned)
+                .or_else(|| {
+                    let r = record.rationale.trim();
+                    if r.is_empty() {
+                        None
+                    } else {
+                        Some(r.to_owned())
+                    }
+                });
+
+            // Pick the pane to steer: if only one pane is supervised,
+            // target it unconditionally.  When multiple panes are
+            // supervised, the model should include the pane id inside
+            // `steer_message` as a hint; we currently just pick the
+            // first, matching pre-rework behavior for the common
+            // single-pane case.
+            let pane_id = panes.first().map(|p| p.pane_id.clone());
+
+            match (pane_id, message) {
+                (Some(pid), Some(msg)) => {
+                    record.steer_message = Some(msg.clone());
+                    SupervisionParsed {
+                        display: format!("  → STEER: {pid}: {msg}\n"),
+                        record,
+                        done_summary: None,
+                        dispatch: Some(SteerDispatch {
+                            pane_id: pid,
+                            message: msg,
+                        }),
+                    }
+                }
+                _ => {
+                    // Downgrade: malformed STEER becomes a WAIT with
+                    // explanation so the next turn's prompt carries
+                    // the issue forward.
+                    let rationale = format!(
+                        "(malformed STEER — no target pane or message; kept as WAIT) {}",
+                        record.rationale.trim()
+                    );
+                    let wait_record = tasks::VerdictRecord {
+                        stated_intent: record.stated_intent,
+                        observed_action: record.observed_action,
+                        verdict: tasks::VerdictKind::Wait,
+                        rationale,
+                        steer_message: None,
+                        timestamp: 0,
+                    };
+                    SupervisionParsed {
+                        display: format!("  → {}\n", wait_record.to_line()),
+                        record: wait_record,
+                        done_summary: None,
+                        dispatch: None,
+                    }
+                }
+            }
+        }
+        tasks::VerdictKind::Wait | tasks::VerdictKind::Legacy => {
+            // LEGACY shouldn't come out of the LLM — but if the model
+            // echoes an unknown value, coerce to WAIT.
+            if record.verdict == tasks::VerdictKind::Legacy {
+                record.verdict = tasks::VerdictKind::Wait;
+            }
+            SupervisionParsed {
+                display: format!("  → {}\n", record.to_line()),
+                record,
+                done_summary: None,
+                dispatch: None,
+            }
+        }
+    }
+}
+
+/// Extract the first top-level `{...}` object from `raw`, stripping
+/// common wrappers (``` fences, leading/trailing prose).  Returns
+/// `None` when no balanced object exists.
+fn extract_json_object(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    // Fast path: response is pure JSON already.
+    if trimmed.starts_with('{') && trimmed.ends_with('}') {
+        return Some(trimmed.to_string());
+    }
+    // Find a `{` and scan for its matching `}` respecting string literals.
+    let bytes = raw.as_bytes();
+    let start = bytes.iter().position(|&b| b == b'{')?;
+    let mut depth = 0i32;
+    let mut in_str = false;
+    let mut escape = false;
+    for (i, &b) in bytes.iter().enumerate().skip(start) {
+        if escape {
+            escape = false;
+            continue;
+        }
+        match b {
+            b'\\' if in_str => escape = true,
+            b'"' => in_str = !in_str,
+            b'{' if !in_str => depth += 1,
+            b'}' if !in_str => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(raw[start..=i].to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Persist a verdict record to `~/.amaebi/tasks.db` for every
+/// `(repo_dir, tag)` target among `panes`.  Best-effort: failures are
+/// logged but do not propagate — the notebook is auxiliary to live
+/// supervision.
+async fn persist_verdict_record(
+    state: &Arc<DaemonState>,
+    panes: &[crate::ipc::SupervisionTarget],
+    record: &tasks::VerdictRecord,
+) {
+    let mut targets: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    for target in panes.iter() {
+        if let (Some(repo_dir), Some(tag)) = (target.repo_dir.as_deref(), target.tag.as_deref()) {
+            targets.insert((repo_dir.to_string(), tag.to_string()));
+        }
+    }
+    for (repo_dir, tag) in targets {
+        let state_cl = Arc::clone(state);
+        let record = record.clone();
+        let repo_dir_log = repo_dir.clone();
+        let tag_log = tag.clone();
+        match tokio::task::spawn_blocking(move || -> Result<()> {
+            ensure_tasks_db(&state_cl)?;
+            let guard = state_cl
+                .tasks_db
+                .lock()
+                .map_err(|e| anyhow::anyhow!("tasks_db mutex poisoned: {e}"))?;
+            let conn = guard
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("tasks_db not initialised"))?;
+            tasks::append_verdict_record(conn, &repo_dir, &tag, &record)
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::warn!(
+                error = %e,
+                repo_dir = %repo_dir_log,
+                tag = %tag_log,
+                "failed to persist verdict"
+            ),
+            Err(e) => tracing::warn!(
+                error = %e,
+                repo_dir = %repo_dir_log,
+                tag = %tag_log,
+                "verdict persist task panicked"
+            ),
+        }
+    }
+}
 
 /// Pure helper that formats the user message fed to the supervision LLM
 /// every turn.  Extracted from [`handle_supervision_inner`] so tests can
@@ -2549,6 +3065,7 @@ fn build_supervision_user_content(
     task_lines: &[(String, String)],
     hard_constraints: &str,
     notebook_context: &str,
+    git_evidence: &str,
     verdict_history: &std::collections::VecDeque<String>,
     last_steer_full: Option<&str>,
     pane_snapshots: &str,
@@ -2597,12 +3114,20 @@ fn build_supervision_user_content(
     };
 
     // Assemble without source-indentation so every section header (TASK,
-    // HARD CONSTRAINTS, notebook context, verdict list, STEER carry-over,
-    // snapshot header) lands at column 0 in the LLM-facing output.
+    // HARD CONSTRAINTS, notebook context, git evidence, verdict list,
+    // STEER carry-over, snapshot header) lands at column 0 in the
+    // LLM-facing output.
     let mut out = task_section;
     out.push('\n');
     out.push_str(hard_constraints);
     out.push_str(notebook_context);
+    if !git_evidence.trim().is_empty() {
+        out.push_str(git_evidence);
+        if !git_evidence.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push('\n');
+    }
     out.push_str("Your recent verdicts this session (newest last):\n");
     out.push_str(&verdict_history_block);
     out.push('\n');
@@ -2692,8 +3217,10 @@ async fn render_hard_constraints(panes: &[crate::ipc::SupervisionTarget]) -> Str
 /// How often `handle_supervision` emits a [`Response::Heartbeat`] frame on
 /// the supervision socket.  Chosen so a stuck daemon trips the client's
 /// 30-minute watchdog within ~30 minutes even on a pane that would
-/// otherwise produce no other frames (WAIT/STEER/DONE headers only land
-/// every `AMAEBI_SUPERVISION_INTERVAL_SECS`, defaulting to 5 minutes).
+/// otherwise produce no other frames.  Supervision verdicts land
+/// whenever the pane has been idle for `IDLE_SECS` — often far more
+/// frequent than the heartbeat — but long compile / sim runs still
+/// benefit from the heartbeat to prove liveness.
 const HEARTBEAT_INTERVAL_SECS: u64 = 10 * 60;
 
 /// Inner body of [`handle_supervision`]; see that function's doc for context.
@@ -2718,19 +3245,21 @@ async fn handle_supervision_inner(
     // same holder id derived in the wrapper; cleanup still flows
     // through `release_all_by_holder` there.
 
-    // Max time to wait between LLM checks.  Default 5 min; override with
-    // AMAEBI_SUPERVISION_INTERVAL_SECS.  This is the *ceiling*: each iteration
-    // actually waits for the pane to go idle (see `IDLE_SECS` below) so that
-    // the snapshot fed to the LLM is stable, and only falls back to the
-    // ceiling when Claude is continuously producing output.  The higher
-    // ceiling reduces supervision LLM cost when Claude is in a long
-    // compile / test / think phase where the pane barely changes for
-    // minutes at a time.
+    // Ceiling on the wait-for-idle step.  Effect (catching drift) has
+    // been prioritised over cost (see drift-detection rework): Claude
+    // may pause briefly between tool calls even during active work, so
+    // a short ceiling like the prior 5 min would let the supervisor
+    // judge only while Claude was genuinely stuck — too late to catch
+    // drift in flight.  Defaulting to the full supervision timeout
+    // means `wait_for_pane_idle` will return once the pane has been
+    // stable for IDLE_SECS (10 s), which is the real trigger we want.
+    // `AMAEBI_SUPERVISION_INTERVAL_SECS` remains available as an
+    // escape hatch for operators who need to rate-limit LLM calls.
     let poll_interval = tokio::time::Duration::from_secs(
         std::env::var("AMAEBI_SUPERVISION_INTERVAL_SECS")
             .ok()
             .and_then(|v| v.parse().ok())
-            .unwrap_or(300u64) // 5 min
+            .unwrap_or(crate::pane_lease::LEASE_TTL_SECS)
             .max(1), // clamp to >= 1 s to prevent a tight loop
     );
     // How long a pane must be unchanged to be considered idle before
@@ -2934,6 +3463,15 @@ async fn handle_supervision_inner(
         // so resumes without a CLI desc can find it.
         let notebook_context = build_notebook_context(state, panes, turn == 1).await;
 
+        // Ground-truth evidence — per-pane git diff / status.  Pulled
+        // from each pane's worktree (looked up in tmux-state.json by
+        // pane_id).  The supervisor needs this to catch drift that
+        // pane narration can't reveal: Claude may claim "reading X"
+        // while the diff shows edits to Y.  A pane without a bound
+        // worktree (raw `--resume-pane` on an ad-hoc shell) produces
+        // no evidence block; the prompt simply omits the section.
+        let git_evidence = collect_git_evidence(panes).await;
+
         let task_lines: Vec<(String, String)> = snapshots
             .iter()
             .map(|s| (s.pane_id.clone(), s.task_description.clone()))
@@ -2943,6 +3481,7 @@ async fn handle_supervision_inner(
             &task_lines,
             &hard_constraints,
             &notebook_context,
+            &git_evidence,
             &verdict_history,
             last_steer_full.as_deref(),
             &pane_snapshots,
@@ -3011,16 +3550,30 @@ async fn handle_supervision_inner(
             }
         };
 
-        let trimmed = response_text.trim();
+        // --- Parse structured JSON verdict and act ---
+        //
+        // The system prompt requires a single JSON object with
+        // (stated_intent, observed_action, verdict, rationale,
+        // optional steer_message).  Any shape deviation is treated as
+        // a WAIT with a diagnostic rationale so the loop survives a
+        // misbehaving model without skipping safety actions.
+        //
+        // `steer_dispatched` is true only when the parsed STEER was
+        // valid AND the message was actually injected into the pane,
+        // so `last_steer_full` next turn reflects a message claude
+        // really saw.
+        let parsed = parse_supervision_verdict(&response_text, panes);
+        let SupervisionParsed {
+            mut record,
+            display,
+            done_summary,
+            dispatch,
+        } = parsed;
 
-        // --- Parse response and act ---
-        // `steer_dispatched` is true only when the parsed STEER was valid
-        // and actually sent into a pane — so the next turn's carry-over
-        // (`last_steer_full`) reflects a message claude really saw.
-        // Malformed / unknown-pane STEERs leave `last_steer_full` alone.
-        let mut steer_dispatched = false;
-        let verdict_line = if trimmed.starts_with("DONE:") || trimmed == "DONE" {
-            let summary = trimmed.strip_prefix("DONE:").unwrap_or("").trim();
+        if let Some(summary) = done_summary {
+            // Record the DONE verdict before exit so the notebook
+            // reflects the final state.
+            persist_verdict_record(state, panes, &record).await;
             let mut w = writer.lock().await;
             write_frame(
                 &mut *w,
@@ -3031,152 +3584,58 @@ async fn handle_supervision_inner(
             .await?;
             // wrapper writes Response::Done after the resume hint
             return Ok(());
-        } else if let Some(rest) = trimmed.strip_prefix("STEER:") {
-            if let Some((pane_id_raw, message)) = rest.trim().split_once(':') {
-                let pane_id = pane_id_raw.trim().to_owned();
-                let message = message.trim().to_owned();
-                let is_valid_pane = panes.iter().any(|t| t.pane_id == pane_id);
-                if !pane_id.is_empty() && !message.is_empty() && is_valid_pane {
-                    let pid = pane_id.clone();
-                    let msg = message.clone();
-                    // `send_pane_keys` returns `true` only when both the
-                    // text injection and the trailing Enter succeeded at
-                    // tmux.  We also guard against JoinError (panic /
-                    // cancel) by pattern-matching the JoinHandle result.
-                    // Either failure leaves `steer_dispatched = false` so
-                    // next turn does not claim claude received a message
-                    // that never actually arrived.
-                    match tokio::task::spawn_blocking(move || send_pane_keys(&pid, &msg)).await {
-                        Ok(true) => {
-                            steer_dispatched = true;
-                        }
-                        Ok(false) => {
-                            tracing::warn!(
-                                pane_id = %pane_id,
-                                "tmux send-keys reported failure; treating STEER as undelivered"
-                            );
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                pane_id = %pane_id,
-                                error = %e,
-                                "send_pane_keys task failed; treating STEER as undelivered"
-                            );
-                        }
-                    }
-                    // Keep the `STEER: <pane>: <msg>` shape exactly as the
-                    // parser (and system prompt) expect, so when this line
-                    // is echoed back via `verdict_history` / `last_steer_full`
-                    // next turn the LLM is primed with the same grammar it
-                    // must emit.  A `STEER %X: ...` (no colon after STEER)
-                    // would be mis-parsed as WAIT on the next round-trip.
-                    format!("  → STEER: {pane_id}: {message}\n")
-                } else if !pane_id.is_empty() && !message.is_empty() && !is_valid_pane {
-                    format!("  → STEER: {pane_id} (unknown pane, ignored)\n")
-                } else {
-                    "  → STEER: (malformed response)\n".to_string()
+        }
+
+        let mut steer_dispatched = false;
+        if let Some(SteerDispatch { pane_id, message }) = dispatch {
+            let pid = pane_id.clone();
+            let msg = message.clone();
+            match tokio::task::spawn_blocking(move || send_pane_keys(&pid, &msg)).await {
+                Ok(true) => {
+                    steer_dispatched = true;
                 }
-            } else {
-                "  → STEER: (malformed response)\n".to_string()
+                Ok(false) => {
+                    tracing::warn!(
+                        pane_id = %pane_id,
+                        "tmux send-keys reported failure; treating STEER as undelivered"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        pane_id = %pane_id,
+                        error = %e,
+                        "send_pane_keys task failed; treating STEER as undelivered"
+                    );
+                }
             }
-        } else {
-            // WAIT: <note> or bare WAIT
-            let note = trimmed.strip_prefix("WAIT:").unwrap_or("").trim();
-            if note.is_empty() {
-                "  → WAIT\n".to_string()
-            } else {
-                format!("  → WAIT: {note}\n")
+        }
+
+        if !steer_dispatched {
+            // Suppress `steer_message` on the record when the message
+            // wasn't actually delivered so future rounds and the
+            // notebook don't claim Claude saw something it didn't.
+            if record.verdict == tasks::VerdictKind::Steer {
+                record.steer_message = None;
             }
-        };
-        // Remember this verdict (minus the display prefix) so the next
-        // iteration can pass it back into the user prompt.  `verdict_line`
-        // starts with "  → " and ends with "\n"; strip both for a compact
-        // one-line carry-over.
-        let verdict_compact = verdict_line
-            .trim_start_matches("  → ")
-            .trim_end_matches('\n')
-            .to_string();
-        // The verdict_history rendering uses one line per entry; an
-        // embedded `\n` (possible when a STEER message spans multiple
-        // lines — parser doesn't reject them) would break the `[last] …`
-        // / `[N turns ago] …` table shape and push downstream section
-        // headers off column 0.  Escape newlines to a visible `\n` so
-        // the LLM still sees the content but the layout is preserved.
-        let verdict_single_line = verdict_compact.replace('\n', "\\n");
+        }
+
+        // Compact single-line form for the in-session verdict history
+        // ring — preserves the existing prompt layout (one line per
+        // entry, no embedded newlines).
+        let verdict_single_line = record.to_line().replace('\n', "\\n");
         if verdict_history.len() >= VERDICT_HISTORY_LEN {
             verdict_history.pop_front();
         }
         verdict_history.push_back(verdict_single_line.clone());
-        // Only stash the full text when the STEER was actually dispatched.
-        // `steer_dispatched` stays false for "unknown pane, ignored" and
-        // "malformed response" variants so the next turn's prompt does not
-        // claim claude received something it never did.  Use the escaped
-        // single-line form for the same layout-protection reason.
         if steer_dispatched {
             last_steer_full = Some(verdict_single_line);
         }
 
-        // Persist verdict to task notebook (best-effort, once per unique
-        // `(repo_dir, tag)`).  Deduped because multiple panes sharing a
-        // tag (user `--tag foo` for a multi-task launch) would otherwise
-        // append duplicate rows for a single supervision turn.  Failures
-        // (panic OR SQLite Err) are logged but must not break the loop —
-        // notebook is auxiliary to the live verdict decision.
-        let mut verdict_targets: std::collections::HashSet<(String, String)> =
-            std::collections::HashSet::new();
-        for target in panes.iter() {
-            if let (Some(repo_dir), Some(tag)) = (target.repo_dir.as_deref(), target.tag.as_deref())
-            {
-                verdict_targets.insert((repo_dir.to_string(), tag.to_string()));
-            }
-        }
-        for (repo_dir, tag) in verdict_targets {
-            let state_cl = Arc::clone(state);
-            let verdict = verdict_compact.clone();
-            let repo_dir_log = repo_dir.clone();
-            let tag_log = tag.clone();
-            match tokio::task::spawn_blocking(move || -> Result<()> {
-                // Lazy-open the DB if no prior code path did.  Resume-pane
-                // launches skip the tag-acquisition block in
-                // `handle_claude_launch` that normally opens it, so when a
-                // resumed pane produces the first verdict the handle may
-                // still be `None`.  `ensure_tasks_db` is idempotent.
-                ensure_tasks_db(&state_cl)?;
-                let guard = state_cl
-                    .tasks_db
-                    .lock()
-                    .map_err(|e| anyhow::anyhow!("tasks_db mutex poisoned: {e}"))?;
-                let conn = guard
-                    .as_ref()
-                    .ok_or_else(|| anyhow::anyhow!("tasks_db not initialised"))?;
-                tasks::append_verdict(conn, &repo_dir, &tag, &verdict)
-            })
-            .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => tracing::warn!(
-                    error = %e,
-                    repo_dir = %repo_dir_log,
-                    tag = %tag_log,
-                    "failed to persist verdict"
-                ),
-                Err(e) => tracing::warn!(
-                    error = %e,
-                    repo_dir = %repo_dir_log,
-                    tag = %tag_log,
-                    "verdict persist task panicked"
-                ),
-            }
-        }
+        // Persist structured verdict to task notebook (best-effort).
+        persist_verdict_record(state, panes, &record).await;
 
         let mut w = writer.lock().await;
-        write_frame(
-            &mut *w,
-            &Response::Text {
-                chunk: verdict_line,
-            },
-        )
-        .await?;
+        write_frame(&mut *w, &Response::Text { chunk: display }).await?;
     }
 }
 
@@ -8575,6 +9034,7 @@ mod tests {
             &task_lines,
             "",
             "",
+            "",
             &history,
             None,
             "=== Pane %5 ===\nidle\n",
@@ -8596,6 +9056,292 @@ mod tests {
     }
 
     #[test]
+    fn event_stream_history_folds_identical_wait_runs() {
+        let mk_wait = |intent: &str, obs: &str| tasks::VerdictRecord {
+            stated_intent: intent.into(),
+            observed_action: obs.into(),
+            verdict: tasks::VerdictKind::Wait,
+            rationale: "still reading".into(),
+            steer_message: None,
+            timestamp: 0,
+        };
+        let records = vec![
+            mk_wait("reading auth.rs", ""),
+            mk_wait("reading auth.rs", ""),
+            mk_wait("reading auth.rs", ""),
+            mk_wait("running tests", "touched auth_test.rs"),
+            mk_wait("running tests", "touched auth_test.rs"),
+        ];
+        let rendered = render_event_stream_history(&records);
+        // Three identical WAITs collapse to one `[3 ticks] sustained …`.
+        assert!(
+            rendered.contains("[3 ticks] sustained WAIT: reading auth.rs"),
+            "first run must fold: got {rendered:?}"
+        );
+        // New signature gets its own fold.
+        assert!(
+            rendered.contains("[2 ticks] sustained WAIT: running tests"),
+            "second run must fold: got {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn event_stream_history_keeps_steer_verbatim() {
+        let records = vec![
+            tasks::VerdictRecord {
+                stated_intent: "idle".into(),
+                observed_action: "".into(),
+                verdict: tasks::VerdictKind::Wait,
+                rationale: "r".into(),
+                steer_message: None,
+                timestamp: 0,
+            },
+            tasks::VerdictRecord {
+                stated_intent: "reading x".into(),
+                observed_action: "modified y".into(),
+                verdict: tasks::VerdictKind::Steer,
+                rationale: "drift".into(),
+                steer_message: Some("return to x".into()),
+                timestamp: 0,
+            },
+            tasks::VerdictRecord {
+                stated_intent: "idle again".into(),
+                observed_action: "".into(),
+                verdict: tasks::VerdictKind::Wait,
+                rationale: "r2".into(),
+                steer_message: None,
+                timestamp: 0,
+            },
+        ];
+        let rendered = render_event_stream_history(&records);
+        assert!(
+            rendered.contains("STEER: return to x"),
+            "STEER must appear verbatim, got {rendered:?}"
+        );
+        // The WAIT before and after must each survive (different signatures).
+        assert!(rendered.contains("WAIT: r"));
+        assert!(rendered.contains("WAIT: r2"));
+    }
+
+    #[test]
+    fn event_stream_history_keeps_changed_wait_signatures() {
+        let mk_wait = |intent: &str, obs: &str, rationale: &str| tasks::VerdictRecord {
+            stated_intent: intent.into(),
+            observed_action: obs.into(),
+            verdict: tasks::VerdictKind::Wait,
+            rationale: rationale.into(),
+            steer_message: None,
+            timestamp: 0,
+        };
+        // observed_action changes every round → every WAIT is a new event.
+        let records = vec![
+            mk_wait("exploring", "touched a.rs", "r1"),
+            mk_wait("exploring", "touched a.rs, b.rs", "r2"),
+            mk_wait("exploring", "touched a.rs, b.rs, c.rs", "r3"),
+        ];
+        let rendered = render_event_stream_history(&records);
+        // No folding marker.
+        assert!(!rendered.contains("sustained WAIT"));
+        // All three rationales appear verbatim, oldest first.
+        let i1 = rendered.find("WAIT: r1").expect("r1 missing");
+        let i2 = rendered.find("WAIT: r2").expect("r2 missing");
+        let i3 = rendered.find("WAIT: r3").expect("r3 missing");
+        assert!(i1 < i2 && i2 < i3, "must be oldest-first");
+    }
+
+    #[test]
+    fn parse_supervision_verdict_wait_happy_path() {
+        let raw = r#"{
+            "stated_intent": "reading src/auth.rs",
+            "observed_action": "no diff yet — only file reads",
+            "verdict": "WAIT",
+            "rationale": "Claude is investigating the right area"
+        }"#;
+        let panes = vec![crate::ipc::SupervisionTarget {
+            pane_id: "%5".into(),
+            task_description: "fix flaky auth test".into(),
+            tag: None,
+            repo_dir: None,
+        }];
+        let out = parse_supervision_verdict(raw, &panes);
+        assert_eq!(out.record.verdict, tasks::VerdictKind::Wait);
+        assert_eq!(out.record.stated_intent, "reading src/auth.rs");
+        assert!(out.dispatch.is_none());
+        assert!(out.done_summary.is_none());
+        assert!(out.display.contains("WAIT"));
+    }
+
+    #[test]
+    fn parse_supervision_verdict_steer_dispatches_to_pane() {
+        let raw = r#"{
+            "stated_intent": "reading src/auth.rs",
+            "observed_action": "modified src/daemon.rs (+12 -3)",
+            "verdict": "STEER",
+            "rationale": "touched file outside scope",
+            "steer_message": "stop — you said A, modified daemon.rs instead"
+        }"#;
+        let panes = vec![crate::ipc::SupervisionTarget {
+            pane_id: "%5".into(),
+            task_description: "t".into(),
+            tag: None,
+            repo_dir: None,
+        }];
+        let out = parse_supervision_verdict(raw, &panes);
+        assert_eq!(out.record.verdict, tasks::VerdictKind::Steer);
+        let d = out.dispatch.expect("STEER must dispatch");
+        assert_eq!(d.pane_id, "%5");
+        assert!(d.message.contains("modified daemon.rs"));
+    }
+
+    #[test]
+    fn parse_supervision_verdict_steer_without_message_downgrades_to_wait() {
+        let raw = r#"{"verdict":"STEER","rationale":""}"#;
+        let panes = vec![crate::ipc::SupervisionTarget {
+            pane_id: "%5".into(),
+            task_description: "t".into(),
+            tag: None,
+            repo_dir: None,
+        }];
+        let out = parse_supervision_verdict(raw, &panes);
+        assert_eq!(out.record.verdict, tasks::VerdictKind::Wait);
+        assert!(out.dispatch.is_none());
+        assert!(out.record.rationale.contains("malformed STEER"));
+    }
+
+    #[test]
+    fn parse_supervision_verdict_done_carries_rationale_as_summary() {
+        let raw = r#"{
+            "stated_intent": "",
+            "observed_action": "",
+            "verdict": "DONE",
+            "rationale": "task complete: flaky test fixed, passing now"
+        }"#;
+        let panes = vec![crate::ipc::SupervisionTarget {
+            pane_id: "%5".into(),
+            task_description: "t".into(),
+            tag: None,
+            repo_dir: None,
+        }];
+        let out = parse_supervision_verdict(raw, &panes);
+        assert_eq!(out.record.verdict, tasks::VerdictKind::Done);
+        let summary = out.done_summary.expect("DONE must carry summary");
+        assert!(summary.contains("flaky test fixed"));
+    }
+
+    #[test]
+    fn parse_supervision_verdict_unparseable_becomes_wait_with_raw_in_rationale() {
+        let raw = "I am confused and will just say hi.";
+        let panes: Vec<crate::ipc::SupervisionTarget> = Vec::new();
+        let out = parse_supervision_verdict(raw, &panes);
+        assert_eq!(out.record.verdict, tasks::VerdictKind::Wait);
+        assert!(out.record.rationale.contains("unparseable"));
+        assert!(out.dispatch.is_none());
+    }
+
+    #[test]
+    fn parse_supervision_verdict_strips_code_fence_wrapper() {
+        let raw = "```json\n{\"verdict\":\"WAIT\",\"rationale\":\"ok\"}\n```";
+        let panes: Vec<crate::ipc::SupervisionTarget> = Vec::new();
+        let out = parse_supervision_verdict(raw, &panes);
+        assert_eq!(out.record.verdict, tasks::VerdictKind::Wait);
+        assert_eq!(out.record.rationale, "ok");
+    }
+
+    #[test]
+    fn supervision_prompt_renders_git_evidence_when_non_empty() {
+        let task_lines = vec![("%5".to_string(), "implement feature".to_string())];
+        let history: std::collections::VecDeque<String> = std::collections::VecDeque::new();
+        let evidence = "── Filesystem ground truth — pane %5 ──\n\
+                        git status --short:\n   M src/daemon.rs\n";
+        let out = build_supervision_user_content(
+            &task_lines,
+            "",
+            "",
+            evidence,
+            &history,
+            None,
+            "snap",
+            1,
+            0,
+        );
+        assert!(
+            out.contains("Filesystem ground truth — pane %5"),
+            "evidence block must appear in prompt, got: {out:?}"
+        );
+        assert!(
+            out.contains(" M src/daemon.rs"),
+            "touched files must appear verbatim, got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn supervision_prompt_omits_git_evidence_when_empty() {
+        let task_lines = vec![("%5".to_string(), "task".to_string())];
+        let history: std::collections::VecDeque<String> = std::collections::VecDeque::new();
+        let out =
+            build_supervision_user_content(&task_lines, "", "", "", &history, None, "snap", 1, 0);
+        assert!(
+            !out.contains("Filesystem ground truth"),
+            "no evidence → no header, got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn git_evidence_captures_diff_and_status_in_real_worktree() {
+        // Stand up a throwaway git repo, commit one file, modify it, and
+        // confirm capture_git_evidence surfaces the change via status +
+        // diff.  Skipped in sandboxed environments where `git` is not
+        // executable.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let wt = dir.path().to_owned();
+
+        let init = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&wt)
+            .status();
+        if !matches!(init, Ok(s) if s.success()) {
+            eprintln!("git unavailable; skipping git_evidence test");
+            return;
+        }
+        // Quiet commits in sandboxes without a user configured.
+        let _ = std::process::Command::new("git")
+            .args(["-c", "user.email=t@t", "-c", "user.name=t"])
+            .args(["commit", "--allow-empty", "-m", "root"])
+            .current_dir(&wt)
+            .status();
+
+        let file = wt.join("foo.txt");
+        std::fs::write(&file, "hello\n").unwrap();
+        let _ = std::process::Command::new("git")
+            .args(["add", "foo.txt"])
+            .current_dir(&wt)
+            .status();
+        let _ = std::process::Command::new("git")
+            .args(["-c", "user.email=t@t", "-c", "user.name=t"])
+            .args(["commit", "-q", "-m", "add foo"])
+            .current_dir(&wt)
+            .status();
+
+        // Unstaged modification — must show up in both status and diff.
+        std::fs::write(&file, "hello world\n").unwrap();
+
+        let evidence = capture_git_evidence(wt.to_str().unwrap());
+        assert!(
+            evidence.status.contains("foo.txt"),
+            "status must mention modified file, got: {evidence:?}"
+        );
+        assert!(
+            evidence.patch.contains("hello world"),
+            "diff must contain added line, got: {evidence:?}"
+        );
+        assert!(!evidence.truncated, "small diff shouldn't truncate");
+
+        let rendered = render_git_evidence("%9", &evidence);
+        assert!(rendered.contains("── Filesystem ground truth — pane %9 ──"));
+        assert!(rendered.contains("foo.txt"));
+    }
+
+    #[test]
     fn supervision_prompt_verdict_history_renders_multiple_lines() {
         let task_lines = vec![("%5".to_string(), "task".to_string())];
         let mut history = std::collections::VecDeque::new();
@@ -8605,7 +9351,8 @@ mod tests {
         // verdict format or parser prefix diverge.
         history.push_back("STEER: %5: use sim-9900".to_string());
         history.push_back("WAIT: now on sim-9900".to_string());
-        let out = build_supervision_user_content(&task_lines, "", "", &history, None, "snap", 4, 3);
+        let out =
+            build_supervision_user_content(&task_lines, "", "", "", &history, None, "snap", 4, 3);
         assert!(
             out.contains("[last] WAIT: now on sim-9900"),
             "newest verdict must be labelled [last], got: {out:?}"
@@ -8630,6 +9377,7 @@ mod tests {
                      task says sim-9900; rerun with the correct port";
         let out = build_supervision_user_content(
             &task_lines,
+            "",
             "",
             "",
             &history,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2068,18 +2068,48 @@ struct GitEvidence {
 /// [`GitEvidence::truncated`] flag is set so the supervisor knows.
 const MAX_GIT_EVIDENCE_BYTES: usize = 50 * 1024;
 
+/// Wall-clock ceiling on each individual `git` invocation inside
+/// [`capture_git_evidence`].  A hung filesystem (stalled NFS, index
+/// lock never released) would otherwise block the supervision loop
+/// indefinitely.  3 s is generous: even a cold `git diff HEAD` on a
+/// reasonably sized repo returns in well under a second.
+const GIT_EVIDENCE_CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
 /// Run `git diff` and `git status --short` in `worktree` and assemble a
-/// [`GitEvidence`] snapshot.  Each git invocation is capped at 3 s so a
-/// hung filesystem cannot stall the supervision loop.
+/// [`GitEvidence`] snapshot.  Each git invocation is capped at
+/// [`GIT_EVIDENCE_CALL_TIMEOUT`] so a hung filesystem cannot stall the
+/// supervision loop; on timeout the child process is killed and the
+/// field is left empty.
 ///
-/// Call from `spawn_blocking` — the git calls are synchronous.
-fn capture_git_evidence(worktree: &str) -> GitEvidence {
-    fn run(worktree: &str, args: &[&str]) -> Option<String> {
-        let out = std::process::Command::new("git")
-            .args(["-C", worktree])
-            .args(args)
-            .output()
-            .ok()?;
+/// The post-capture `cap()` step bounds every field to
+/// [`MAX_GIT_EVIDENCE_BYTES`] for prompt-size purposes, but git can in
+/// principle fill memory with megabytes of diff before `output()`
+/// returns — the timeout is the real backstop on runaway output.
+async fn capture_git_evidence(worktree: String) -> GitEvidence {
+    async fn run(worktree: &str, args: &[&str]) -> Option<String> {
+        let mut cmd = tokio::process::Command::new("git");
+        cmd.args(["-C", worktree]).args(args).kill_on_drop(true);
+
+        let child_fut = cmd.output();
+        let out = match tokio::time::timeout(GIT_EVIDENCE_CALL_TIMEOUT, child_fut).await {
+            Ok(Ok(out)) => out,
+            Ok(Err(e)) => {
+                tracing::debug!(worktree, args = ?args, error = %e, "git evidence spawn failed");
+                return None;
+            }
+            Err(_) => {
+                // `kill_on_drop` terminates the child when the future is
+                // dropped, which happens as we fall out of this block.
+                tracing::warn!(
+                    worktree,
+                    args = ?args,
+                    timeout_ms = GIT_EVIDENCE_CALL_TIMEOUT.as_millis(),
+                    "git evidence call timed out; killing child"
+                );
+                return None;
+            }
+        };
+
         if !out.status.success() {
             tracing::debug!(
                 worktree,
@@ -2109,13 +2139,16 @@ fn capture_git_evidence(worktree: &str) -> GitEvidence {
 
     let mut truncated = false;
     GitEvidence {
-        stat: run(worktree, &["diff", "--stat", "HEAD"])
+        stat: run(&worktree, &["diff", "--stat", "HEAD"])
+            .await
             .map(|s| cap(s, &mut truncated))
             .unwrap_or_default(),
-        patch: run(worktree, &["diff", "HEAD"])
+        patch: run(&worktree, &["diff", "HEAD"])
+            .await
             .map(|s| cap(s, &mut truncated))
             .unwrap_or_default(),
-        status: run(worktree, &["status", "--short"])
+        status: run(&worktree, &["status", "--short"])
+            .await
             .map(|s| cap(s, &mut truncated))
             .unwrap_or_default(),
         truncated,
@@ -2196,8 +2229,8 @@ async fn collect_git_evidence(panes: &[crate::ipc::SupervisionTarget]) -> String
             continue;
         };
         let pane_id = target.pane_id.clone();
-        tasks.push(tokio::task::spawn_blocking(move || {
-            let evidence = capture_git_evidence(&worktree);
+        tasks.push(tokio::spawn(async move {
+            let evidence = capture_git_evidence(worktree).await;
             (pane_id, evidence)
         }));
     }
@@ -2694,7 +2727,17 @@ async fn build_notebook_context(
 
             let latest = tasks::latest_desc(conn, repo_dir, tag)?
                 .unwrap_or_else(|| "(none recorded)".to_string());
-            let all = tasks::all_verdict_records(conn, repo_dir, tag)?;
+            // Bound per-tick work: load only verdicts from the last
+            // supervision-lease TTL (24 h).  Older rows have already
+            // informed prior verdicts and don't need to be re-folded
+            // every tick.  Without this, a tag that has been running
+            // for days would re-read a growing SQLite result set on
+            // every supervision call.
+            let since_ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64 - crate::pane_lease::LEASE_TTL_SECS as i64)
+                .unwrap_or(0);
+            let all = tasks::all_verdict_records(conn, repo_dir, tag, since_ts)?;
             let rendered = render_event_stream_history(&all);
 
             out.push_str(&format!("=== Task notebook for tag '{tag}' ===\n"));
@@ -2860,13 +2903,17 @@ struct SteerDispatch {
 /// - JSON wrapped in ``` code fences (some models add them despite the
 ///   instruction).
 /// - Extra whitespace and trailing prose before/after the object.
-/// - Unknown / missing fields (default via serde).
+/// - Missing optional fields — every [`tasks::VerdictRecord`] field
+///   except `verdict` has `#[serde(default)]`.  `verdict` itself is
+///   required, and its absence makes the object unparseable (see
+///   below).
 ///
-/// A completely unparseable response produces a WAIT-style record with
-/// the raw text captured in `rationale`, so the loop never stalls on
-/// model misbehaviour.  A STEER naming an unknown pane is downgraded
-/// to WAIT with `rationale` explaining the pane mismatch — same policy
-/// as the legacy string-format parser.
+/// A completely unparseable response (including one with `verdict`
+/// missing) produces a WAIT-style record with the raw text captured
+/// in `rationale`, so the loop never stalls on model misbehaviour.
+/// A STEER naming an unknown pane is downgraded to WAIT with
+/// `rationale` explaining the pane mismatch — same policy as the
+/// legacy string-format parser.
 fn parse_supervision_verdict(
     raw: &str,
     panes: &[crate::ipc::SupervisionTarget],
@@ -2933,12 +2980,22 @@ fn parse_supervision_verdict(
                     }
                 });
 
-            // Pick the pane to steer: if only one pane is supervised,
-            // target it unconditionally.  When multiple panes are
-            // supervised, the model should include the pane id inside
-            // `steer_message` as a hint; we currently just pick the
-            // first, matching pre-rework behavior for the common
-            // single-pane case.
+            // Pick the pane to steer.  In practice `/claude` runs
+            // single-pane supervision, so `panes.first()` is correct
+            // for every production caller today.  A future multi-pane
+            // PR will need a dedicated `pane_id` field in the verdict
+            // JSON contract (and `SUPERVISION_VERDICT_SCHEMA` updated
+            // to match) so the supervisor can disambiguate — until
+            // that lands, warn so multi-pane sessions leave a visible
+            // breadcrumb in the logs instead of silently steering the
+            // wrong pane.
+            if panes.len() > 1 {
+                tracing::warn!(
+                    pane_count = panes.len(),
+                    "multi-pane STEER not yet supported; targeting panes[0] — \
+                     the other panes will not receive this message"
+                );
+            }
             let pane_id = panes.first().map(|p| p.pane_id.clone());
 
             match (pane_id, message) {
@@ -9696,8 +9753,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn git_evidence_captures_diff_and_status_in_real_worktree() {
+    #[tokio::test]
+    async fn git_evidence_captures_diff_and_status_in_real_worktree() {
         // Stand up a throwaway git repo, commit one file, modify it, and
         // confirm capture_git_evidence surfaces the change via status +
         // diff.  Skipped in sandboxed environments where `git` is not
@@ -9735,7 +9792,7 @@ mod tests {
         // Unstaged modification — must show up in both status and diff.
         std::fs::write(&file, "hello world\n").unwrap();
 
-        let evidence = capture_git_evidence(wt.to_str().unwrap());
+        let evidence = capture_git_evidence(wt.to_str().unwrap().to_owned()).await;
         assert!(
             evidence.status.contains("foo.txt"),
             "status must mention modified file, got: {evidence:?}"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2754,8 +2754,23 @@ const SUPERVISION_SYSTEM_PROMPT: &str = concat!(
     "    \"observed_action\": \"<one sentence — what changed on disk this turn, per the git evidence?>\",\n",
     "    \"verdict\":         \"WAIT\" | \"STEER\" | \"DONE\",\n",
     "    \"rationale\":       \"<one sentence — why this verdict?>\",\n",
-    "    \"steer_message\":   \"<only present when verdict=STEER: the message to send to the pane; must name the drift concretely>\"\n",
+    "    \"steer_message\":   \"<only present when verdict=STEER: the message to send to the pane; must name the drift concretely>\",\n",
+    "    \"claude_responded_to_last_steer\": true | false | null\n",
     "  }\n",
+    "\n",
+    "Field guide for `claude_responded_to_last_steer` (drives the hard-boundary escalation):\n",
+    "  - `true`  — Claude engaged with the most recent STEER: adjusted approach,\n",
+    "              moved to the requested area, answered the question, or is visibly\n",
+    "              reasoning about the correction.  Pane thinking / reading counts\n",
+    "              as responded — Claude does not need to have edited files yet.\n",
+    "  - `false` — Claude ignored the STEER, continued the prior drift, or pretended\n",
+    "              not to see it.  Three consecutive `false` values trigger a hard\n",
+    "              interrupt (ESC + forced message), so be honest: do not set `false`\n",
+    "              merely because Claude's response is slow.\n",
+    "  - `null`  — No prior STEER in this session, or the recent history is\n",
+    "              WAIT/DONE only.  Use on the first turn.\n",
+    "  Judge from BOTH the pane (thinking / reading / tool calls) and the git diff.\n",
+    "\n",
     "\n",
     "Verdict rules:\n",
     "\n",
@@ -2850,6 +2865,7 @@ fn parse_supervision_verdict(
                 raw.trim().chars().take(200).collect::<String>()
             ),
             steer_message: None,
+            claude_responded_to_last_steer: None,
             timestamp: 0,
         };
         return SupervisionParsed {
@@ -2928,6 +2944,7 @@ fn parse_supervision_verdict(
                         verdict: tasks::VerdictKind::Wait,
                         rationale,
                         steer_message: None,
+                        claude_responded_to_last_steer: None,
                         timestamp: 0,
                     };
                     SupervisionParsed {
@@ -3300,6 +3317,30 @@ async fn handle_supervision_inner(
     // Claude acted on it.  None until the first STEER is emitted.
     let mut last_steer_full: Option<String> = None;
 
+    // Hard-boundary escalation: a soft STEER message only works if
+    // Claude actually reads it.  When Claude ignores K consecutive
+    // STEERs (judged by `claude_responded_to_last_steer` on each
+    // turn's structured verdict), we send an ESC to interrupt the
+    // current tool call and inject a forced-scope message.
+    //
+    // K is a compile-time constant on purpose: the right value
+    // depends on how the supervisor LLM calibrates "responded" and is
+    // a tuning knob rather than an operator-facing parameter.  Change
+    // this and rebuild.
+    const SUPERVISION_DRIFT_BLOCK_K: u32 = 3;
+    // Rolling count of consecutive STEER verdicts where the
+    // supervisor reported `claude_responded_to_last_steer = false`.
+    // Reset on any non-STEER verdict, on a STEER the supervisor
+    // marked `= true`, and after a hard-boundary fires.
+    let mut unresponsive_steer_count: u32 = 0;
+    // Most recent steer_message texts (after successful dispatch) so
+    // a triggered hard-boundary can echo them back to Claude verbatim
+    // — helps Claude understand which instruction it has been
+    // ignoring.  Bounded to K so we always include exactly the run
+    // that triggered the escalation.
+    let mut recent_steer_messages: std::collections::VecDeque<String> =
+        std::collections::VecDeque::with_capacity(SUPERVISION_DRIFT_BLOCK_K as usize);
+
     // Load skill files (SOUL.md, AGENTS.md, GPU_KERNEL.md) once and reuse
     // across all supervision turns so the LLM has project context for
     // higher-quality STEER decisions.
@@ -3631,12 +3672,185 @@ async fn handle_supervision_inner(
             last_steer_full = Some(verdict_single_line);
         }
 
+        // --- Hard-boundary escalation counter ---
+        //
+        // Bookkeeping runs on every verdict so non-STEER rounds reset
+        // the counter, preventing a scattered history like
+        // WAIT/STEER-ignored/WAIT/STEER-ignored/WAIT/STEER-ignored
+        // from tripping the boundary — only a run of CONSECUTIVE
+        // unresponsive STEERs counts.  Delegated to `update_drift_counter`
+        // so the rule is unit-testable.
+        update_drift_counter(
+            &mut unresponsive_steer_count,
+            &mut recent_steer_messages,
+            &record,
+            steer_dispatched,
+            SUPERVISION_DRIFT_BLOCK_K,
+        );
+
         // Persist structured verdict to task notebook (best-effort).
         persist_verdict_record(state, panes, &record).await;
 
-        let mut w = writer.lock().await;
-        write_frame(&mut *w, &Response::Text { chunk: display }).await?;
+        // Print the soft verdict line before any hard-boundary follow-up
+        // so the user-visible chat stream stays in turn order.
+        {
+            let mut w = writer.lock().await;
+            write_frame(&mut *w, &Response::Text { chunk: display }).await?;
+        }
+
+        // --- Trigger: K consecutive unresponsive STEERs ---
+        if unresponsive_steer_count >= SUPERVISION_DRIFT_BLOCK_K {
+            // The first supervised pane is the steering target by
+            // convention — same rule `parse_supervision_verdict` uses
+            // when mapping a STEER verdict to a pane.
+            if let Some(target) = panes.first() {
+                let pane_id = target.pane_id.clone();
+                let desc = target.task_description.clone();
+                let recent: Vec<String> = recent_steer_messages.iter().cloned().collect();
+                trigger_hard_boundary(writer, &pane_id, &desc, &recent).await?;
+
+                // Record a dedicated notebook row so the escalation is
+                // visible in prior-session history on the next run.
+                let hb_record = tasks::VerdictRecord {
+                    stated_intent: record.stated_intent.clone(),
+                    observed_action: record.observed_action.clone(),
+                    verdict: tasks::VerdictKind::Steer,
+                    rationale: format!(
+                        "HARD_BOUNDARY: K={SUPERVISION_DRIFT_BLOCK_K} drift escalation — \
+                         sent ESC + forced message into pane {pane_id}"
+                    ),
+                    steer_message: None,
+                    claude_responded_to_last_steer: None,
+                    timestamp: 0,
+                };
+                persist_verdict_record(state, panes, &hb_record).await;
+            } else {
+                tracing::warn!(
+                    "hard-boundary K reached but no pane to steer; skipping ESC + forced message"
+                );
+            }
+
+            // Reset state so the next tick starts a fresh count.  The
+            // injected forced message is itself a STEER; if Claude
+            // still ignores it we want the counter to re-accumulate
+            // from zero, not trip again on the very next turn.
+            unresponsive_steer_count = 0;
+            recent_steer_messages.clear();
+        }
     }
+}
+
+/// Update the hard-boundary escalation state for one verdict.
+///
+/// Pure function, extracted from `handle_supervision_inner` so the
+/// counter rules can be unit-tested without standing up a full loop.
+///
+/// Rules:
+/// - An unresponsive STEER (verdict=Steer AND dispatched=true AND
+///   `claude_responded_to_last_steer=Some(false)`) increments the
+///   counter and pushes the steer_message onto the FIFO of quoted
+///   messages (bounded to K entries).
+/// - Any other outcome — non-STEER verdict, responded=true, undelivered
+///   STEER — resets both counter and FIFO to zero.
+///
+/// Returns the new counter value so callers can compare against K.
+fn update_drift_counter(
+    counter: &mut u32,
+    recent_steer_messages: &mut std::collections::VecDeque<String>,
+    record: &tasks::VerdictRecord,
+    steer_dispatched: bool,
+    k: u32,
+) -> u32 {
+    let unresponsive = matches!(record.verdict, tasks::VerdictKind::Steer)
+        && steer_dispatched
+        && record.claude_responded_to_last_steer == Some(false);
+    if unresponsive {
+        *counter += 1;
+        if let Some(msg) = record.steer_message.as_deref() {
+            if recent_steer_messages.len() >= k as usize {
+                recent_steer_messages.pop_front();
+            }
+            recent_steer_messages.push_back(msg.to_string());
+        }
+    } else {
+        *counter = 0;
+        recent_steer_messages.clear();
+    }
+    *counter
+}
+
+/// Escape sequence sent to tmux to interrupt Claude's current tool call.
+/// Claude's TUI interprets a bare ESC as "cancel the active action"
+/// without exiting the process — the right tool for an escalation that
+/// still wants the conversation to continue afterward.
+const HARD_BOUNDARY_ESC: &str = "\x1b";
+
+/// Send ESC to the pane to interrupt the current tool call, then
+/// inject a forced-scope message that quotes the ignored STEERs and
+/// re-states the task.  Best-effort: a tmux failure is logged but does
+/// not propagate (the loop proceeds; the next tick may trigger again
+/// and retry).
+///
+/// `recent_steers` is the list of STEER messages that went
+/// unacknowledged (up to K entries, oldest first).  An empty slice is
+/// valid and simply omits the quoted-steer block.
+async fn trigger_hard_boundary(
+    writer: &Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    pane_id: &str,
+    desc: &str,
+    recent_steers: &[String],
+) -> Result<()> {
+    // 1. Surface the escalation to the chat stream before dispatching
+    //    so the user sees why an ESC landed in the pane.
+    {
+        let mut w = writer.lock().await;
+        write_frame(
+            &mut *w,
+            &Response::Text {
+                chunk: format!(
+                    "  → HARD BOUNDARY: Claude ignored {n} consecutive STEERs; \
+                     sending ESC + forced message to pane {pane_id}\n",
+                    n = recent_steers.len(),
+                ),
+            },
+        )
+        .await?;
+    }
+
+    // 2. ESC to interrupt the current tool call.  `send_pane_keys`
+    //    presses Enter after the keystrokes, which flushes any
+    //    prompt/command buffer Claude may have accumulated.
+    let pid_esc = pane_id.to_string();
+    if let Err(e) =
+        tokio::task::spawn_blocking(move || send_pane_keys(&pid_esc, HARD_BOUNDARY_ESC)).await
+    {
+        tracing::warn!(pane_id, error = %e, "hard-boundary ESC dispatch failed");
+    }
+
+    // 3. Forced message.  Quotes the ignored STEERs verbatim so Claude
+    //    sees the exact guidance it has been declining to follow.
+    let mut forced = String::from(
+        "Stop.  You have ignored the supervisor repeatedly.  Return to the original task.\n\n",
+    );
+    forced.push_str("Original task: ");
+    forced.push_str(desc.trim());
+    forced.push_str("\n\n");
+    if !recent_steers.is_empty() {
+        forced.push_str("Recent steering you did not act on:\n");
+        for s in recent_steers {
+            forced.push_str("  - ");
+            forced.push_str(s.trim());
+            forced.push('\n');
+        }
+    }
+    forced.push_str("\nRe-read the task above and resume work on it now.");
+
+    let pid_msg = pane_id.to_string();
+    if let Err(e) = tokio::task::spawn_blocking(move || send_pane_keys(&pid_msg, &forced)).await {
+        tracing::warn!(pane_id, error = %e, "hard-boundary forced-message dispatch failed");
+    }
+
+    Ok(())
 }
 
 /// Create a git worktree at `~/.amaebi/worktrees/<repo-name>/<tag>-<uuid8>`
@@ -9055,6 +9269,130 @@ mod tests {
         );
     }
 
+    // ── hard boundary (K consecutive unresponsive STEERs) ────────────────
+
+    fn mk_steer(responded: Option<bool>, msg: &str) -> tasks::VerdictRecord {
+        tasks::VerdictRecord {
+            stated_intent: "".into(),
+            observed_action: "".into(),
+            verdict: tasks::VerdictKind::Steer,
+            rationale: "drift".into(),
+            steer_message: Some(msg.into()),
+            claude_responded_to_last_steer: responded,
+            timestamp: 0,
+        }
+    }
+
+    fn mk_wait() -> tasks::VerdictRecord {
+        tasks::VerdictRecord {
+            stated_intent: "".into(),
+            observed_action: "".into(),
+            verdict: tasks::VerdictKind::Wait,
+            rationale: "ok".into(),
+            steer_message: None,
+            claude_responded_to_last_steer: None,
+            timestamp: 0,
+        }
+    }
+
+    #[test]
+    fn drift_counter_increments_on_unresponsive_steer() {
+        let mut counter = 0u32;
+        let mut buf = std::collections::VecDeque::new();
+        let r1 = mk_steer(Some(false), "s1");
+        let n = update_drift_counter(&mut counter, &mut buf, &r1, true, 3);
+        assert_eq!(n, 1);
+        let r2 = mk_steer(Some(false), "s2");
+        let n = update_drift_counter(&mut counter, &mut buf, &r2, true, 3);
+        assert_eq!(n, 2);
+        let r3 = mk_steer(Some(false), "s3");
+        let n = update_drift_counter(&mut counter, &mut buf, &r3, true, 3);
+        assert_eq!(n, 3);
+        // FIFO keeps every steer in the run up to K.
+        assert_eq!(buf.len(), 3);
+        assert_eq!(buf[0], "s1");
+        assert_eq!(buf[2], "s3");
+    }
+
+    #[test]
+    fn drift_counter_resets_on_wait() {
+        let mut counter = 2u32;
+        let mut buf = std::collections::VecDeque::from(vec!["s1".to_string(), "s2".into()]);
+        let n = update_drift_counter(&mut counter, &mut buf, &mk_wait(), false, 3);
+        assert_eq!(n, 0);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn drift_counter_resets_on_responded_steer() {
+        let mut counter = 2u32;
+        let mut buf = std::collections::VecDeque::from(vec!["s1".to_string(), "s2".into()]);
+        let rec = mk_steer(Some(true), "s3");
+        let n = update_drift_counter(&mut counter, &mut buf, &rec, true, 3);
+        assert_eq!(n, 0, "responded=true must reset the counter");
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn drift_counter_resets_on_undelivered_steer() {
+        // Even if the verdict is STEER and the LLM marked the last
+        // STEER as ignored, an undelivered dispatch this turn means
+        // we can't blame Claude — counter resets.
+        let mut counter = 1u32;
+        let mut buf = std::collections::VecDeque::from(vec!["s1".to_string()]);
+        let rec = mk_steer(Some(false), "s2");
+        let n = update_drift_counter(&mut counter, &mut buf, &rec, false, 3);
+        assert_eq!(n, 0, "undelivered STEER must reset, not extend, the count");
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn drift_counter_fifo_bounded_to_k() {
+        // With K=3, pushing a 4th unresponsive STEER must evict the oldest.
+        let mut counter = 0u32;
+        let mut buf = std::collections::VecDeque::new();
+        for tag in ["s1", "s2", "s3", "s4"] {
+            update_drift_counter(&mut counter, &mut buf, &mk_steer(Some(false), tag), true, 3);
+        }
+        assert_eq!(counter, 4);
+        assert_eq!(buf.len(), 3);
+        assert_eq!(buf[0], "s2"); // s1 evicted
+        assert_eq!(buf[2], "s4");
+    }
+
+    #[test]
+    fn drift_counter_null_responded_does_not_increment() {
+        // `None` (null on the wire) means "no prior STEER to judge" — must
+        // not be counted as unresponsive.
+        let mut counter = 0u32;
+        let mut buf = std::collections::VecDeque::new();
+        let rec = mk_steer(None, "s1");
+        let n = update_drift_counter(&mut counter, &mut buf, &rec, true, 3);
+        assert_eq!(n, 0);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn drift_counter_mixed_run_does_not_trip() {
+        // Scattered unresponsive STEERs separated by WAIT should NEVER
+        // accumulate enough to trip — only a CONSECUTIVE run counts.
+        let mut counter = 0u32;
+        let mut buf = std::collections::VecDeque::new();
+        let seq = [
+            (mk_steer(Some(false), "s1"), true),
+            (mk_wait(), false),
+            (mk_steer(Some(false), "s2"), true),
+            (mk_wait(), false),
+            (mk_steer(Some(false), "s3"), true),
+        ];
+        let mut max_seen = 0u32;
+        for (rec, dispatched) in &seq {
+            let n = update_drift_counter(&mut counter, &mut buf, rec, *dispatched, 3);
+            max_seen = max_seen.max(n);
+        }
+        assert_eq!(max_seen, 1, "WAIT in between should reset each time");
+    }
+
     #[test]
     fn event_stream_history_folds_identical_wait_runs() {
         let mk_wait = |intent: &str, obs: &str| tasks::VerdictRecord {
@@ -9063,6 +9401,7 @@ mod tests {
             verdict: tasks::VerdictKind::Wait,
             rationale: "still reading".into(),
             steer_message: None,
+            claude_responded_to_last_steer: None,
             timestamp: 0,
         };
         let records = vec![
@@ -9094,6 +9433,7 @@ mod tests {
                 verdict: tasks::VerdictKind::Wait,
                 rationale: "r".into(),
                 steer_message: None,
+                claude_responded_to_last_steer: None,
                 timestamp: 0,
             },
             tasks::VerdictRecord {
@@ -9102,6 +9442,7 @@ mod tests {
                 verdict: tasks::VerdictKind::Steer,
                 rationale: "drift".into(),
                 steer_message: Some("return to x".into()),
+                claude_responded_to_last_steer: None,
                 timestamp: 0,
             },
             tasks::VerdictRecord {
@@ -9110,6 +9451,7 @@ mod tests {
                 verdict: tasks::VerdictKind::Wait,
                 rationale: "r2".into(),
                 steer_message: None,
+                claude_responded_to_last_steer: None,
                 timestamp: 0,
             },
         ];
@@ -9131,6 +9473,7 @@ mod tests {
             verdict: tasks::VerdictKind::Wait,
             rationale: rationale.into(),
             steer_message: None,
+            claude_responded_to_last_steer: None,
             timestamp: 0,
         };
         // observed_action changes every round → every WAIT is a new event.

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -9,11 +9,10 @@
 //! * `kind = "desc"` — the `<desc>` passed on the CLI.  Written once per
 //!   `/claude --tag <tag> "<desc>"` invocation.  On resume without a
 //!   `<desc>`, the supervisor falls back to the most recent `desc` row.
-//! * `kind = "verdict"` — one row per supervision turn.  Content is a
-//!   JSON-serialised [`VerdictRecord`] capturing the four-field
-//!   verdict (`stated_intent`, `observed_action`, `verdict`,
-//!   `rationale`) plus an optional `steer_message`.  Rows written
-//!   before this schema existed are read back as
+//! * `kind = "verdict"` — one row per supervision turn.  Content is
+//!   the JSON-serialised [`VerdictRecord`] (see its doc for the full
+//!   field set — the schema evolves so listing fields here would rot).
+//!   Rows written before this schema existed are read back as
 //!   [`VerdictKind::Legacy`] with the raw text in `rationale` — no
 //!   migration required.
 //! * `kind = "lease"` — at most one live row per `(repo_dir, tag)`.
@@ -360,29 +359,48 @@ pub fn append_verdict_record(
     Ok(())
 }
 
-/// Return every verdict row for `(repo_dir, tag)`, oldest first.
+/// Upper bound on rows returned by [`all_verdict_records`].
+///
+/// Supervision runs at ~2–4 ticks per minute; 5000 rows covers roughly
+/// a day of continuous activity.  Longer runs trim the oldest tail —
+/// older history has already informed prior verdicts, so losing it
+/// does not hurt drift detection.  Serves as a belt-and-braces cap on
+/// top of the time-window parameter: when a caller mistakenly passes
+/// `since_ts = 0` the result is still bounded.
+pub const MAX_VERDICT_ROWS: usize = 5_000;
+
+/// Return verdict rows for `(repo_dir, tag)` with `timestamp >= since_ts`,
+/// oldest first, capped at [`MAX_VERDICT_ROWS`].
 ///
 /// Used by the event-stream history renderer which needs to run its
 /// own filtering (keep all non-WAIT, dedupe sustained WAIT, fold runs)
 /// rather than the fixed time-window in [`recent_verdicts`].  Legacy
 /// plain-string rows are surfaced as [`VerdictKind::Legacy`] so their
 /// content still makes it into the prompt.
+///
+/// Pass `since_ts = 0` to load everything (capped) — intended for
+/// tests and one-off inspection; the supervision loop should always
+/// pass a real cutoff (e.g. 24 h ago) so per-tick work stays bounded.
 pub fn all_verdict_records(
     conn: &Connection,
     repo_dir: &str,
     tag: &str,
+    since_ts: i64,
 ) -> Result<Vec<VerdictRecord>> {
     let mut stmt = conn
         .prepare(
             "SELECT content, timestamp FROM task_notes
              WHERE repo_dir = ?1 AND tag = ?2 AND kind = 'verdict'
-             ORDER BY timestamp ASC, id ASC",
+               AND timestamp >= ?3
+             ORDER BY timestamp ASC, id ASC
+             LIMIT ?4",
         )
         .context("preparing all_verdict_records query")?;
     let rows = stmt
-        .query_map(params![repo_dir, tag], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-        })
+        .query_map(
+            params![repo_dir, tag, since_ts, MAX_VERDICT_ROWS as i64],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+        )
         .context("running all_verdict_records query")?;
     let mut out = Vec::new();
     for row in rows {
@@ -565,7 +583,7 @@ mod tests {
         };
         append_verdict_record(&conn, "/proj", "kernel", &rec).unwrap();
 
-        let all = all_verdict_records(&conn, "/proj", "kernel").unwrap();
+        let all = all_verdict_records(&conn, "/proj", "kernel", 0).unwrap();
         assert_eq!(all.len(), 1);
         let back = &all[0];
         assert_eq!(back.stated_intent, rec.stated_intent);
@@ -589,7 +607,7 @@ mod tests {
         )
         .unwrap();
 
-        let all = all_verdict_records(&conn, "/proj", "kernel").unwrap();
+        let all = all_verdict_records(&conn, "/proj", "kernel", 0).unwrap();
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].verdict, VerdictKind::Legacy);
         assert_eq!(all[0].rationale, "WAIT: still reading files");
@@ -614,7 +632,7 @@ mod tests {
         append_verdict_record(&conn, "/proj-a", "lint", &mk("lint-v")).unwrap();
 
         let reads = |r, t| -> Vec<String> {
-            all_verdict_records(&conn, r, t)
+            all_verdict_records(&conn, r, t, 0)
                 .unwrap()
                 .into_iter()
                 .map(|v| v.rationale)

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -9,10 +9,13 @@
 //! * `kind = "desc"` — the `<desc>` passed on the CLI.  Written once per
 //!   `/claude --tag <tag> "<desc>"` invocation.  On resume without a
 //!   `<desc>`, the supervisor falls back to the most recent `desc` row.
-//! * `kind = "verdict"` — one row per supervision turn, containing the
-//!   supervisor LLM's `WAIT: ...` / `STEER: ...` / `DONE: ...` line.
-//!   Read back as context for subsequent supervision runs on the same
-//!   tag.
+//! * `kind = "verdict"` — one row per supervision turn.  Content is a
+//!   JSON-serialised [`VerdictRecord`] capturing the four-field
+//!   verdict (`stated_intent`, `observed_action`, `verdict`,
+//!   `rationale`) plus an optional `steer_message`.  Rows written
+//!   before this schema existed are read back as
+//!   [`VerdictKind::Legacy`] with the raw text in `rationale` — no
+//!   migration required.
 //! * `kind = "lease"` — at most one live row per `(repo_dir, tag)`.
 //!   Guarantees same-tag supervision is serialised: parallel `/claude
 //!   --tag <tag>` invocations synchronously reject while another
@@ -38,9 +41,6 @@ use crate::auth::amaebi_home;
 /// `pane_lease::LEASE_TTL_SECS` so a crashed holder is reclaimable on
 /// the same timescale.
 pub const LEASE_TTL_SECS: i64 = 86_400;
-
-/// Maximum history rows returned to the supervisor per turn.
-pub const RECENT_VERDICTS_WINDOW: usize = 10;
 
 const SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS task_notes (
@@ -257,41 +257,142 @@ pub fn latest_desc(conn: &Connection, repo_dir: &str, tag: &str) -> Result<Optio
 // Verdicts
 // ---------------------------------------------------------------------------
 
-/// Append a supervision verdict row.  Timestamp is derived server-side
-/// so callers need not order them.
-pub fn append_verdict(conn: &Connection, repo_dir: &str, tag: &str, verdict: &str) -> Result<()> {
+// ---------------------------------------------------------------------------
+// Structured verdicts
+// ---------------------------------------------------------------------------
+
+/// One supervision turn's full verdict record.  Serialised as JSON into
+/// the existing `content` column so no schema migration is required;
+/// rows written before this rework (plain `"WAIT: ..."` / `"STEER: ..."`
+/// strings) are read back as [`VerdictKind::Legacy`] with the raw text
+/// placed in `rationale`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct VerdictRecord {
+    /// What Claude claims to be doing this turn — distilled by the
+    /// supervisor from pane capture, not regex-scraped.  Empty string
+    /// when the supervisor produced no field value (including LEGACY
+    /// rows written before this schema existed).
+    #[serde(default)]
+    pub stated_intent: String,
+    /// Ground-truth observation: git diff delta, touched files, tool
+    /// calls this turn.
+    #[serde(default)]
+    pub observed_action: String,
+    /// The classification.
+    pub verdict: VerdictKind,
+    /// One-sentence reason for the verdict.
+    #[serde(default)]
+    pub rationale: String,
+    /// STEER payload actually sent into the pane — only present when
+    /// `verdict == Steer` AND the message was dispatched successfully.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub steer_message: Option<String>,
+    /// Unix epoch seconds — server-assigned on append, populated on read.
+    /// Not serialised into the JSON blob (the row's `timestamp` column
+    /// is the source of truth).
+    #[serde(skip)]
+    pub timestamp: i64,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum VerdictKind {
+    Wait,
+    Steer,
+    Done,
+    /// Placeholder for rows written before the structured schema existed.
+    /// Reader maps any non-JSON `content` to this variant.
+    Legacy,
+}
+
+impl VerdictRecord {
+    /// Render as a compact single-line summary suitable for
+    /// `amaebi tag list` and legacy prompt sections that still expect a
+    /// string form.
+    pub fn to_line(&self) -> String {
+        match self.verdict {
+            VerdictKind::Wait => {
+                if self.rationale.is_empty() {
+                    "WAIT".to_string()
+                } else {
+                    format!("WAIT: {}", self.rationale)
+                }
+            }
+            VerdictKind::Steer => match &self.steer_message {
+                Some(m) => format!("STEER: {m}"),
+                None => format!("STEER: {}", self.rationale),
+            },
+            VerdictKind::Done => format!("DONE: {}", self.rationale),
+            VerdictKind::Legacy => self.rationale.clone(),
+        }
+    }
+}
+
+/// Append a structured verdict.  Stored as JSON in `content`.
+pub fn append_verdict_record(
+    conn: &Connection,
+    repo_dir: &str,
+    tag: &str,
+    record: &VerdictRecord,
+) -> Result<()> {
+    let json = serde_json::to_string(record).context("serialising verdict record")?;
     conn.execute(
         "INSERT INTO task_notes (repo_dir, tag, kind, content, timestamp)
          VALUES (?1, ?2, 'verdict', ?3, ?4)",
-        params![repo_dir, tag, verdict, now_epoch()],
+        params![repo_dir, tag, json, now_epoch()],
     )
-    .context("appending verdict")?;
+    .context("appending verdict record")?;
     Ok(())
 }
 
-/// Return up to [`RECENT_VERDICTS_WINDOW`] most recent verdicts, oldest
-/// first (so the supervisor sees them in chronological order when
-/// rendered into a prompt).
-pub fn recent_verdicts(conn: &Connection, repo_dir: &str, tag: &str) -> Result<Vec<String>> {
+/// Return every verdict row for `(repo_dir, tag)`, oldest first.
+///
+/// Used by the event-stream history renderer which needs to run its
+/// own filtering (keep all non-WAIT, dedupe sustained WAIT, fold runs)
+/// rather than the fixed time-window in [`recent_verdicts`].  Legacy
+/// plain-string rows are surfaced as [`VerdictKind::Legacy`] so their
+/// content still makes it into the prompt.
+pub fn all_verdict_records(
+    conn: &Connection,
+    repo_dir: &str,
+    tag: &str,
+) -> Result<Vec<VerdictRecord>> {
     let mut stmt = conn
         .prepare(
-            "SELECT content FROM task_notes
+            "SELECT content, timestamp FROM task_notes
              WHERE repo_dir = ?1 AND tag = ?2 AND kind = 'verdict'
-             ORDER BY timestamp DESC
-             LIMIT ?3",
+             ORDER BY timestamp ASC, id ASC",
         )
-        .context("preparing recent_verdicts query")?;
+        .context("preparing all_verdict_records query")?;
     let rows = stmt
-        .query_map(
-            params![repo_dir, tag, RECENT_VERDICTS_WINDOW as i64],
-            |row| row.get::<_, String>(0),
-        )
-        .context("running recent_verdicts query")?;
-    let mut out: Vec<String> = rows
-        .collect::<rusqlite::Result<Vec<_>>>()
-        .context("collecting recent_verdicts rows")?;
-    out.reverse(); // oldest first for prompt rendering
+        .query_map(params![repo_dir, tag], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })
+        .context("running all_verdict_records query")?;
+    let mut out = Vec::new();
+    for row in rows {
+        let (content, ts) = row.context("decoding all_verdict_records row")?;
+        let mut rec = parse_verdict_content(&content);
+        rec.timestamp = ts;
+        out.push(rec);
+    }
     Ok(out)
+}
+
+/// Parse a `task_notes.content` string into a [`VerdictRecord`],
+/// tolerating legacy plain-text rows from before the JSON schema.
+fn parse_verdict_content(raw: &str) -> VerdictRecord {
+    if let Ok(parsed) = serde_json::from_str::<VerdictRecord>(raw) {
+        return parsed;
+    }
+    VerdictRecord {
+        stated_intent: String::new(),
+        observed_action: String::new(),
+        verdict: VerdictKind::Legacy,
+        rationale: raw.to_string(),
+        steer_message: None,
+        timestamp: 0,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -435,69 +536,76 @@ mod tests {
     // ── verdicts ─────────────────────────────────────────────────────────
 
     #[test]
-    fn recent_verdicts_empty_initially() {
+    fn structured_verdict_roundtrips() {
         let (conn, _g) = fresh_db();
-        let v = recent_verdicts(&conn, "/proj", "kernel").unwrap();
-        assert!(v.is_empty());
-    }
+        let rec = VerdictRecord {
+            stated_intent: "read src/auth.rs to understand sessions".into(),
+            observed_action: "modified src/daemon.rs".into(),
+            verdict: VerdictKind::Steer,
+            rationale: "touched file outside scope".into(),
+            steer_message: Some("stop, return to reading src/auth.rs".into()),
+            timestamp: 0,
+        };
+        append_verdict_record(&conn, "/proj", "kernel", &rec).unwrap();
 
-    #[test]
-    fn append_verdicts_and_read_oldest_first() {
-        let (conn, _g) = fresh_db();
-        // Use explicit timestamps so ordering is deterministic.
-        for (i, v) in ["first", "second", "third"].iter().enumerate() {
-            conn.execute(
-                "INSERT INTO task_notes (repo_dir, tag, kind, content, timestamp) \
-                 VALUES ('/proj', 'kernel', 'verdict', ?1, ?2)",
-                params![v, now_epoch() + i as i64],
-            )
-            .unwrap();
-        }
-        let v = recent_verdicts(&conn, "/proj", "kernel").unwrap();
-        assert_eq!(v, vec!["first", "second", "third"]);
-    }
-
-    #[test]
-    fn recent_verdicts_caps_at_window() {
-        let (conn, _g) = fresh_db();
-        let total = RECENT_VERDICTS_WINDOW + 5;
-        for i in 0..total {
-            conn.execute(
-                "INSERT INTO task_notes (repo_dir, tag, kind, content, timestamp) \
-                 VALUES ('/proj', 'kernel', 'verdict', ?1, ?2)",
-                params![format!("v{i}"), now_epoch() + i as i64],
-            )
-            .unwrap();
-        }
-        let v = recent_verdicts(&conn, "/proj", "kernel").unwrap();
-        assert_eq!(v.len(), RECENT_VERDICTS_WINDOW);
-        // Oldest-first means we should see the last 10 inserted, in order.
+        let all = all_verdict_records(&conn, "/proj", "kernel").unwrap();
+        assert_eq!(all.len(), 1);
+        let back = &all[0];
+        assert_eq!(back.stated_intent, rec.stated_intent);
+        assert_eq!(back.observed_action, rec.observed_action);
+        assert_eq!(back.verdict, VerdictKind::Steer);
         assert_eq!(
-            v.first().unwrap(),
-            &format!("v{}", total - RECENT_VERDICTS_WINDOW)
+            back.steer_message.as_deref(),
+            Some(rec.steer_message.as_deref().unwrap())
         );
-        assert_eq!(v.last().unwrap(), &format!("v{}", total - 1));
+        assert!(back.timestamp > 0);
+    }
+
+    #[test]
+    fn legacy_plain_string_verdict_reads_as_legacy() {
+        let (conn, _g) = fresh_db();
+        // Simulate a row written before the JSON schema existed.
+        conn.execute(
+            "INSERT INTO task_notes (repo_dir, tag, kind, content, timestamp) \
+             VALUES ('/proj', 'kernel', 'verdict', ?1, ?2)",
+            params!["WAIT: still reading files", now_epoch()],
+        )
+        .unwrap();
+
+        let all = all_verdict_records(&conn, "/proj", "kernel").unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].verdict, VerdictKind::Legacy);
+        assert_eq!(all[0].rationale, "WAIT: still reading files");
+        // Legacy render must still produce a non-empty line for the prompt.
+        assert_eq!(all[0].to_line(), "WAIT: still reading files");
     }
 
     #[test]
     fn verdicts_isolated_by_repo_dir_and_tag() {
         let (conn, _g) = fresh_db();
-        append_verdict(&conn, "/proj-a", "kernel", "a-v").unwrap();
-        append_verdict(&conn, "/proj-b", "kernel", "b-v").unwrap();
-        append_verdict(&conn, "/proj-a", "lint", "lint-v").unwrap();
+        let mk = |rationale: &str| VerdictRecord {
+            stated_intent: String::new(),
+            observed_action: String::new(),
+            verdict: VerdictKind::Wait,
+            rationale: rationale.into(),
+            steer_message: None,
+            timestamp: 0,
+        };
+        append_verdict_record(&conn, "/proj-a", "kernel", &mk("a-v")).unwrap();
+        append_verdict_record(&conn, "/proj-b", "kernel", &mk("b-v")).unwrap();
+        append_verdict_record(&conn, "/proj-a", "lint", &mk("lint-v")).unwrap();
 
-        assert_eq!(
-            recent_verdicts(&conn, "/proj-a", "kernel").unwrap(),
-            vec!["a-v".to_string()]
-        );
-        assert_eq!(
-            recent_verdicts(&conn, "/proj-b", "kernel").unwrap(),
-            vec!["b-v".to_string()]
-        );
-        assert_eq!(
-            recent_verdicts(&conn, "/proj-a", "lint").unwrap(),
-            vec!["lint-v".to_string()]
-        );
+        let reads = |r, t| -> Vec<String> {
+            all_verdict_records(&conn, r, t)
+                .unwrap()
+                .into_iter()
+                .map(|v| v.rationale)
+                .collect()
+        };
+
+        assert_eq!(reads("/proj-a", "kernel"), vec!["a-v".to_string()]);
+        assert_eq!(reads("/proj-b", "kernel"), vec!["b-v".to_string()]);
+        assert_eq!(reads("/proj-a", "lint"), vec!["lint-v".to_string()]);
     }
 
     // ── lease ────────────────────────────────────────────────────────────

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -287,6 +287,21 @@ pub struct VerdictRecord {
     /// `verdict == Steer` AND the message was dispatched successfully.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub steer_message: Option<String>,
+    /// Whether Claude acted on the most recent prior STEER, judged by
+    /// the supervisor looking at the pane (thinking/reading counts) and
+    /// git diff together.
+    ///
+    /// * `Some(true)` — Claude responded meaningfully (followed the
+    ///   STEER, or at least engaged with it).
+    /// * `Some(false)` — Claude ignored or contradicted the STEER.
+    ///   Drives the K=3 hard-boundary counter.
+    /// * `None` — No prior STEER to compare against (first turn,
+    ///   or only WAIT/DONE verdicts have been issued).
+    ///
+    /// Added in the hard-boundary PR; legacy rows and pre-feature
+    /// verdicts deserialise as `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_responded_to_last_steer: Option<bool>,
     /// Unix epoch seconds — server-assigned on append, populated on read.
     /// Not serialised into the JSON blob (the row's `timestamp` column
     /// is the source of truth).
@@ -391,6 +406,7 @@ fn parse_verdict_content(raw: &str) -> VerdictRecord {
         verdict: VerdictKind::Legacy,
         rationale: raw.to_string(),
         steer_message: None,
+        claude_responded_to_last_steer: None,
         timestamp: 0,
     }
 }
@@ -544,6 +560,7 @@ mod tests {
             verdict: VerdictKind::Steer,
             rationale: "touched file outside scope".into(),
             steer_message: Some("stop, return to reading src/auth.rs".into()),
+            claude_responded_to_last_steer: None,
             timestamp: 0,
         };
         append_verdict_record(&conn, "/proj", "kernel", &rec).unwrap();
@@ -589,6 +606,7 @@ mod tests {
             verdict: VerdictKind::Wait,
             rationale: rationale.into(),
             steer_message: None,
+            claude_responded_to_last_steer: None,
             timestamp: 0,
         };
         append_verdict_record(&conn, "/proj-a", "kernel", &mk("a-v")).unwrap();


### PR DESCRIPTION
## Summary

Refocuses the supervision loop from *"is Claude stuck?"* to *"is Claude on task?"*. The old WAIT/STEER/DONE classifier only saw pane capture — Claude's self-narration — which always sounds plausible even when the diff drifts outside scope. This PR gives the supervisor **ground truth (git diff/status)**, **structured JSON verdicts (server-enforced on supported Claude models, client-tolerant elsewhere)**, **event-stream history**, and a **K=3 hard boundary** that escalates when Claude ignores repeated STEERs.

Pre-ops and post-ops (lease acquisition, pane/worktree setup, resource injection, AGENTS.md, cleanup) are unchanged. Loop-only rework.

## What changed

Three commits on this branch:

### 1. Drift-detection rework (`95f2fef`)

- **Per-tick git evidence.** `capture_git_evidence` runs `git diff` + `git status --short` in the pane's worktree each turn and renders them into the supervisor prompt alongside the pane snapshot. Pane without a bound worktree contributes nothing.
- **Structured JSON verdict.** Supervisor emits `{stated_intent, observed_action, verdict, rationale, steer_message?, claude_responded_to_last_steer?}`. `stated_intent` (from pane) vs `observed_action` (from diff) is the classic drift signal. Unparseable output downgrades to WAIT with the raw text in `rationale` so flaky models never silently skip safety actions.
- **Notebook rows upgraded to JSON `VerdictRecord`.** Rows written before this schema read back as `VerdictKind::Legacy` with raw text in `rationale` — no migration required.
- **Event-stream history replaces fixed `last 10` window.** Non-WAIT rounds kept verbatim, WAIT rounds kept on signature change, identical-signature WAIT runs folded to `[N ticks] sustained WAIT: …`. Hundreds of `reading files` WAITs no longer drown out real drift events.
- **5-min poll-interval ceiling removed.** Idle threshold (10 s) is now the sole pacing knob. `AMAEBI_SUPERVISION_INTERVAL_SECS` remains as an escape hatch.

### 2. K=3 hard boundary (`26aac0d`)

- `claude_responded_to_last_steer` is the 6th verdict field: the supervisor judges whether Claude acted on the most recent STEER (by reading diff + pane thinking state).
- `SUPERVISION_DRIFT_BLOCK_K = 3`: after three consecutive STEERs that Claude ignores, send ESC to interrupt Claude's current tool call, then inject a forced message re-stating the task + naming the drift.
- Recent-steer VecDeque + `trigger_hard_boundary` helper drive the counter + ESC dispatch.

### 3. Server-enforced structured outputs (`90daed8`)

- On supported Claude models (Opus 4.6/4.7, Sonnet 4.6), `SUPERVISION_VERDICT_SCHEMA` is passed to Bedrock via `outputConfig.textFormat = { type: "json_schema", ... }` (field added in `aws-sdk-bedrockruntime` 1.124.0, 2026-02-04). Bedrock guarantees the model's text output conforms to the schema — no code fences, no prose prefix, no field omission.
- `supports_structured_output` allowlist matches `supports_adaptive_thinking`. Older Claude + Copilot keep the prompt-only + tolerant-parser path as a fallback.
- `OutputSchema { schema_json, name, description }` and `build_output_config()` are unit-tested against the smithy wire shape (`shape_output_format*.rs`).
- Drift-guard test in `daemon::tests` pins `VerdictRecord`'s serialised keys to the schema's `properties` keys — renaming one without the other fails CI.

## Reliability fixes from Copilot review (`3faad39`)

- `capture_git_evidence` now actually enforces its 3 s per-call timeout via `tokio::process::Command` + `tokio::time::timeout` + `kill_on_drop(true)`. Previously the doc claimed the timeout but `Command::output()` had none — a hung FS would stall the loop.
- `all_verdict_records` takes a `since_ts` bound and a 5000-row LIMIT. The supervision caller passes "now − 24 h", so per-tick work is O(last-day rows) instead of O(total).
- `parse_supervision_verdict` warns (`tracing::warn!`) when `panes.len() > 1` and targets `panes.first()`; multi-pane routing is a follow-up that needs a schema change.
- Doc fixes in `docs/supervision.md`, `src/tasks.rs` module docs, and `parse_supervision_verdict` docstring (field counts / required-vs-default semantics).

## Tests

- `tasks::structured_verdict_roundtrips`, `legacy_plain_string_verdict_reads_as_legacy` — schema + legacy compat.
- `daemon::git_evidence_captures_diff_and_status_in_real_worktree` — real git subprocess, now `#[tokio::test]`.
- `daemon::parse_supervision_verdict_*` — happy path, STEER dispatch, malformed STEER → WAIT, DONE summary, unparseable → WAIT, code-fence stripping.
- `daemon::event_stream_history_*` — folding, STEER passthrough, changed-signature preservation.
- `daemon::supervision_prompt_*_git_evidence_*` — prompt assembly with/without evidence.
- `daemon::supervision_verdict_schema_is_valid_json` + `supervision_verdict_schema_keys_cover_verdict_record_fields` — drift guard between schema string and `VerdictRecord`.
- `bedrock::structured_output_*` + `output_config_*` — allowlist + wire shape against the smithy SDK.

666 lib + 38 integration tests passing. `cargo fmt --check` clean. `cargo clippy -- -D warnings` clean. `scripts/next-version.sh --check` clean at 2026.4.67.

## Deliberately out of scope

- **Scope hint distillation + 10 s stdin confirm window.** Requires `client.rs` dual-channel logic (stdin ownership during the confirm window); deserves its own review scope.
- **Multi-pane STEER routing.** Needs a dedicated `pane_id` field in the verdict JSON contract + `SUPERVISION_VERDICT_SCHEMA` update. Single-pane is what `/claude` does today; multi-pane now leaves a `tracing::warn!` breadcrumb.
- **Prompt caching on the supervision prompt.** Separate PR (#147).

## Test plan
- [ ] CI passes (fmt, clippy, tests, version check).
- [ ] Manual: `/claude --tag drift-test "refactor src/tasks.rs only"` and confirm pane injection, diff in prompt, structured verdicts in `~/.amaebi/tasks.db`.
- [ ] Manual: deliberately have Claude touch a file outside scope; confirm supervisor STEERs and the `steer_message` names the drift.
- [ ] Manual: have Claude ignore 3 STEERs in a row; confirm K=3 hard boundary fires ESC + forced message.
