### PR TITLE
feat(ipc): add worktree+resources to PaneAssigned (PR B of chat-takeover)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.2"
+version = "2026.5.3"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.2"
+version = "2026.5.3"
 edition = "2021"
 
 [[bin]]

--- a/src/client.rs
+++ b/src/client.rs
@@ -632,6 +632,7 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                     tag,
                     pane_id,
                     session_id: sid,
+                    ..
                 } => {
                     let msg = format!("[pane {pane_id}] tag={tag} → session {sid}\n");
                     stdout.write_all(msg.as_bytes()).await?;
@@ -1181,6 +1182,7 @@ pub async fn run_chat_loop(
                             tag,
                             pane_id,
                             session_id: sid,
+                            ..
                         } => {
                             let msg = format!("[pane {pane_id}] tag={tag} → session {sid}\n");
                             stdout.write_all(msg.as_bytes()).await?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1894,6 +1894,10 @@ async fn handle_claude_launch(
         // before this ClaudeLaunch arrived (or supplied by `--tag`).
         // It's used as pane lease holder / worktree dir / tmux title /
         // notebook key — all three are already wired up upstream.
+        // `worktree` + `resources` ride along so the client can synthesise a
+        // `[launched]` user turn without a second round-trip
+        // (`docs/design/claude-chat-takeover.md`, PR B/F).
+        let resources: Vec<String> = resource_leases.iter().map(|r| r.name.clone()).collect();
         let mut w = writer.lock().await;
         write_frame(
             &mut *w,
@@ -1901,6 +1905,8 @@ async fn handle_claude_launch(
                 tag: task.tag,
                 pane_id,
                 session_id,
+                worktree,
+                resources,
             },
         )
         .await?;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -280,6 +280,20 @@ pub enum Response {
         pane_id: String,
         /// amaebi session UUID for the new chat session running in the pane.
         session_id: String,
+        /// Absolute path to the git worktree the task is running in, or
+        /// `None` when worktree isolation is off (auto-creation failed or
+        /// the caller opted out).  Carried here so the client can fold it
+        /// into the synthesised `[launched]` user turn; see
+        /// `docs/design/claude-chat-takeover.md` (PR B/F).
+        /// `#[serde(default)]` keeps older clients compatible with newer
+        /// daemons that emit this field.
+        #[serde(default)]
+        worktree: Option<String>,
+        /// Resolved resource names acquired for this pane, in canonical
+        /// `resource_lease` ordering.  Empty when `--resource` was not
+        /// passed.  Added alongside `worktree` for the same reason.
+        #[serde(default)]
+        resources: Vec<String>,
     },
     /// The LLM called the `switch_model` tool and the active model changed.
     ///
@@ -862,6 +876,8 @@ mod tests {
             tag: "pr-123".into(),
             pane_id: "%3".into(),
             session_id: "uuid-xyz".into(),
+            worktree: Some("/home/u/.amaebi/worktrees/amaebi/pr-123-ab12cd34".into()),
+            resources: vec!["xesim-9902".into(), "xesim-9903".into()],
         };
         let json = serde_json::to_string(&r).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -869,9 +885,63 @@ mod tests {
         assert_eq!(v["tag"], "pr-123");
         assert_eq!(v["pane_id"], "%3");
         assert_eq!(v["session_id"], "uuid-xyz");
+        assert_eq!(
+            v["worktree"],
+            "/home/u/.amaebi/worktrees/amaebi/pr-123-ab12cd34"
+        );
+        assert_eq!(v["resources"][0], "xesim-9902");
+        assert_eq!(v["resources"][1], "xesim-9903");
 
         let back: Response = serde_json::from_str(&json).unwrap();
-        assert!(matches!(back, Response::PaneAssigned { .. }));
+        let Response::PaneAssigned {
+            tag,
+            pane_id,
+            session_id,
+            worktree,
+            resources,
+        } = back
+        else {
+            panic!("expected PaneAssigned");
+        };
+        assert_eq!(tag, "pr-123");
+        assert_eq!(pane_id, "%3");
+        assert_eq!(session_id, "uuid-xyz");
+        assert_eq!(
+            worktree.as_deref(),
+            Some("/home/u/.amaebi/worktrees/amaebi/pr-123-ab12cd34")
+        );
+        assert_eq!(resources, vec!["xesim-9902", "xesim-9903"]);
+    }
+
+    /// A daemon that predates PR B emits `PaneAssigned` frames without
+    /// `worktree` / `resources`.  Deserialising such a frame must still
+    /// succeed and land on the documented defaults, so a newer client can
+    /// talk to an older daemon without `serde` erroring on the missing
+    /// fields.
+    #[test]
+    fn response_pane_assigned_defaults_when_old_format() {
+        let legacy = r#"{
+            "type": "pane_assigned",
+            "tag": "pr-123",
+            "pane_id": "%3",
+            "session_id": "uuid-xyz"
+        }"#;
+        let back: Response = serde_json::from_str(legacy).unwrap();
+        let Response::PaneAssigned {
+            tag,
+            pane_id,
+            session_id,
+            worktree,
+            resources,
+        } = back
+        else {
+            panic!("expected PaneAssigned");
+        };
+        assert_eq!(tag, "pr-123");
+        assert_eq!(pane_id, "%3");
+        assert_eq!(session_id, "uuid-xyz");
+        assert_eq!(worktree, None);
+        assert!(resources.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Implements **PR B** of the `/claude` chat-takeover refactor — see design contract in `docs/design/claude-chat-takeover.md` (design PR #150).
- **Field-expansion only — zero behavioural change.** Existing `/claude` flow keeps working exactly as today; the client still renders only `[pane %X] tag=Y → session Z`.
- `Response::PaneAssigned` gains `#[serde(default)] worktree: Option<String>` and `#[serde(default)] resources: Vec<String>` so a later PR (F) can synthesise a `[launched]` user turn client-side without a second round-trip.
- Daemon populates both from the existing `worktree` binding and the in-scope `resource_leases` vector inside `handle_claude_launch`.
- Client destructures of `Response::PaneAssigned` gained a `..` rest-pattern; no other client change is made (none is allowed per the PR plan).

## Changes

- `src/ipc.rs` — two new fields on `Response::PaneAssigned`, both `#[serde(default)]` (matches the convention used by `TaskSpec::resume_pane`, `TaskSpec::resources`, `TaskSpec::resource_timeout_secs`, `SupervisionTarget::tag`, `SupervisionTarget::repo_dir`).
- `src/ipc.rs` (tests) — round-trip test extended to cover non-empty values on both new fields, and a new `response_pane_assigned_defaults_when_old_format` test deserialises a legacy frame (no `worktree`, no `resources`) and verifies `None` / empty-vec defaults.
- `src/daemon.rs` — at the `PaneAssigned { ... }` construction site in `handle_claude_launch`, extract `let resources: Vec<String> = resource_leases.iter().map(|r| r.name.clone()).collect();` and move `worktree` into the frame.
- `src/client.rs` — two destructures (`run` at line 631, `run_chat_loop` at line 1181) get `..` to stay exhaustive-safe.
- `Cargo.toml` / `Cargo.lock` — calver bump to `2026.5.3` (one `feat(...)` commit in 2026-05).

## Not in this PR (per design doc)

- No new tool, no new IPC variant, no new `DaemonState` field. Those belong to PR C (`task_done`, `ClaudeRelease`, `HeldResources`, idempotent release fn).
- No `handle_supervision*` changes — the entire supervision path is untouched; PR F deletes it atomically.

## Test plan

- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy -- -D warnings` — no NEW warnings; the 4 pre-existing ones on `master` (unused `steer`, `unnecessary_get_then_check`, `type_complexity`, `useless_vec`) are untouched.
- [x] `cargo test` — 658 unit tests + 38 integration tests pass; the new `response_pane_assigned_defaults_when_old_format` and the extended round-trip test both pass.
- [x] `bash scripts/next-version.sh --check` — prints `OK 2026.5.3`.
- [ ] Interactive tmux `/claude` smoke test — **skipped**: running in a headless agent environment with no tmux server / interactive terminal available. The field-expansion is covered by the serde round-trip tests; the daemon-side population happens in a single plain `let` + struct literal with no conditional logic.

Design doc: PR #150 (`design/chat-takeover`).