### PR TITLE
fix(chat): empty Enter and single Ctrl-C at idle prompt no longer exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.1"
+version = "2026.5.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.0"
+version = "2026.5.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.4.65"
+version = "2026.5.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.1"
+version = "2026.5.2"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.4.65"
+version = "2026.5.0"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.0"
+version = "2026.5.1"
 edition = "2021"
 
 [[bin]]

--- a/src/client.rs
+++ b/src/client.rs
@@ -965,7 +965,8 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
 /// Run a persistent multi-turn chat session on a single socket connection.
 ///
 /// Ctrl-C mid-generation → interrupt + steer prompt (same as `amaebi ask`).
-/// Double Ctrl-C within 2 s → exit. Empty line or Ctrl-D → exit.
+/// Double Ctrl-C within 2 s → exit. Ctrl-D → exit. Empty / whitespace-only
+/// Enter is a silent re-prompt (never forwarded to the daemon).
 #[allow(unused_assignments)] // steer_pending is read inside select! async blocks
 pub async fn run_chat_loop(
     socket: PathBuf,
@@ -999,7 +1000,7 @@ pub async fn run_chat_loop(
         crate::banner::print(&model, &session_id, &cwd);
     } else if std::io::stderr().is_terminal() {
         // Minimal fallback when the banner is opted out but we're still on a TTY.
-        eprintln!("Chat session started (ID: {session_id}). Empty line or Ctrl-D to exit.\n");
+        eprintln!("Chat session started (ID: {session_id}). Ctrl-D or double Ctrl-C to exit.\n");
     }
 
     // Snapshot session id for the history writer so each persisted
@@ -2435,7 +2436,12 @@ mod prompt_input {
             Ok(line) => {
                 // Match the old editor: only non-empty lines join history,
                 // so Up/Down navigation skips accidental bare-Enter presses.
-                let persist = !line.is_empty();
+                // Use `trim().is_empty()` so whitespace-only input — which
+                // the chat REPL classifies as `Continue` (silent re-prompt,
+                // never forwarded to the daemon) — also stays out of
+                // history, keeping what ↑ surfaces aligned with what was
+                // actually sent.
+                let persist = !line.trim().is_empty();
                 if persist {
                     let _ = ed.add_history_entry(line.as_str());
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1064,7 +1064,19 @@ pub async fn run_chat_loop(
                 let now = Instant::now();
                 match classify_prompt_input(line_opt, is_interrupt, last_ctrl_c, now) {
                     PromptInputDecision::Exit => break 'session,
-                    PromptInputDecision::Continue => continue 'session,
+                    PromptInputDecision::Continue => {
+                        // Any intervening input — including an empty /
+                        // whitespace-only Enter — resets the double-tap
+                        // window.  The contract is that **consecutive**
+                        // Ctrl-C presses exit; a stray Enter between two
+                        // Ctrl-Cs should count as "not consecutive" and
+                        // make the second press behave like a fresh
+                        // first tap.  Without this clear, Ctrl-C → Enter
+                        // → Ctrl-C inside `DOUBLE_CTRLC_WINDOW` would
+                        // still exit.
+                        last_ctrl_c = None;
+                        continue 'session;
+                    }
                     PromptInputDecision::FirstCtrlC => {
                         if std::io::stderr().is_terminal() {
                             eprintln!(
@@ -3312,6 +3324,41 @@ mod tests {
         let first = now - DOUBLE_CTRLC_WINDOW - Duration::from_secs(1);
         let d = classify_prompt_input(None, true, Some(first), now);
         assert_eq!(d, PromptInputDecision::FirstCtrlC);
+    }
+
+    #[test]
+    fn ctrl_c_then_empty_enter_then_ctrl_c_does_not_exit() {
+        // The "two Ctrl-C to exit" contract requires the two presses to
+        // be **consecutive**.  Any intervening input — including an
+        // empty / whitespace-only Enter — must reset the double-tap
+        // window, so a subsequent Ctrl-C behaves like a fresh first
+        // tap.  This threads the same `last_ctrl_c` state that
+        // `run_chat_loop` threads, to make sure the clear-on-Continue
+        // call-site wiring stays in place.
+        let t0 = Instant::now();
+        let mut last_ctrl_c: Option<Instant> = None;
+
+        // Step 1: single Ctrl-C at the idle prompt → FirstCtrlC.  The
+        // caller records the timestamp.
+        let d1 = classify_prompt_input(None, true, last_ctrl_c, t0);
+        assert_eq!(d1, PromptInputDecision::FirstCtrlC);
+        last_ctrl_c = Some(t0);
+
+        // Step 2: empty Enter a moment later — well inside the
+        // double-tap window — is a `Continue`.  `run_chat_loop`
+        // clears `last_ctrl_c` on this path.
+        let t1 = t0 + Duration::from_millis(200);
+        let d2 = classify_prompt_input(Some(String::new()), false, last_ctrl_c, t1);
+        assert_eq!(d2, PromptInputDecision::Continue);
+        last_ctrl_c = None;
+
+        // Step 3: Ctrl-C again, still inside what would have been the
+        // original double-tap window.  Because Step 2 cleared the
+        // state, this is a fresh first tap — NOT Exit.
+        let t2 = t0 + Duration::from_millis(400);
+        assert!(t2 - t0 < DOUBLE_CTRLC_WINDOW);
+        let d3 = classify_prompt_input(None, true, last_ctrl_c, t2);
+        assert_eq!(d3, PromptInputDecision::FirstCtrlC);
     }
 
     // -----------------------------------------------------------------------

--- a/src/client.rs
+++ b/src/client.rs
@@ -1035,14 +1035,51 @@ pub async fn run_chat_loop(
                 let raw_result = tokio::task::spawn_blocking(prompt_input::read_line_raw)
                     .await
                     .context("prompt input task panicked")?;
-                match raw_result {
-                    Ok(None) => break 'session,
-                    Ok(Some(line)) if line.is_empty() => break 'session,
-                    Ok(Some(line)) => line,
-                    // Ctrl-C during prompt input — exit the session cleanly.
-                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => break 'session,
+                // Translate the rustyline outcome + current Ctrl-C state
+                // into a `PromptInputDecision` (exit / send / continue /
+                // first-tap).  The contract:
+                //   * Ctrl-D (Ok(None))      → Exit (one-press)
+                //   * Empty / whitespace-only → Continue (silent re-prompt,
+                //                                never forwarded to the LLM)
+                //   * Single Ctrl-C           → FirstCtrlC (warn + re-prompt)
+                //   * Second Ctrl-C within
+                //     DOUBLE_CTRLC_WINDOW     → Exit
+                //   * Non-empty text          → Send
+                let (line_opt, is_interrupt) = match raw_result {
+                    Ok(line) => (line, false),
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => (None, true),
                     Err(e) => {
                         return Err(anyhow::Error::new(e).context("reading prompt from stdin"))
+                    }
+                };
+                // Capture `now` once and reuse it for both the
+                // double-tap-window check inside `classify_prompt_input`
+                // and the `last_ctrl_c` write below.  Two separate
+                // `Instant::now()` calls would let a scheduler delay
+                // between them flip a just-inside-window press into a
+                // just-outside one, and vice versa — the existing
+                // streaming-path double-Ctrl-C handling already captures
+                // `now` once for the same reason.
+                let now = Instant::now();
+                match classify_prompt_input(line_opt, is_interrupt, last_ctrl_c, now) {
+                    PromptInputDecision::Exit => break 'session,
+                    PromptInputDecision::Continue => continue 'session,
+                    PromptInputDecision::FirstCtrlC => {
+                        if std::io::stderr().is_terminal() {
+                            eprintln!(
+                                "[Ctrl-C again within {}s to exit, Ctrl-D to exit immediately]",
+                                DOUBLE_CTRLC_WINDOW.as_secs()
+                            );
+                        }
+                        last_ctrl_c = Some(now);
+                        continue 'session;
+                    }
+                    PromptInputDecision::Send(line) => {
+                        // Non-empty input consumed; clear any pending
+                        // single-Ctrl-C so the next press starts a fresh
+                        // double-tap window.
+                        last_ctrl_c = None;
+                        line
                     }
                 }
             }
@@ -3114,6 +3151,52 @@ fn is_within_window(last_press: Option<Instant>, now: Instant, window: Duration)
     }
 }
 
+/// What to do with a readline result at the idle chat prompt.
+///
+/// Kept as a pure enum + classifier (`classify_prompt_input`) so the
+/// chat-exit contract is unit-testable without spinning up an async
+/// client.  The live loop in [`run_chat_loop`] mirrors these outcomes
+/// one-to-one.
+#[derive(Debug, PartialEq, Eq)]
+enum PromptInputDecision {
+    /// Use the line as a user message to the daemon.
+    Send(String),
+    /// Silently re-prompt.  Used only for empty / whitespace-only
+    /// Enter.  (Single Ctrl-C presses go through `FirstCtrlC`
+    /// instead, so the caller can warn the user and record the
+    /// timestamp for the double-tap check.)
+    Continue,
+    /// Exit the chat session.  Triggered by Ctrl-D / EOF and by a
+    /// second Ctrl-C inside [`DOUBLE_CTRLC_WINDOW`].
+    Exit,
+    /// Record `now` as the first press of a potential Ctrl-C double
+    /// tap and re-prompt.  The caller stores this in `last_ctrl_c`.
+    FirstCtrlC,
+}
+
+/// Classify a raw readline outcome plus current Ctrl-C state into a
+/// [`PromptInputDecision`].  Does not mutate state; the caller is
+/// responsible for recording `FirstCtrlC` into `last_ctrl_c`.
+fn classify_prompt_input(
+    line: Option<String>,
+    is_interrupt: bool,
+    last_ctrl_c: Option<Instant>,
+    now: Instant,
+) -> PromptInputDecision {
+    if is_interrupt {
+        return if is_within_window(last_ctrl_c, now, DOUBLE_CTRLC_WINDOW) {
+            PromptInputDecision::Exit
+        } else {
+            PromptInputDecision::FirstCtrlC
+        };
+    }
+    match line {
+        None => PromptInputDecision::Exit,
+        Some(s) if s.trim().is_empty() => PromptInputDecision::Continue,
+        Some(s) => PromptInputDecision::Send(s),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3156,6 +3239,73 @@ mod tests {
             now,
             Duration::from_secs(2)
         ));
+    }
+
+    // -----------------------------------------------------------------------
+    // classify_prompt_input — chat idle-prompt exit contract
+    //
+    // The chat session's exit contract at the idle prompt is:
+    //   * Ctrl-D (EOF)                              → immediate exit
+    //   * Empty Enter / whitespace-only Enter       → silent re-prompt
+    //   * Single Ctrl-C                             → warn + re-prompt
+    //   * Second Ctrl-C within DOUBLE_CTRLC_WINDOW  → exit
+    //   * Non-empty text                            → send to daemon
+    //
+    // These tests pin that contract — regressing any of them turns a
+    // stray keystroke back into a session killer.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn classify_eof_is_exit() {
+        let d = classify_prompt_input(None, false, None, Instant::now());
+        assert_eq!(d, PromptInputDecision::Exit);
+    }
+
+    #[test]
+    fn classify_empty_line_is_continue() {
+        // An empty Enter on the idle prompt must not exit the chat and
+        // must not be forwarded to the daemon.  Regression guard against
+        // the pre-fix behaviour that broke sessions after long streams.
+        let d = classify_prompt_input(Some(String::new()), false, None, Instant::now());
+        assert_eq!(d, PromptInputDecision::Continue);
+    }
+
+    #[test]
+    fn classify_whitespace_only_is_continue() {
+        let d = classify_prompt_input(Some("   \t  ".to_string()), false, None, Instant::now());
+        assert_eq!(d, PromptInputDecision::Continue);
+    }
+
+    #[test]
+    fn classify_non_empty_line_is_send() {
+        let d = classify_prompt_input(Some("hello".into()), false, None, Instant::now());
+        assert_eq!(d, PromptInputDecision::Send("hello".into()));
+    }
+
+    #[test]
+    fn classify_first_ctrl_c_is_first_tap() {
+        // No prior Ctrl-C recorded → single Ctrl-C is a first tap, not an exit.
+        let d = classify_prompt_input(None, true, None, Instant::now());
+        assert_eq!(d, PromptInputDecision::FirstCtrlC);
+    }
+
+    #[test]
+    fn classify_second_ctrl_c_inside_window_is_exit() {
+        let now = Instant::now();
+        let first = now - Duration::from_secs(1);
+        let d = classify_prompt_input(None, true, Some(first), now);
+        assert_eq!(d, PromptInputDecision::Exit);
+    }
+
+    #[test]
+    fn classify_second_ctrl_c_after_window_is_first_tap() {
+        // Two Ctrl-Cs spaced beyond the window are independent presses
+        // — the second one starts its own double-tap window and does
+        // NOT exit.
+        let now = Instant::now();
+        let first = now - DOUBLE_CTRLC_WINDOW - Duration::from_secs(1);
+        let d = classify_prompt_input(None, true, Some(first), now);
+        assert_eq!(d, PromptInputDecision::FirstCtrlC);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

`amaebi chat`'s idle prompt used to treat three distinct keypresses
as session-fatal:

1. **Empty Enter** — a stray Enter on an idle prompt (common after a
   long streaming response) hit `break 'session`.  The session
   ended and any `carried_messages` context was gone.
2. **Single Ctrl-C** — pressed while idle, also `break 'session`.
   Asymmetric with the streaming path, which already requires a
   double-tap within `DOUBLE_CTRLC_WINDOW = 2 s`.
3. **end_turn after a long report** — downstream effect of (1):
   when the LLM ended a turn with a long text summary and no tool
   call, the daemon returned control to the client.  The client
   re-prompted.  A stray Enter after that killed the chat.
   Verified in a real session: daemon log showed `session end
   reason="stop"` immediately followed by the client's `Session
   ended. ID: ...` banner.

## New contract

The idle chat prompt now exits only on:

- **Ctrl-D / EOF** — one press, immediate exit.
- **Two consecutive Ctrl-C presses within `DOUBLE_CTRLC_WINDOW` (2 s)** —
  matching the existing streaming-loop contract.  "Consecutive"
  means no intervening input: any text, empty Enter, or
  whitespace-only Enter between the two Ctrl-Cs resets the window.

Everything else at the prompt:

- **Empty / whitespace-only Enter** → silent re-prompt.  Not
  forwarded to the daemon.  Also clears any pending
  `last_ctrl_c` — an intervening Enter makes the next Ctrl-C a
  fresh first tap.
- **Single Ctrl-C** → prints `[Ctrl-C again within 2s to exit,
  Ctrl-D to exit immediately]` and re-prompts.
- **Non-empty text** → sent to the daemon.  Clears any pending
  `last_ctrl_c` for the same reason as empty Enter.

The fallback TTY banner and `~/.amaebi/history.jsonl` persistence
gate were updated to match this contract: the banner no longer
advertises "Empty line to exit", and `read_line_raw` now uses
`!line.trim().is_empty()` so whitespace-only input is both
ignored by the chat loop and kept out of history (so ↑ only
surfaces lines that were actually sent).

## Implementation

Extracted the decision into a pure `classify_prompt_input`
function returning a `PromptInputDecision` enum
(`Send | Continue | Exit | FirstCtrlC`).  The async loop in
`run_chat_loop` maps each variant to the right control-flow
action and owns the `last_ctrl_c` bookkeeping (clear on
`Send` / `Continue`, record on `FirstCtrlC`).  Keeping the
classification pure lets most of the contract be unit-tested
without spinning up an async client + daemon; a sequence test
additionally threads the same `last_ctrl_c` state the live
loop threads to pin the call-site wiring.

## Tests

Eight new unit tests in `client::tests` pin the contract:

- `classify_eof_is_exit`
- `classify_empty_line_is_continue` — regression guard against
  pre-fix `break 'session` on empty Enter
- `classify_whitespace_only_is_continue`
- `classify_non_empty_line_is_send`
- `classify_first_ctrl_c_is_first_tap`
- `classify_second_ctrl_c_inside_window_is_exit`
- `classify_second_ctrl_c_after_window_is_first_tap` — old Ctrl-C
  outside the window cannot pair with a new one
- `ctrl_c_then_empty_enter_then_ctrl_c_does_not_exit` — Ctrl-C →
  empty Enter → Ctrl-C within the window must NOT exit, because
  the intervening `Continue` branch clears `last_ctrl_c`

Triple Check: `cargo fmt --check` clean, `cargo clippy -- -D
warnings` clean, 657 lib + 38 integration tests passing.

## Deliberately out of scope

- The daemon-side `run_agentic_loop` `Stop` branch still returns
  control to the client on `finish_reason="stop"` — that is a
  turn end, not a session end, and the client already loops to
  re-prompt.  The visible "session died on end_turn" symptom came
  entirely from the client's exit-on-empty-Enter path fixed here.
  If a future user still finds the LLM too eager to end_turn
  mid-task, the right fix is a prompt-level or
  `--sticky`-flag-level change (separate PR).
- `amaebi ask` (one-shot) is unaffected: it never enters this loop.
