### PR TITLE
fix(bedrock): retry once on transient malformed_* stopReasons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.4.65"
+version = "2026.4.64"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.4.65"
+version = "2026.4.64"
 edition = "2021"
 
 [[bin]]

--- a/src/bedrock.rs
+++ b/src/bedrock.rs
@@ -1053,6 +1053,10 @@ where
                 "end_turn" => FinishReason::Stop,
                 "tool_use" => FinishReason::ToolCalls,
                 "max_tokens" => FinishReason::Length,
+                // Transient "model botched this turn" signals (since
+                // bedrockruntime 1.119, 2025-12-02).  Handled as a one-shot
+                // retry in the session loop; see FinishReason::Malformed.
+                "malformed_model_output" | "malformed_tool_use" => FinishReason::Malformed,
                 other => FinishReason::Other(other.to_owned()),
             };
             tracing::debug!(stop_reason = reason, "Bedrock: messageStop");
@@ -1623,6 +1627,93 @@ mod tests {
         .await
         .unwrap();
         assert!(matches!(finish, FinishReason::Length));
+    }
+
+    #[tokio::test]
+    async fn parse_message_stop_malformed_model_output() {
+        let payload = br#"{"stopReason":"malformed_model_output"}"#;
+        let frame_bytes = eventstream::build_test_frame(
+            &[(":event-type", "messageStop"), (":message-type", "event")],
+            payload,
+        );
+
+        let mut finish = FinishReason::Stop;
+        let mut sink = tokio::io::sink();
+        let (parsed, _) = eventstream::try_parse_frame(&frame_bytes).unwrap().unwrap();
+        handle_frame(
+            &parsed,
+            &mut String::new(),
+            &mut Vec::new(),
+            &mut std::collections::HashMap::new(),
+            &mut finish,
+            &mut 0,
+            &mut sink,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(finish, FinishReason::Malformed),
+            "malformed_model_output must map to Malformed, not Other"
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_message_stop_malformed_tool_use() {
+        let payload = br#"{"stopReason":"malformed_tool_use"}"#;
+        let frame_bytes = eventstream::build_test_frame(
+            &[(":event-type", "messageStop"), (":message-type", "event")],
+            payload,
+        );
+
+        let mut finish = FinishReason::Stop;
+        let mut sink = tokio::io::sink();
+        let (parsed, _) = eventstream::try_parse_frame(&frame_bytes).unwrap().unwrap();
+        handle_frame(
+            &parsed,
+            &mut String::new(),
+            &mut Vec::new(),
+            &mut std::collections::HashMap::new(),
+            &mut finish,
+            &mut 0,
+            &mut sink,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(finish, FinishReason::Malformed),
+            "malformed_tool_use must map to Malformed, not Other"
+        );
+    }
+
+    /// Regression guard: any stopReason value we do NOT explicitly match
+    /// must still fall through to `Other(_)` so the daemon terminates the
+    /// session cleanly instead of silently being treated as success.  This
+    /// also prevents a future PR from accidentally folding a new
+    /// transient-retry candidate into the `Malformed` branch without
+    /// discussion.
+    #[tokio::test]
+    async fn parse_message_stop_unknown_reason_still_other() {
+        let payload = br#"{"stopReason":"content_filtered"}"#;
+        let frame_bytes = eventstream::build_test_frame(
+            &[(":event-type", "messageStop"), (":message-type", "event")],
+            payload,
+        );
+
+        let mut finish = FinishReason::Stop;
+        let mut sink = tokio::io::sink();
+        let (parsed, _) = eventstream::try_parse_frame(&frame_bytes).unwrap().unwrap();
+        handle_frame(
+            &parsed,
+            &mut String::new(),
+            &mut Vec::new(),
+            &mut std::collections::HashMap::new(),
+            &mut finish,
+            &mut 0,
+            &mut sink,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(finish, FinishReason::Other(ref s) if s == "content_filtered"));
     }
 
     #[tokio::test]

--- a/src/copilot.rs
+++ b/src/copilot.rs
@@ -167,6 +167,17 @@ pub enum FinishReason {
     Stop,
     ToolCalls,
     Length,
+    /// The server completed the turn but flagged the output as malformed —
+    /// currently only emitted by Bedrock ConverseStream with stopReason
+    /// `malformed_model_output` or `malformed_tool_use` (added in the
+    /// 2025-12-02 `aws-sdk-bedrockruntime` 1.119 release).
+    ///
+    /// These are treated as transient: the server returned HTTP 200 with an
+    /// application-level "model botched this one turn" signal, and retrying
+    /// the same request with the same messages usually succeeds.  The daemon
+    /// retries once before falling back to the same termination path as
+    /// [`FinishReason::Other`].
+    Malformed,
     Other(String),
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5205,6 +5205,15 @@ where
     let mut read_cache: std::collections::HashMap<std::path::PathBuf, ((u128, u64), String)> =
         Default::default();
 
+    // Bedrock `malformed_model_output` / `malformed_tool_use` stopReasons
+    // (since bedrockruntime 1.119, 2025-12-02) signal a transient per-turn
+    // failure inside the model, not a protocol or quota error.  We retry
+    // each such turn once with identical `messages`; on the second strike
+    // we fall through to the `Other`-style termination path.  Bounded to
+    // one to prevent loop storms if the model is in a stuck pattern.
+    const MAX_MALFORMED_RETRIES: usize = 1;
+    let mut malformed_retries: usize = 0;
+
     loop {
         // Drain any steering corrections that arrived since the last model
         // call (covers non-tool turns and the time between tool completion
@@ -5295,6 +5304,7 @@ where
             FinishReason::Stop => "stop",
             FinishReason::Length => "length",
             FinishReason::ToolCalls => "tool_calls",
+            FinishReason::Malformed => "malformed",
             FinishReason::Other(_) => "other",
         };
         tracing::debug!(
@@ -5924,7 +5934,29 @@ where
                 // the top of the next loop iteration, before the model call.
             }
 
-            FinishReason::Other(ref reason) => {
+            FinishReason::Malformed if malformed_retries < MAX_MALFORMED_RETRIES => {
+                // Transient per-turn model error (Bedrock stopReason
+                // `malformed_model_output` / `malformed_tool_use`).  Retry
+                // the exact same request once — do not push any partial
+                // assistant text or tool calls onto `messages`, so the
+                // next iteration re-sends an identical payload.
+                malformed_retries += 1;
+                tracing::warn!(
+                    attempt = malformed_retries,
+                    "malformed model output; retrying turn with unchanged messages"
+                );
+                continue;
+            }
+
+            FinishReason::Malformed | FinishReason::Other(_) => {
+                // Second-strike Malformed (or any other unhandled
+                // finish reason): terminate the session cleanly and
+                // surface the reason string to the client.
+                let reason: String = match &resp.finish_reason {
+                    FinishReason::Other(s) => s.clone(),
+                    FinishReason::Malformed => "malformed_output".to_string(),
+                    _ => unreachable!(),
+                };
                 tracing::warn!(finish_reason = %reason, "session end: unexpected finish reason");
                 let warning = format!("\n[stopped: unexpected finish reason '{reason}']");
                 write_frame(writer, &Response::Text { chunk: warning }).await?;


### PR DESCRIPTION
## Motivation

Bedrock's ConverseStream returns two stopReasons for per-turn model
failures that aren't user-level rejections:

- \`malformed_model_output\` — server couldn't validate the text output
  (e.g. structured-output JSON not schema-compliant)
- \`malformed_tool_use\` — the tool_use block's JSON arguments are
  corrupt (unclosed quotes, truncation, etc.)

Both have been shipped since \`bedrockruntime\` 1.119.0 (2025-12-02).
AWS returns HTTP 200 with a semantic stopReason instead of a 5xx,
indicating the error is transient and the client should decide what
to do — retrying the same request usually works.

Today amaebi routes any unknown stopReason into
\`FinishReason::Other(string)\`, which terminates the session with a
\`[stopped: unexpected finish reason '...']\` warning.  That's correct
for \`guardrail_intervened\` / \`content_filtered\` (user-visible
rejections) but wrong for \`malformed_*\` — the user sees a string
they can't act on, and the turn that would have succeeded on a
retry is lost.

## What this PR does

- **New \`FinishReason::Malformed\` variant** (\`src/copilot.rs\`),
  distinct from \`Other\`.
- **Bedrock parser** maps \`malformed_model_output\` and
  \`malformed_tool_use\` to \`Malformed\`; everything else keeps the
  prior \`Other(_)\` fall-through (regression-guarded by a new test).
- **\`run_agentic_loop\`** gets a \`MAX_MALFORMED_RETRIES = 1\` bounded
  counter.  First strike: warn, \`continue\` with identical
  \`messages\` — no partial assistant text / tool calls appended, so
  the next iteration resends an unchanged payload.  Second strike:
  fall through to the \`Other\` termination path, surfacing
  \`malformed_output\` to the client.

Bounded-to-one prevents loop storms if the model is stuck in a
pattern.  The existing \`Other\` path is preserved as the
second-strike safety net.

## Tests

New unit tests in \`src/bedrock.rs\`:

- \`parse_message_stop_malformed_model_output\` — wire → variant
- \`parse_message_stop_malformed_tool_use\` — wire → variant
- \`parse_message_stop_unknown_reason_still_other\` — regression guard
  that future stopReason values don't accidentally land in
  \`Malformed\` without discussion

Triple Check: \`cargo fmt --check\` clean, \`cargo clippy -- -D
warnings\` clean, 643 lib + 38 integration tests passing.

## Deliberately out of scope

- An integration-level retry test would require a Bedrock-shaped
  mock server — the current \`mock_llm\` speaks OpenAI-compatible
  SSE, not AWS event-stream.  The unit tests pin the parser
  mapping; the session-loop retry is a ~10-line addition that is
  easier to read than to mock.
- ConverseStream \`model_context_window_exceeded\` is another
  transient-ish stopReason that currently routes to \`Other\`.  Not
  included here because the right retry policy is different (needs
  a pre-flight trim, not a same-payload retry).

## Source traced

The two stopReasons and their wire strings were confirmed against
\`aws-sdk-bedrockruntime\`'s \`_stop_reason.rs\` on main, per the
procedure in \`docs/bedrock-upstream-check.md\` (#145).

🤖 Generated with [Claude Code](https://claude.com/claude-code)