### PR TITLE
feat(chat): plan checklist — LLM-written, client-rendered progress line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.18"
+version = "2026.5.19"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.16"
+version = "2026.5.17"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.17"
+version = "2026.5.18"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.19"
+version = "2026.5.20"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.20"
+version = "2026.5.21"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.18"
+version = "2026.5.19"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.17"
+version = "2026.5.18"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.16"
+version = "2026.5.17"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.20"
+version = "2026.5.21"
 edition = "2021"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.19"
+version = "2026.5.20"
 edition = "2021"
 
 [[bin]]

--- a/src/client.rs
+++ b/src/client.rs
@@ -203,62 +203,82 @@ fn render_markdown(text: &str) -> String {
 /// The LLM is instructed (see `format_pane_alive_reminder` in daemon.rs)
 /// to rewrite its plan on every status change using `- [ ]` / `- [x]`
 /// markers.  We watch the text buffer, find the last contiguous run of
-/// checklist lines, count done vs. total, and emit a `\r[3/5 done]`
-/// status line so the user sees progress without scroll.
+/// checklist lines, count done vs. total, and emit a
+/// `\r\x1b[K[plan {done}/{total} done]` status line so the user sees
+/// progress without scroll.  The leading `\r` anchors at column 0 and
+/// the `\x1b[K` clear-to-EOL prevents stale glyphs when successive
+/// renders have different widths; no trailing newline is emitted until
+/// the turn finishes.
 ///
 /// Intentionally tolerant — malformed or partial checklists reduce to
 /// "no progress update this tick" rather than crash.  Emits only when
 /// (done, total) changes across renders so the stderr line doesn't flap.
+///
+/// Parsing is incremental: each `push` advances `parsed_offset` over
+/// complete (newline-terminated) lines only, updating the running
+/// `current` / `latest` state.  That keeps per-chunk work proportional
+/// to the chunk size rather than the whole accumulated buffer, so a
+/// long streamed response doesn't degrade to O(n²).
 #[derive(Default)]
 struct PlanProgressTracker {
     buf: String,
+    /// Byte offset in `buf` up to which we've already parsed complete
+    /// lines.  Partial trailing text (no newline yet) is left for a
+    /// future `push` to complete.
+    parsed_offset: usize,
+    /// Running counts for the current contiguous checklist run.  `None`
+    /// once a non-checklist non-blank line terminates the run.
+    current: Option<(usize, usize)>,
+    /// Most recent fully-terminated checklist run.  `current` wins over
+    /// this when both are populated (latest-run-wins).
+    latest: Option<(usize, usize)>,
     last_emitted: Option<(usize, usize)>,
 }
 
 impl PlanProgressTracker {
     fn push(&mut self, chunk: &str) {
         self.buf.push_str(chunk);
-    }
-
-    /// Extract (done, total) for the most recent contiguous checklist in
-    /// `buf`.  "Recent" = the last run of `- [ ]` / `- [x]` lines,
-    /// separated from prior runs by any non-checklist line.  Handles
-    /// leading indentation (nested bullets) and case-insensitive `[X]`.
-    fn latest_progress(&self) -> Option<(usize, usize)> {
-        let mut current: Option<(usize, usize)> = None;
-        let mut latest: Option<(usize, usize)> = None;
-        for line in self.buf.lines() {
+        // Only consume up to the last newline in the unparsed region;
+        // any trailing partial line stays buffered for next push.
+        let Some(rel) = self.buf[self.parsed_offset..].rfind('\n') else {
+            return;
+        };
+        let end = self.parsed_offset + rel + 1;
+        // Extend the borrow by slicing first, then iterate lines().
+        let slice = &self.buf[self.parsed_offset..end];
+        for line in slice.lines() {
             let trimmed = line.trim_start();
-            let is_checklist_item = trimmed.starts_with("- [ ]")
-                || trimmed.starts_with("- [x]")
-                || trimmed.starts_with("- [X]");
-            if is_checklist_item {
-                let done = if trimmed.starts_with("- [x]") || trimmed.starts_with("- [X]") {
-                    1
-                } else {
-                    0
-                };
-                let (cd, ct) = current.unwrap_or((0, 0));
-                current = Some((cd + done, ct + 1));
+            let is_done = trimmed.starts_with("- [x]") || trimmed.starts_with("- [X]");
+            let is_pending = trimmed.starts_with("- [ ]");
+            if is_done || is_pending {
+                let done = if is_done { 1 } else { 0 };
+                let (cd, ct) = self.current.unwrap_or((0, 0));
+                self.current = Some((cd + done, ct + 1));
             } else if !trimmed.is_empty() {
                 // Non-checklist non-blank line terminates the current run.
-                if current.is_some() {
-                    latest = current.take();
+                if self.current.is_some() {
+                    self.latest = self.current.take();
                 }
             }
             // Blank lines inside a checklist are tolerated (some models
             // add them between items).
         }
-        // `current` may still hold the final run if the buffer ended on
-        // a checklist line.  That one wins — it's the latest.
-        current.or(latest)
+        self.parsed_offset = end;
+    }
+
+    /// Extract (done, total) for the most recent contiguous checklist.
+    /// `current` (still-open run) wins over `latest` (closed run) so
+    /// the displayed progress always reflects the newest plan the LLM
+    /// has emitted.
+    fn latest_progress(&self) -> Option<(usize, usize)> {
+        self.current.or(self.latest)
     }
 
     /// Emit a stderr progress line IF `latest_progress` has changed.
     /// Best-effort; write errors are swallowed.
     async fn render_if_changed<W>(&mut self, err: &mut W)
     where
-        W: tokio::io::AsyncWriteExt + Unpin,
+        W: tokio::io::AsyncWrite + Unpin,
     {
         let Some((done, total)) = self.latest_progress() else {
             return;
@@ -284,7 +304,7 @@ impl PlanProgressTracker {
     /// completed turn.  No-op when nothing was ever emitted.
     async fn finish<W>(&mut self, err: &mut W)
     where
-        W: tokio::io::AsyncWriteExt + Unpin,
+        W: tokio::io::AsyncWrite + Unpin,
     {
         if self.last_emitted.is_some() {
             let _ = err.write_all(b"\n").await;
@@ -1275,8 +1295,11 @@ pub async fn run_chat_loop(
     // Plan progress tracker — separate from md_buf because its input is
     // raw chunks (pre-markdown-render), per-turn not per-session, and its
     // output goes to stderr not stdout.  A fresh tracker is installed on
-    // every new turn inside the stream loop below.
+    // every new turn inside the stream loop below.  We hold a single
+    // `stderr` handle for the whole session and reuse it on every render
+    // so the per-chunk hot path doesn't re-acquire the descriptor.
     let mut plan_tracker = PlanProgressTracker::default();
+    let mut plan_err = tokio::io::stderr();
 
     'session: loop {
         let prompt = match next_prompt.take() {
@@ -1657,8 +1680,7 @@ pub async fn run_chat_loop(
                                 // markers survive intact.  Emits a stderr
                                 // `[plan N/M done]` line on progress change.
                                 plan_tracker.push(&chunk);
-                                let mut err = tokio::io::stderr();
-                                plan_tracker.render_if_changed(&mut err).await;
+                                plan_tracker.render_if_changed(&mut plan_err).await;
                                 while let Some(ready) = md_buf.flush_if_ready() {
                                     let out = render_markdown(&ready);
                                     stdout.write_all(out.as_bytes()).await?;
@@ -1682,8 +1704,7 @@ pub async fn run_chat_loop(
                             // Move the cursor off the plan status line (if
                             // one was emitted) and reset the tracker for
                             // the next turn.
-                            let mut err = tokio::io::stderr();
-                            plan_tracker.finish(&mut err).await;
+                            plan_tracker.finish(&mut plan_err).await;
                             plan_tracker = PlanProgressTracker::default();
                             break;
                         }
@@ -1699,6 +1720,11 @@ pub async fn run_chat_loop(
                             let msg = format!("Error: {message}\n");
                             stdout.write_all(msg.as_bytes()).await?;
                             stdout.flush().await?;
+                            // Error path terminates the turn just like Done;
+                            // finish the progress line and reset the tracker
+                            // so stale counts don't bleed into the next turn.
+                            plan_tracker.finish(&mut plan_err).await;
+                            plan_tracker = PlanProgressTracker::default();
                             break;
                         }
                         Response::ToolUse { name, detail } => {
@@ -4376,5 +4402,17 @@ mod tests {
         t.push("Just some prose without any checklist in it.\n");
         t.push("Maybe a bullet - no brackets.\n");
         assert!(t.latest_progress().is_none());
+    }
+
+    #[test]
+    fn plan_tracker_incremental_handles_midline_split() {
+        // Streamed input often splits inside a line.  The parser must
+        // defer scoring a line until its terminating newline arrives,
+        // otherwise a half-seen "- [ " would be misclassified.
+        let mut t = PlanProgressTracker::default();
+        t.push("- [x] done\n- [");
+        assert_eq!(t.latest_progress(), Some((1, 1)));
+        t.push(" ] pending\n");
+        assert_eq!(t.latest_progress(), Some((1, 2)));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -197,6 +197,102 @@ fn render_markdown(text: &str) -> String {
     }
 }
 
+/// Accumulates streamed assistant text and renders the most recent
+/// markdown checklist as a stderr progress line.
+///
+/// The LLM is instructed (see `format_pane_alive_reminder` in daemon.rs)
+/// to rewrite its plan on every status change using `- [ ]` / `- [x]`
+/// markers.  We watch the text buffer, find the last contiguous run of
+/// checklist lines, count done vs. total, and emit a `\r[3/5 done]`
+/// status line so the user sees progress without scroll.
+///
+/// Intentionally tolerant — malformed or partial checklists reduce to
+/// "no progress update this tick" rather than crash.  Emits only when
+/// (done, total) changes across renders so the stderr line doesn't flap.
+#[derive(Default)]
+struct PlanProgressTracker {
+    buf: String,
+    last_emitted: Option<(usize, usize)>,
+}
+
+impl PlanProgressTracker {
+    fn push(&mut self, chunk: &str) {
+        self.buf.push_str(chunk);
+    }
+
+    /// Extract (done, total) for the most recent contiguous checklist in
+    /// `buf`.  "Recent" = the last run of `- [ ]` / `- [x]` lines,
+    /// separated from prior runs by any non-checklist line.  Handles
+    /// leading indentation (nested bullets) and case-insensitive `[X]`.
+    fn latest_progress(&self) -> Option<(usize, usize)> {
+        let mut current: Option<(usize, usize)> = None;
+        let mut latest: Option<(usize, usize)> = None;
+        for line in self.buf.lines() {
+            let trimmed = line.trim_start();
+            let is_checklist_item = trimmed.starts_with("- [ ]")
+                || trimmed.starts_with("- [x]")
+                || trimmed.starts_with("- [X]");
+            if is_checklist_item {
+                let done = if trimmed.starts_with("- [x]") || trimmed.starts_with("- [X]") {
+                    1
+                } else {
+                    0
+                };
+                let (cd, ct) = current.unwrap_or((0, 0));
+                current = Some((cd + done, ct + 1));
+            } else if !trimmed.is_empty() {
+                // Non-checklist non-blank line terminates the current run.
+                if current.is_some() {
+                    latest = current.take();
+                }
+            }
+            // Blank lines inside a checklist are tolerated (some models
+            // add them between items).
+        }
+        // `current` may still hold the final run if the buffer ended on
+        // a checklist line.  That one wins — it's the latest.
+        current.or(latest)
+    }
+
+    /// Emit a stderr progress line IF `latest_progress` has changed.
+    /// Best-effort; write errors are swallowed.
+    async fn render_if_changed<W>(&mut self, err: &mut W)
+    where
+        W: tokio::io::AsyncWriteExt + Unpin,
+    {
+        let Some((done, total)) = self.latest_progress() else {
+            return;
+        };
+        if total == 0 {
+            return;
+        }
+        if self.last_emitted == Some((done, total)) {
+            return;
+        }
+        self.last_emitted = Some((done, total));
+        // `\r` anchors the line at column 0 so subsequent renders
+        // overwrite in place; final `\n` intentionally omitted.
+        // `\x1b[K` clears to end-of-line so a shorter new line doesn't
+        // leave stale glyphs from the previous render.
+        let line = format!("\r\x1b[K[plan {done}/{total} done]");
+        let _ = err.write_all(line.as_bytes()).await;
+        let _ = err.flush().await;
+    }
+
+    /// Emit a final newline on stderr so the stream moves off the
+    /// progress line before the next chat `>` prompt.  Called once per
+    /// completed turn.  No-op when nothing was ever emitted.
+    async fn finish<W>(&mut self, err: &mut W)
+    where
+        W: tokio::io::AsyncWriteExt + Unpin,
+    {
+        if self.last_emitted.is_some() {
+            let _ = err.write_all(b"\n").await;
+            let _ = err.flush().await;
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Slash command parsing
 // ---------------------------------------------------------------------------
@@ -1176,6 +1272,11 @@ pub async fn run_chat_loop(
     // streaming output does not interleave with user input.
     let mut steer_text_buf: Vec<String> = Vec::new();
     let mut md_buf = MarkdownBuffer::default();
+    // Plan progress tracker — separate from md_buf because its input is
+    // raw chunks (pre-markdown-render), per-turn not per-session, and its
+    // output goes to stderr not stdout.  A fresh tracker is installed on
+    // every new turn inside the stream loop below.
+    let mut plan_tracker = PlanProgressTracker::default();
 
     'session: loop {
         let prompt = match next_prompt.take() {
@@ -1551,6 +1652,13 @@ pub async fn run_chat_loop(
                                 steer_text_buf.push(chunk);
                             } else {
                                 md_buf.push(&chunk);
+                                // Feed raw chunk (not the markdown-rendered
+                                // output) to the plan tracker so checklist
+                                // markers survive intact.  Emits a stderr
+                                // `[plan N/M done]` line on progress change.
+                                plan_tracker.push(&chunk);
+                                let mut err = tokio::io::stderr();
+                                plan_tracker.render_if_changed(&mut err).await;
                                 while let Some(ready) = md_buf.flush_if_ready() {
                                     let out = render_markdown(&ready);
                                     stdout.write_all(out.as_bytes()).await?;
@@ -1571,6 +1679,12 @@ pub async fn run_chat_loop(
                             }
                             stdout.write_all(b"\n").await?;
                             stdout.flush().await?;
+                            // Move the cursor off the plan status line (if
+                            // one was emitted) and reset the tracker for
+                            // the next turn.
+                            let mut err = tokio::io::stderr();
+                            plan_tracker.finish(&mut err).await;
+                            plan_tracker = PlanProgressTracker::default();
                             break;
                         }
                         Response::Error { message } => {
@@ -4194,5 +4308,73 @@ mod tests {
         let dirty = format_task_released("%54", &[], None, None, Some("/path"), true, "");
         assert!(clean.contains("worktree=/path\n") || clean.contains("worktree=/path "));
         assert!(dirty.contains("worktree=/path (dirty)"));
+    }
+
+    // ------------------------------------------------------------------
+    // PlanProgressTracker
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn plan_tracker_empty_returns_none() {
+        let t = PlanProgressTracker::default();
+        assert!(t.latest_progress().is_none());
+    }
+
+    #[test]
+    fn plan_tracker_all_pending() {
+        let mut t = PlanProgressTracker::default();
+        t.push("- [ ] Step 1\n- [ ] Step 2\n- [ ] Step 3\n");
+        assert_eq!(t.latest_progress(), Some((0, 3)));
+    }
+
+    #[test]
+    fn plan_tracker_mixed_done() {
+        let mut t = PlanProgressTracker::default();
+        t.push("- [x] Step 1\n- [X] Step 2\n- [ ] Step 3\n");
+        assert_eq!(t.latest_progress(), Some((2, 3)));
+    }
+
+    #[test]
+    fn plan_tracker_picks_latest_run() {
+        // First checklist (superseded) + narrative line + second checklist.
+        let mut t = PlanProgressTracker::default();
+        t.push("- [ ] old step A\n- [ ] old step B\n");
+        t.push("Here is my revised plan:\n");
+        t.push("- [x] new step 1\n- [ ] new step 2\n");
+        assert_eq!(t.latest_progress(), Some((1, 2)));
+    }
+
+    #[test]
+    fn plan_tracker_indented_bullets_count() {
+        let mut t = PlanProgressTracker::default();
+        t.push("  - [ ] indented step\n    - [x] deeper step\n");
+        assert_eq!(t.latest_progress(), Some((1, 2)));
+    }
+
+    #[test]
+    fn plan_tracker_tolerates_blank_lines_inside_run() {
+        let mut t = PlanProgressTracker::default();
+        t.push("- [x] Step 1\n\n- [x] Step 2\n\n- [ ] Step 3\n");
+        assert_eq!(t.latest_progress(), Some((2, 3)));
+    }
+
+    #[test]
+    fn plan_tracker_non_checklist_resets_run() {
+        // A narrative sentence between two checklist blocks must make the
+        // SECOND block win — we want the most recent plan, not a merged
+        // count of both.
+        let mut t = PlanProgressTracker::default();
+        t.push("- [x] A\n- [x] B\n- [x] C\n");
+        t.push("Revised plan below:\n");
+        t.push("- [ ] X\n- [ ] Y\n");
+        assert_eq!(t.latest_progress(), Some((0, 2)));
+    }
+
+    #[test]
+    fn plan_tracker_no_checklist_markers_returns_none() {
+        let mut t = PlanProgressTracker::default();
+        t.push("Just some prose without any checklist in it.\n");
+        t.push("Maybe a bullet - no brackets.\n");
+        assert!(t.latest_progress().is_none());
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -221,6 +221,14 @@ fn render_markdown(text: &str) -> String {
 /// streamed output.  Per-chunk work is proportional to the chunk size,
 /// not the accumulated response, so long streams don't degrade to O(n²)
 /// and memory doesn't duplicate what `MarkdownBuffer` already holds.
+///
+/// Rendering is gated on `render_enabled` (caller-supplied, typically
+/// `std::io::stderr().is_terminal()`).  When stderr is not a TTY —
+/// e.g. `amaebi chat 2>progress.log` — the tracker still parses the
+/// stream to stay consistent with the rest of the code, but skips all
+/// `\r\x1b[K…` ANSI control writes so redirected output stays free of
+/// terminal escape noise.  Matches the pattern used for other stderr
+/// UI in this file (`ToolUse`, `Compacting`, the SIGINT steer banner).
 #[derive(Default)]
 struct PlanProgressTracker {
     /// Unparsed tail of the stream — at most one partial (no-newline)
@@ -234,9 +242,20 @@ struct PlanProgressTracker {
     /// this when both are populated (latest-run-wins).
     latest: Option<(usize, usize)>,
     last_emitted: Option<(usize, usize)>,
+    /// `false` when stderr is not a TTY — all async render / clear /
+    /// finish methods become no-ops so we don't pollute a redirected
+    /// log with `\r\x1b[K[plan …]` noise.
+    render_enabled: bool,
 }
 
 impl PlanProgressTracker {
+    fn new(render_enabled: bool) -> Self {
+        Self {
+            render_enabled,
+            ..Default::default()
+        }
+    }
+
     fn push(&mut self, chunk: &str) {
         self.buf.push_str(chunk);
         // Only consume up to the last newline; any trailing partial
@@ -280,6 +299,9 @@ impl PlanProgressTracker {
     where
         W: tokio::io::AsyncWrite + Unpin,
     {
+        if !self.render_enabled {
+            return;
+        }
         let Some((done, total)) = self.latest_progress() else {
             return;
         };
@@ -306,6 +328,9 @@ impl PlanProgressTracker {
     where
         W: tokio::io::AsyncWrite + Unpin,
     {
+        if !self.render_enabled {
+            return;
+        }
         if self.last_emitted.is_some() {
             let _ = err.write_all(b"\n").await;
             let _ = err.flush().await;
@@ -323,7 +348,7 @@ impl PlanProgressTracker {
     where
         W: tokio::io::AsyncWrite + Unpin,
     {
-        if self.last_emitted.is_none() {
+        if !self.render_enabled || self.last_emitted.is_none() {
             return;
         }
         // `\r\x1b[K` wipes the status line in place; we don't need a
@@ -1320,7 +1345,12 @@ pub async fn run_chat_loop(
     // every new turn inside the stream loop below.  We hold a single
     // `stderr` handle for the whole session and reuse it on every render
     // so the per-chunk hot path doesn't re-acquire the descriptor.
-    let mut plan_tracker = PlanProgressTracker::default();
+    // Gate plan-line rendering on stderr being a TTY — when redirected
+    // (e.g. `amaebi chat 2>progress.log`) we skip all `\r\x1b[K…` writes
+    // so the log file stays free of terminal escape sequences.  Computed
+    // once per session; the handle type doesn't change mid-process.
+    let stderr_is_tty = std::io::stderr().is_terminal();
+    let mut plan_tracker = PlanProgressTracker::new(stderr_is_tty);
     let mut plan_err = tokio::io::stderr();
 
     'session: loop {
@@ -1733,7 +1763,7 @@ pub async fn run_chat_loop(
                             // one was emitted) and reset the tracker for
                             // the next turn.
                             plan_tracker.finish(&mut plan_err).await;
-                            plan_tracker = PlanProgressTracker::default();
+                            plan_tracker = PlanProgressTracker::new(stderr_is_tty);
                             break;
                         }
                         Response::Error { message } => {
@@ -1752,7 +1782,7 @@ pub async fn run_chat_loop(
                             // finish the progress line and reset the tracker
                             // so stale counts don't bleed into the next turn.
                             plan_tracker.finish(&mut plan_err).await;
-                            plan_tracker = PlanProgressTracker::default();
+                            plan_tracker = PlanProgressTracker::new(stderr_is_tty);
                             break;
                         }
                         Response::ToolUse { name, detail } => {
@@ -4474,7 +4504,7 @@ mod tests {
         // (e.g. a tool notice) must be preceded by `\r\x1b[K` so it
         // doesn't concatenate onto the `[plan …]` row.  Idempotent: a
         // second call with no fresh render is a no-op.
-        let mut t = PlanProgressTracker::default();
+        let mut t = PlanProgressTracker::new(true);
         t.push("- [x] step 1\n- [ ] step 2\n");
         let mut sink: Vec<u8> = Vec::new();
         t.render_if_changed(&mut sink).await;
@@ -4486,5 +4516,23 @@ mod tests {
         sink.clear();
         t.clear_for_mid_turn_output(&mut sink).await;
         assert!(sink.is_empty());
+    }
+
+    #[tokio::test]
+    async fn plan_tracker_non_tty_skips_all_ansi_writes() {
+        // Regression guard: when stderr isn't a TTY (e.g. redirected to
+        // a log), the tracker must not emit `\r\x1b[K…` escape codes,
+        // even though it still parses the stream to keep counts current.
+        let mut t = PlanProgressTracker::new(false);
+        t.push("- [x] a\n- [ ] b\n");
+        assert_eq!(t.latest_progress(), Some((1, 2)));
+        let mut sink: Vec<u8> = Vec::new();
+        t.render_if_changed(&mut sink).await;
+        t.clear_for_mid_turn_output(&mut sink).await;
+        t.finish(&mut sink).await;
+        assert!(
+            sink.is_empty(),
+            "non-tty tracker wrote escape bytes: {sink:?}"
+        );
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -214,18 +214,19 @@ fn render_markdown(text: &str) -> String {
 /// "no progress update this tick" rather than crash.  Emits only when
 /// (done, total) changes across renders so the stderr line doesn't flap.
 ///
-/// Parsing is incremental: each `push` advances `parsed_offset` over
-/// complete (newline-terminated) lines only, updating the running
-/// `current` / `latest` state.  That keeps per-chunk work proportional
-/// to the chunk size rather than the whole accumulated buffer, so a
-/// long streamed response doesn't degrade to O(n²).
+/// Parsing is incremental: each `push` consumes complete
+/// (newline-terminated) lines only, updating the running `current` /
+/// `latest` state, then drops the parsed prefix so `buf` stays at
+/// O(size_of_unparsed_tail) rather than growing with the whole turn's
+/// streamed output.  Per-chunk work is proportional to the chunk size,
+/// not the accumulated response, so long streams don't degrade to O(n²)
+/// and memory doesn't duplicate what `MarkdownBuffer` already holds.
 #[derive(Default)]
 struct PlanProgressTracker {
+    /// Unparsed tail of the stream — at most one partial (no-newline)
+    /// line at any point, since `push` drains completed lines before
+    /// returning.
     buf: String,
-    /// Byte offset in `buf` up to which we've already parsed complete
-    /// lines.  Partial trailing text (no newline yet) is left for a
-    /// future `push` to complete.
-    parsed_offset: usize,
     /// Running counts for the current contiguous checklist run.  `None`
     /// once a non-checklist non-blank line terminates the run.
     current: Option<(usize, usize)>,
@@ -238,15 +239,14 @@ struct PlanProgressTracker {
 impl PlanProgressTracker {
     fn push(&mut self, chunk: &str) {
         self.buf.push_str(chunk);
-        // Only consume up to the last newline in the unparsed region;
-        // any trailing partial line stays buffered for next push.
-        let Some(rel) = self.buf[self.parsed_offset..].rfind('\n') else {
+        // Only consume up to the last newline; any trailing partial
+        // line stays buffered for next push.
+        let Some(end) = self.buf.rfind('\n').map(|i| i + 1) else {
             return;
         };
-        let end = self.parsed_offset + rel + 1;
-        // Extend the borrow by slicing first, then iterate lines().
-        let slice = &self.buf[self.parsed_offset..end];
-        for line in slice.lines() {
+        // Parse the complete-lines prefix, then drain it so `buf`
+        // shrinks back to just the unparsed tail.
+        for line in self.buf[..end].lines() {
             let trimmed = line.trim_start();
             let is_done = trimmed.starts_with("- [x]") || trimmed.starts_with("- [X]");
             let is_pending = trimmed.starts_with("- [ ]");
@@ -263,7 +263,7 @@ impl PlanProgressTracker {
             // Blank lines inside a checklist are tolerated (some models
             // add them between items).
         }
-        self.parsed_offset = end;
+        self.buf.drain(..end);
     }
 
     /// Extract (done, total) for the most recent contiguous checklist.
@@ -310,6 +310,28 @@ impl PlanProgressTracker {
             let _ = err.write_all(b"\n").await;
             let _ = err.flush().await;
         }
+    }
+
+    /// Clear an in-place plan line so mid-turn stderr output (tool
+    /// notices, compacting banners, SIGINT prompt, …) doesn't append
+    /// onto it and produce a garbled row like
+    /// `[plan 2/5 done]📄 foo.rs`.  Idempotent: no-op when nothing has
+    /// been emitted this turn.  After this returns the next
+    /// `render_if_changed` will re-draw the status line (the reset of
+    /// `last_emitted` forces a fresh render on the next progress tick).
+    async fn clear_for_mid_turn_output<W>(&mut self, err: &mut W)
+    where
+        W: tokio::io::AsyncWrite + Unpin,
+    {
+        if self.last_emitted.is_none() {
+            return;
+        }
+        // `\r\x1b[K` wipes the status line in place; we don't need a
+        // newline here — the caller is about to print one itself
+        // (`eprintln!` et al).
+        let _ = err.write_all(b"\r\x1b[K").await;
+        let _ = err.flush().await;
+        self.last_emitted = None;
     }
 }
 
@@ -1646,6 +1668,7 @@ pub async fn run_chat_loop(
                     }
                     steer_pending = true;
                     if std::io::stderr().is_terminal() {
+                        plan_tracker.clear_for_mid_turn_output(&mut plan_err).await;
                         eprintln!("\n^C interrupted. Enter correction (empty line to cancel): ");
                         // The prompt marker `> ` is emitted by rustyline itself.
                     }
@@ -1668,6 +1691,16 @@ pub async fn run_chat_loop(
                     let resp: Response = serde_json::from_str(&line)?;
                     match resp {
                         Response::Text { chunk } => {
+                            // Always feed the tracker — even while steer-
+                            // buffering — so checklist updates emitted
+                            // during a `WaitingForInput` / Ctrl-C steer
+                            // prompt aren't dropped.  We only suppress the
+                            // *render* (status-line write to stderr) while
+                            // the user is typing, so the correction prompt
+                            // stays readable; the tracker will draw the
+                            // catch-up status line on the next chunk after
+                            // `SteerAck` clears `steer_pending`.
+                            plan_tracker.push(&chunk);
                             if steer_pending {
                                 // Buffer text while the user is typing a steer
                                 // correction so streaming output does not
@@ -1675,11 +1708,6 @@ pub async fn run_chat_loop(
                                 steer_text_buf.push(chunk);
                             } else {
                                 md_buf.push(&chunk);
-                                // Feed raw chunk (not the markdown-rendered
-                                // output) to the plan tracker so checklist
-                                // markers survive intact.  Emits a stderr
-                                // `[plan N/M done]` line on progress change.
-                                plan_tracker.push(&chunk);
                                 plan_tracker.render_if_changed(&mut plan_err).await;
                                 while let Some(ready) = md_buf.flush_if_ready() {
                                     let out = render_markdown(&ready);
@@ -1735,6 +1763,10 @@ pub async fn run_chat_loop(
                                 let _ = stdout.flush().await;
                             }
                             if std::io::stderr().is_terminal() {
+                                // Wipe any in-place `[plan N/M done]` line
+                                // so the tool notice doesn't concatenate
+                                // onto it and garble the row.
+                                plan_tracker.clear_for_mid_turn_output(&mut plan_err).await;
                                 match name.as_str() {
                                     "shell_command" => eprint!("{}", render_markdown(&format!("```bash\n$ {detail}\n```\n"))),
                                     "read_file"     => eprintln!("📄 {detail}"),
@@ -1748,6 +1780,7 @@ pub async fn run_chat_loop(
                             // iteration of the select! loop reads stdin via the
                             // existing steer arm — keeping SIGINT responsive.
                             if std::io::stderr().is_terminal() && !extra.is_empty() {
+                                plan_tracker.clear_for_mid_turn_output(&mut plan_err).await;
                                 eprintln!("\n{extra}");
                             }
                             // The prompt marker `> ` is emitted by rustyline itself.
@@ -1777,7 +1810,10 @@ pub async fn run_chat_loop(
                                 let _ = stdout.write_all(out.as_bytes()).await;
                                 let _ = stdout.flush().await;
                             }
-                            if std::io::stderr().is_terminal() { eprintln!("\n[compacting…]"); }
+                            if std::io::stderr().is_terminal() {
+                                plan_tracker.clear_for_mid_turn_output(&mut plan_err).await;
+                                eprintln!("\n[compacting…]");
+                            }
                         }
                         Response::ModelSwitched { model: new_model } => {
                             // Keep client model in sync so the next Request::Chat
@@ -4414,5 +4450,41 @@ mod tests {
         assert_eq!(t.latest_progress(), Some((1, 1)));
         t.push(" ] pending\n");
         assert_eq!(t.latest_progress(), Some((1, 2)));
+    }
+
+    #[test]
+    fn plan_tracker_buf_does_not_grow_with_stream_length() {
+        // Memory invariant: `buf` holds only the unparsed tail (at most
+        // one partial line).  Feeding many completed lines must leave
+        // `buf` empty; a trailing partial-line chunk leaves only that
+        // fragment in `buf`.
+        let mut t = PlanProgressTracker::default();
+        for _ in 0..1000 {
+            t.push("- [ ] step\n");
+        }
+        assert_eq!(t.buf.len(), 0);
+        assert_eq!(t.latest_progress(), Some((0, 1000)));
+        t.push("- [x");
+        assert_eq!(t.buf.as_str(), "- [x");
+    }
+
+    #[tokio::test]
+    async fn plan_tracker_clear_for_mid_turn_output_wipes_line() {
+        // After a status line has been emitted, mid-turn stderr output
+        // (e.g. a tool notice) must be preceded by `\r\x1b[K` so it
+        // doesn't concatenate onto the `[plan …]` row.  Idempotent: a
+        // second call with no fresh render is a no-op.
+        let mut t = PlanProgressTracker::default();
+        t.push("- [x] step 1\n- [ ] step 2\n");
+        let mut sink: Vec<u8> = Vec::new();
+        t.render_if_changed(&mut sink).await;
+        assert_eq!(sink, b"\r\x1b[K[plan 1/2 done]");
+        sink.clear();
+        t.clear_for_mid_turn_output(&mut sink).await;
+        assert_eq!(sink, b"\r\x1b[K");
+        assert_eq!(t.last_emitted, None);
+        sink.clear();
+        t.clear_for_mid_turn_output(&mut sink).await;
+        assert!(sink.is_empty());
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1738,12 +1738,37 @@ pub async fn run_chat_loop(
                                 steer_text_buf.push(chunk);
                             } else {
                                 md_buf.push(&chunk);
-                                plan_tracker.render_if_changed(&mut plan_err).await;
+                                // Output ordering within a tick: stdout
+                                // markdown comes FIRST, plan line LAST.
+                                // stdout and stderr share the terminal
+                                // cursor, so emitting the status line
+                                // before flushing markdown would land
+                                // the markdown at the end of `[plan N/M
+                                // done]`, garbling the row.  Clearing
+                                // the plan line before stdout writes
+                                // also prevents the old status bytes
+                                // from bleeding into the markdown line
+                                // when a redraw follows on the next tick.
+                                let mut flushed_stdout = false;
                                 while let Some(ready) = md_buf.flush_if_ready() {
+                                    if !flushed_stdout {
+                                        plan_tracker
+                                            .clear_for_mid_turn_output(&mut plan_err)
+                                            .await;
+                                        flushed_stdout = true;
+                                    }
                                     let out = render_markdown(&ready);
                                     stdout.write_all(out.as_bytes()).await?;
                                     stdout.flush().await?;
                                 }
+                                // Render the plan line AFTER all stdout
+                                // writes for this tick, so the status
+                                // line is always the last thing the
+                                // terminal drew — subsequent in-place
+                                // redraws via `\r\x1b[K` therefore
+                                // target the status line, not the
+                                // preceding markdown.
+                                plan_tracker.render_if_changed(&mut plan_err).await;
                             }
                         }
                         Response::Done => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -263,26 +263,49 @@ impl PlanProgressTracker {
         let Some(end) = self.buf.rfind('\n').map(|i| i + 1) else {
             return;
         };
-        // Parse the complete-lines prefix, then drain it so `buf`
-        // shrinks back to just the unparsed tail.
-        for line in self.buf[..end].lines() {
-            let trimmed = line.trim_start();
-            let is_done = trimmed.starts_with("- [x]") || trimmed.starts_with("- [X]");
-            let is_pending = trimmed.starts_with("- [ ]");
-            if is_done || is_pending {
-                let done = if is_done { 1 } else { 0 };
-                let (cd, ct) = self.current.unwrap_or((0, 0));
-                self.current = Some((cd + done, ct + 1));
-            } else if !trimmed.is_empty() {
-                // Non-checklist non-blank line terminates the current run.
-                if self.current.is_some() {
-                    self.latest = self.current.take();
-                }
-            }
-            // Blank lines inside a checklist are tolerated (some models
-            // add them between items).
+        // Split the parsed prefix out of `buf` into an owned string
+        // before scoring.  `score_line` takes `&mut self`, so we can't
+        // hold a borrow into `self.buf` while calling it — splitting
+        // first drops the borrow cleanly.  `buf` is left as just the
+        // unparsed tail.
+        let prefix: String = self.buf.drain(..end).collect();
+        for line in prefix.lines() {
+            self.score_line(line);
         }
-        self.buf.drain(..end);
+    }
+
+    /// Score the still-unparsed tail as if it were a complete line.
+    /// Call at end-of-turn (e.g. before `finish()`) so a checklist item
+    /// emitted without a trailing newline — which models sometimes do
+    /// when the checklist is the final thing in the reply — is still
+    /// counted.  Idempotent: once called, `buf` is empty, so repeated
+    /// calls are no-ops.
+    fn finalize_tail(&mut self) {
+        if self.buf.is_empty() {
+            return;
+        }
+        // Clone the tail into a local owned string so `score_line`
+        // can take a `&str` without borrowing self twice.
+        let tail = std::mem::take(&mut self.buf);
+        self.score_line(&tail);
+    }
+
+    fn score_line(&mut self, line: &str) {
+        let trimmed = line.trim_start();
+        let is_done = trimmed.starts_with("- [x]") || trimmed.starts_with("- [X]");
+        let is_pending = trimmed.starts_with("- [ ]");
+        if is_done || is_pending {
+            let done = if is_done { 1 } else { 0 };
+            let (cd, ct) = self.current.unwrap_or((0, 0));
+            self.current = Some((cd + done, ct + 1));
+        } else if !trimmed.is_empty() {
+            // Non-checklist non-blank line terminates the current run.
+            if self.current.is_some() {
+                self.latest = self.current.take();
+            }
+        }
+        // Blank lines inside a checklist are tolerated (some models
+        // add them between items).
     }
 
     /// Extract (done, total) for the most recent contiguous checklist.
@@ -1772,8 +1795,12 @@ pub async fn run_chat_loop(
                             }
                         }
                         Response::Done => {
-                            // Drain any steer-buffered text through md_buf before
-                            // flush_all so the final output is markdown-rendered.
+                            // Drain any steer-buffered text through md_buf
+                            // before flush_all so the final output is
+                            // markdown-rendered.  `plan_tracker` already
+                            // saw each chunk when it first arrived
+                            // (under `Response::Text`), so we don't push
+                            // them again here.
                             for chunk in steer_text_buf.drain(..) {
                                 md_buf.push(&chunk);
                             }
@@ -1784,9 +1811,18 @@ pub async fn run_chat_loop(
                             }
                             stdout.write_all(b"\n").await?;
                             stdout.flush().await?;
-                            // Move the cursor off the plan status line (if
-                            // one was emitted) and reset the tracker for
-                            // the next turn.
+                            // Score the unparsed tail (e.g. a checklist
+                            // item emitted without a trailing newline at
+                            // the very end of the reply) so the final
+                            // status line reflects the complete plan
+                            // before we draw it.
+                            plan_tracker.finalize_tail();
+                            // Draw the final status line (picks up any
+                            // progress that was suppressed while
+                            // steer_pending or that arrived in the tail
+                            // we just finalized), then move the cursor
+                            // off it and reset for the next turn.
+                            plan_tracker.render_if_changed(&mut plan_err).await;
                             plan_tracker.finish(&mut plan_err).await;
                             plan_tracker = PlanProgressTracker::new(stderr_is_tty);
                             break;
@@ -1804,8 +1840,11 @@ pub async fn run_chat_loop(
                             stdout.write_all(msg.as_bytes()).await?;
                             stdout.flush().await?;
                             // Error path terminates the turn just like Done;
-                            // finish the progress line and reset the tracker
-                            // so stale counts don't bleed into the next turn.
+                            // finalize the buffered tail, draw a final
+                            // status line if progress changed, then
+                            // finish + reset.
+                            plan_tracker.finalize_tail();
+                            plan_tracker.render_if_changed(&mut plan_err).await;
                             plan_tracker.finish(&mut plan_err).await;
                             plan_tracker = PlanProgressTracker::new(stderr_is_tty);
                             break;
@@ -1857,6 +1896,17 @@ pub async fn run_chat_loop(
                                 }
                             }
                             let _ = stdout.flush().await;
+                            // The steer flow erased the in-place plan
+                            // line (via `clear_for_mid_turn_output` in
+                            // the SIGINT / WaitingForInput paths) and
+                            // reset `last_emitted`, so a fresh draw
+                            // here is not a no-op: it restores the
+                            // indicator immediately after steering ends.
+                            // Without this, the status line stays
+                            // erased until the next `Response::Text`
+                            // chunk — a problem when the LLM goes
+                            // straight from SteerAck to Done.
+                            plan_tracker.render_if_changed(&mut plan_err).await;
                         }
                         Response::Compacting => {
                             // Flush pending markdown before the compacting notice.
@@ -4559,5 +4609,35 @@ mod tests {
             sink.is_empty(),
             "non-tty tracker wrote escape bytes: {sink:?}"
         );
+    }
+
+    #[test]
+    fn plan_tracker_finalize_tail_counts_unterminated_last_line() {
+        // Models sometimes emit the final checklist item without a
+        // trailing newline, then the reply ends.  `push` alone won't
+        // score that line (it only parses up to the last newline), so
+        // the end-of-turn paths must call `finalize_tail` before
+        // rendering the final status line.
+        let mut t = PlanProgressTracker::new(true);
+        t.push("- [x] step 1\n- [ ] step 2");
+        // Before finalize: only the terminated line counts.
+        assert_eq!(t.latest_progress(), Some((1, 1)));
+        t.finalize_tail();
+        assert_eq!(t.latest_progress(), Some((1, 2)));
+        // Idempotent: a second call does nothing — `buf` is empty now.
+        t.finalize_tail();
+        assert_eq!(t.latest_progress(), Some((1, 2)));
+    }
+
+    #[test]
+    fn plan_tracker_finalize_tail_ignores_empty_buf() {
+        // End-of-turn path always calls finalize; calling it when the
+        // stream ended on a newline (tail is empty) must be a no-op,
+        // not a panic and not a phantom count.
+        let mut t = PlanProgressTracker::new(true);
+        t.push("- [x] a\n- [x] b\n");
+        assert_eq!(t.latest_progress(), Some((2, 2)));
+        t.finalize_tail();
+        assert_eq!(t.latest_progress(), Some((2, 2)));
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4740,7 +4740,28 @@ fn format_pane_alive_reminder(pane_ids: &[String]) -> String {
          Claude's output (via `tmux_capture_pane`) and judged the work \
          complete — do not call it on the first turn just to exit.  Once \
          ALL panes are released, this reminder disappears and you can \
-         reply with plain text again."
+         reply with plain text again.\n\
+         \n\
+         **Multi-step plan (≥3 steps).**  For tasks with three or more \
+         distinct steps, maintain a plan as a markdown checklist inside \
+         your text reply (NOT in a tool call):\n\
+         \n\
+         ```\n\
+         - [ ] Step 1 description\n\
+         - [ ] Step 2 description\n\
+         - [x] Step 3 description (done)\n\
+         ```\n\
+         \n\
+         Rewrite the WHOLE checklist on every turn that changes status — \
+         do not diff, do not output just the changed line.  Use `[ ]` for \
+         pending / in-progress and `[x]` for completed.  The client picks \
+         up the most recent complete checklist and renders a live \
+         progress indicator for the user; emitting only a partial list \
+         will confuse the indicator.  Put the final state of the \
+         checklist in your `task_done` summary so the inbox archive \
+         captures it.  For trivial single-step tasks (a one-line echo, a \
+         single file edit) skip the checklist entirely — the overhead \
+         isn't worth it."
     )
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -8153,6 +8153,38 @@ mod tests {
     }
 
     #[test]
+    fn pane_alive_reminder_instructs_multi_step_plan_checklist() {
+        // Regression guard for the prompt clause that tells the
+        // supervisor LLM to maintain a markdown checklist for
+        // ≥3-step tasks.  The client's `PlanProgressTracker`
+        // (src/client.rs) parses that checklist out of streamed text
+        // to render the live `[plan N/M done]` status line — if this
+        // clause gets silently rewritten or dropped, the feature
+        // degrades to "no progress indicator ever appears" with no
+        // compile-time or CI signal.
+        let r = format_pane_alive_reminder(&["%54".into()]);
+        assert!(
+            r.contains("Multi-step plan"),
+            "prompt must keep the multi-step plan section header so \
+             future edits see it as a load-bearing clause"
+        );
+        assert!(
+            r.contains("- [ ] Step 1 description") && r.contains("- [x] Step 3 description"),
+            "prompt must keep the exact `- [ ]` / `- [x]` example \
+             markers — the client parser (PlanProgressTracker) \
+             matches those literal prefixes, so paraphrasing the \
+             example (e.g. using `* [ ]` or `[ ] Step …`) would \
+             silently break the progress indicator"
+        );
+        assert!(
+            r.contains("Rewrite the WHOLE checklist on every turn"),
+            "prompt must keep the rewrite-whole-list directive — \
+             diff-only / partial-list output confuses the tracker's \
+             latest-run-wins logic"
+        );
+    }
+
+    #[test]
     fn pane_alive_reminder_lists_all_five_supervision_tools() {
         // Restrict the search to the "Your supervision vocabulary:"
         // section so a tool name mentioned in an earlier clause (e.g.


### PR DESCRIPTION
## Summary

A lightweight plan/todo mechanism for multi-step `/claude` tasks, built on the chat-takeover contract (#153) and the supervisor-autonomy / TUI-chrome fixes (#155, #156).

No new tools, no new state, no schema changes.  The design is **prompt-driven on the LLM side** and **pattern-driven on the client side**.

## Design

### daemon side: prompt instruction

`format_pane_alive_reminder` gets a new `**Multi-step plan (≥3 steps).**` section instructing the supervisor LLM to maintain a markdown checklist inside its text reply for any task with 3+ distinct steps:

```
- [ ] Step 1 description
- [ ] Step 2 description
- [x] Step 3 description (done)
```

- Rewrite the whole checklist on every turn (no diffs, no partial lists).
- Use `[ ]` for pending / in-progress and `[x]` for completed.
- Put the final checklist state in `task_done` summary so the inbox archive captures it.
- Trivial single-step tasks skip the checklist entirely.

### client side: progress tracker

`PlanProgressTracker` watches the streamed assistant text, parses the most recent contiguous run of checklist lines, and emits a `\r\x1b[K[plan N/M done]` line on **stderr** each time `(done, total)` changes.  The line is anchored at column 0 with `\x1b[K` so it overwrites in place; a trailing newline fires once per turn so the next chat prompt lands on a fresh row.

Tracker handles:
- Leading indentation (nested bullets)
- Case-insensitive `[X]`
- Blank lines between items
- Multiple checklists in one buffer (latest wins)
- Narrative sentences between checklists (reset the current run)
- Mid-line stream splits (parsing deferred until each line terminates)
- Bounded memory — `buf` drains its parsed prefix on each `push`, so it holds only the unparsed tail

Tracker state is **per-turn** — resets on every `Response::Done` / `Response::Error` so stale progress from one `/claude` doesn't bleed into the next.  `clear_for_mid_turn_output` wipes the in-place status line before any mid-turn `eprintln!` (tool notice, compacting banner, SIGINT steer prompt) so it doesn't concatenate onto the `[plan N/M done]` row.

## Test plan

- [x] 11 unit tests for `PlanProgressTracker`: empty input, all-pending, mixed done, latest-wins, indented bullets, blank lines between items, non-checklist sentence resets the run, prose-only returns None, mid-line stream split, bounded-buffer invariant over 1000 lines, `clear_for_mid_turn_output` emits `\r\x1b[K` idempotently.
- [x] `cargo test --bin amaebi` — 686 pass
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings` clean
- [x] `scripts/next-version.sh --check` — `OK 2026.5.21`

## Relation to other PRs

Builds on: #153 (chat-takeover), #154 (versioning delta-invariant), #155 (TUI chrome / resume hint), #156 (supervisor autonomy prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
