### PR TITLE
feat(chat): show /claude loop duration + stop premature task_done

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.22"
+version = "2026.5.23"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.22"
+version = "2026.5.23"
 edition = "2021"
 
 [[bin]]

--- a/src/client.rs
+++ b/src/client.rs
@@ -456,6 +456,7 @@ fn parse_slash_command(input: &str) -> Option<SlashCommand> {
 /// Chat, Resume, Ask, and `/release` stream handlers so rendering is
 /// consistent no matter how the release was triggered (task_done, /release,
 /// socket break in a different conn, etc.).
+#[allow(clippy::too_many_arguments)] // mirrors `Response::TaskReleased`'s fields 1:1
 fn format_task_released(
     pane_id: &str,
     resources_freed: &[String],
@@ -464,6 +465,7 @@ fn format_task_released(
     worktree_path: Option<&str>,
     worktree_dirty: bool,
     pane_tail: &str,
+    elapsed_ms: u64,
 ) -> String {
     let mut out = format!("[released {pane_id}]");
     if let Some(t) = tag {
@@ -479,6 +481,16 @@ fn format_task_released(
         ));
     }
     out.push('\n');
+    // `elapsed_ms == 0` only happens on legacy fixtures that predate
+    // the field (they deserialize with `#[serde(default)]`).  Skip the
+    // line in that case so replay diffs stay stable; real releases
+    // always round to at least a few milliseconds.
+    if elapsed_ms > 0 {
+        out.push_str(&format!(
+            "  duration: {}\n",
+            crate::ipc::format_duration_ms(elapsed_ms)
+        ));
+    }
     if let Some(s) = summary {
         out.push_str(&format!("  summary: {s}\n"));
     }
@@ -1220,6 +1232,7 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                         worktree_path,
                         worktree_dirty,
                         pane_tail,
+                        elapsed_ms,
                     } => {
                         let out = format_task_released(
                             &pane_id,
@@ -1229,6 +1242,7 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                             worktree_path.as_deref(),
                             worktree_dirty,
                             &pane_tail,
+                            elapsed_ms,
                         );
                         stdout.write_all(out.as_bytes()).await?;
                     }
@@ -1673,6 +1687,7 @@ pub async fn run_chat_loop(
                                     worktree_path,
                                     worktree_dirty,
                                     pane_tail,
+                                    elapsed_ms,
                                 } => {
                                     let out = format_task_released(
                                         &pane_id,
@@ -1682,6 +1697,7 @@ pub async fn run_chat_loop(
                                         worktree_path.as_deref(),
                                         worktree_dirty,
                                         &pane_tail,
+                                        elapsed_ms,
                                     );
                                     stdout.write_all(out.as_bytes()).await?;
                                 }
@@ -1934,6 +1950,7 @@ pub async fn run_chat_loop(
                             worktree_path,
                             worktree_dirty,
                             pane_tail,
+                            elapsed_ms,
                         } => {
                             // Flush any in-flight markdown before the release
                             // banner so the user sees a clear break.
@@ -1949,6 +1966,7 @@ pub async fn run_chat_loop(
                                 worktree_path.as_deref(),
                                 worktree_dirty,
                                 &pane_tail,
+                                elapsed_ms,
                             );
                             stdout.write_all(out.as_bytes()).await?;
                             stdout.flush().await?;
@@ -2319,6 +2337,7 @@ pub async fn run_resume(
                         worktree_path,
                         worktree_dirty,
                         pane_tail,
+                        elapsed_ms,
                     } => {
                         let out = format_task_released(
                             &pane_id,
@@ -2328,6 +2347,7 @@ pub async fn run_resume(
                             worktree_path.as_deref(),
                             worktree_dirty,
                             &pane_tail,
+                            elapsed_ms,
                         );
                         stdout.write_all(out.as_bytes()).await?;
                     }
@@ -4384,27 +4404,28 @@ mod tests {
 
     #[test]
     fn format_task_released_header_includes_pane_and_tag() {
-        let out = format_task_released("%54", &[], Some("kernel-opt"), None, None, false, "");
+        let out = format_task_released("%54", &[], Some("kernel-opt"), None, None, false, "", 0);
         assert!(out.starts_with("[released %54]"));
         assert!(out.contains("tag=kernel-opt"));
     }
 
     #[test]
     fn format_task_released_header_without_tag_omits_tag_field() {
-        let out = format_task_released("%54", &[], None, None, None, false, "");
+        let out = format_task_released("%54", &[], None, None, None, false, "", 0);
         assert!(out.starts_with("[released %54]"));
         assert!(!out.contains("tag="));
     }
 
     #[test]
     fn format_task_released_includes_summary_when_present() {
-        let out = format_task_released("%54", &[], None, Some("all tests pass"), None, false, "");
+        let out =
+            format_task_released("%54", &[], None, Some("all tests pass"), None, false, "", 0);
         assert!(out.contains("  summary: all tests pass\n"));
     }
 
     #[test]
     fn format_task_released_summary_absent_when_none() {
-        let out = format_task_released("%54", &[], None, None, None, false, "");
+        let out = format_task_released("%54", &[], None, None, None, false, "", 0);
         assert!(!out.contains("  summary: "));
     }
 
@@ -4413,8 +4434,8 @@ mod tests {
         // Hint block must appear regardless of tag presence — the pane
         // is preserved across release and --resume-pane is the correct
         // reuse path.
-        let with_tag = format_task_released("%54", &[], Some("foo"), None, None, false, "");
-        let without_tag = format_task_released("%7", &[], None, None, None, false, "");
+        let with_tag = format_task_released("%54", &[], Some("foo"), None, None, false, "", 0);
+        let without_tag = format_task_released("%7", &[], None, None, None, false, "", 0);
         assert!(with_tag.contains("--- resume this pane ---"));
         assert!(with_tag.contains("/claude --resume-pane %54"));
         assert!(without_tag.contains("--- resume this pane ---"));
@@ -4427,7 +4448,7 @@ mod tests {
         // requires a description on the `--tag` path, so a bare
         // `/claude --tag <tag>` hint would error out.  Confirm the
         // hint only mentions --resume-pane, never --tag.
-        let out = format_task_released("%54", &[], Some("kernel-opt"), None, None, false, "");
+        let out = format_task_released("%54", &[], Some("kernel-opt"), None, None, false, "", 0);
         // The header still carries `tag=kernel-opt` as a label; the
         // resume-hint block must NOT contain `/claude --tag`.
         let hint_start = out.find("--- resume this pane ---").expect("hint present");
@@ -4441,7 +4462,7 @@ mod tests {
     #[test]
     fn format_task_released_pane_tail_rendered_with_pipe_prefix() {
         let tail = "line1\nline2\nline3";
-        let out = format_task_released("%54", &[], None, None, None, false, tail);
+        let out = format_task_released("%54", &[], None, None, None, false, tail, 0);
         assert!(out.contains("--- pane tail ---"));
         assert!(out.contains("  | line1\n"));
         assert!(out.contains("  | line2\n"));
@@ -4451,7 +4472,7 @@ mod tests {
     #[test]
     fn format_task_released_empty_pane_tail_skipped() {
         // Empty / whitespace-only tail should not emit the tail block.
-        let out = format_task_released("%54", &[], None, None, None, false, "   \n\n  ");
+        let out = format_task_released("%54", &[], None, None, None, false, "   \n\n  ", 0);
         assert!(!out.contains("--- pane tail ---"));
     }
 
@@ -4465,20 +4486,21 @@ mod tests {
             None,
             false,
             "",
+            0,
         );
         assert!(out.contains("resources=[xesim-9902,gpu-0]"));
     }
 
     #[test]
     fn format_task_released_worktree_dirty_flag_rendered() {
-        let clean = format_task_released("%54", &[], None, None, Some("/path"), false, "");
-        let dirty = format_task_released("%54", &[], None, None, Some("/path"), true, "");
+        let clean = format_task_released("%54", &[], None, None, Some("/path"), false, "", 0);
+        let dirty = format_task_released("%54", &[], None, None, Some("/path"), true, "", 0);
         assert!(clean.contains("worktree=/path\n") || clean.contains("worktree=/path "));
         assert!(dirty.contains("worktree=/path (dirty)"));
     }
 
     // ------------------------------------------------------------------
-    // PlanProgressTracker
+    // PlanProgressTracker (inherited from PR #157)
     // ------------------------------------------------------------------
 
     #[test]
@@ -4639,5 +4661,44 @@ mod tests {
         assert_eq!(t.latest_progress(), Some((2, 2)));
         t.finalize_tail();
         assert_eq!(t.latest_progress(), Some((2, 2)));
+    }
+
+    // ------------------------------------------------------------------
+    // format_task_released — duration (PR #159)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn format_task_released_duration_rendered_when_nonzero() {
+        // Elapsed_ms > 0 → a `  duration:` line appears between the
+        // header and the summary.  Spot-check the three size buckets
+        // (sub-second, sub-minute, and multi-minute) so a future
+        // wording change in `format_duration_ms` fails loudly here.
+        let sub_sec = format_task_released("%54", &[], None, None, None, false, "", 312);
+        assert!(
+            sub_sec.contains("  duration: 312ms\n"),
+            "sub-second duration missing: {sub_sec}"
+        );
+        let under_minute = format_task_released("%54", &[], None, None, None, false, "", 37_500);
+        assert!(
+            under_minute.contains("  duration: 37s\n"),
+            "37-second duration missing: {under_minute}"
+        );
+        let over_minute =
+            format_task_released("%54", &[], None, None, None, false, "", 14 * 60_000 + 2_000);
+        assert!(
+            over_minute.contains("  duration: 14m 2s\n"),
+            "14m 2s duration missing: {over_minute}"
+        );
+    }
+
+    #[test]
+    fn format_task_released_duration_suppressed_when_zero() {
+        // Legacy fixtures (pre-serde-default field) deserialize with
+        // elapsed_ms=0; we don't want those to render `duration: 0s`.
+        let out = format_task_released("%54", &[], None, None, None, false, "", 0);
+        assert!(
+            !out.contains("duration:"),
+            "zero elapsed should skip the duration line: {out}"
+        );
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -481,10 +481,15 @@ fn format_task_released(
         ));
     }
     out.push('\n');
-    // `elapsed_ms == 0` only happens on legacy fixtures that predate
-    // the field (they deserialize with `#[serde(default)]`).  Skip the
-    // line in that case so replay diffs stay stable; real releases
-    // always round to at least a few milliseconds.
+    // `elapsed_ms == 0` is reserved for "field absent on the wire"
+    // (legacy payloads that predate `TaskReleased.elapsed_ms` — they
+    // deserialize with `#[serde(default)]`).  Real releases cannot
+    // produce `0` because the daemon rounds sub-millisecond durations
+    // up to `1` before shipping the frame; see
+    // `release_held_entry`'s `elapsed_ms` computation for the
+    // round-up rationale.  Suppressing the line when zero therefore
+    // keeps replay diffs stable without hiding any legitimate
+    // duration from the live UI.
     if elapsed_ms > 0 {
         out.push_str(&format!(
             "  duration: {}\n",

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2242,6 +2242,26 @@ async fn release_held_entry(
     // Capture pane tail (best-effort — don't fail the release if tmux is sick).
     let pane_tail = capture_pane_tail(pane_id).await.unwrap_or_default();
 
+    // Elapsed milliseconds since the TaskEntry was created.  Shared by
+    // the inbox archive body and the `Response::TaskReleased` frame so
+    // the two surfaces can't drift.  Two rounding concerns to flag:
+    //   - `Duration::as_millis()` truncates.  A genuinely sub-1ms
+    //     release (rare but possible on a cached no-op launch) would
+    //     otherwise land at 0 and the client's "elapsed_ms == 0 means
+    //     legacy payload" suppression would eat the duration line,
+    //     leaving users confused.  `.max(1)` rounds up so non-legacy
+    //     durations always render.
+    //   - `u128 → u64` conversion saturates at `u64::MAX` (~584
+    //     million years).  Any supervision loop hitting that cap has
+    //     much bigger problems than a wrong duration string.
+    let elapsed_ms: u64 = entry
+        .created_at
+        .elapsed()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+        .max(1);
+
     // Worktree dirty flag — cheap git-porcelain query, tolerates missing dir.
     let (worktree_path, worktree_dirty) = match entry.worktree.as_deref() {
         Some(wt) => {
@@ -2294,14 +2314,7 @@ async fn release_held_entry(
         // snapshots sees the same shape as the live chat print.
         body.push_str(&format!(
             "duration: {}\n",
-            crate::ipc::format_duration_ms(
-                entry
-                    .created_at
-                    .elapsed()
-                    .as_millis()
-                    .try_into()
-                    .unwrap_or(u64::MAX)
-            )
+            crate::ipc::format_duration_ms(elapsed_ms)
         ));
         if let Some(s) = &summary {
             body.push_str(&format!("\nsummary:\n{s}\n"));
@@ -2318,17 +2331,6 @@ async fn release_held_entry(
             }
         }
     }
-
-    // Wall-clock duration of the supervision loop.  `Instant::elapsed`
-    // saturates at zero if the system clock jumped backward, and the
-    // cast to u64 saturates at u64::MAX — in both cases we'd rather
-    // ship a slightly-off number than panic on the release path.
-    let elapsed_ms: u64 = entry
-        .created_at
-        .elapsed()
-        .as_millis()
-        .try_into()
-        .unwrap_or(u64::MAX);
 
     Some(crate::ipc::Response::TaskReleased {
         pane_id: pane_id.to_string(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2288,6 +2288,21 @@ async fn release_held_entry(
         if let Some(wt) = &worktree_path {
             body.push_str(&format!("worktree: {wt} (dirty={worktree_dirty})\n"));
         }
+        // Elapsed from launch to release.  The inbox row ordering
+        // (tag → worktree → duration) mirrors the interactive release
+        // UI in `format_task_released` so a user reviewing archive
+        // snapshots sees the same shape as the live chat print.
+        body.push_str(&format!(
+            "duration: {}\n",
+            crate::ipc::format_duration_ms(
+                entry
+                    .created_at
+                    .elapsed()
+                    .as_millis()
+                    .try_into()
+                    .unwrap_or(u64::MAX)
+            )
+        ));
         if let Some(s) = &summary {
             body.push_str(&format!("\nsummary:\n{s}\n"));
         }
@@ -2304,6 +2319,17 @@ async fn release_held_entry(
         }
     }
 
+    // Wall-clock duration of the supervision loop.  `Instant::elapsed`
+    // saturates at zero if the system clock jumped backward, and the
+    // cast to u64 saturates at u64::MAX — in both cases we'd rather
+    // ship a slightly-off number than panic on the release path.
+    let elapsed_ms: u64 = entry
+        .created_at
+        .elapsed()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX);
+
     Some(crate::ipc::Response::TaskReleased {
         pane_id: pane_id.to_string(),
         resources_freed,
@@ -2312,6 +2338,7 @@ async fn release_held_entry(
         worktree_path,
         worktree_dirty,
         pane_tail,
+        elapsed_ms,
     })
 }
 
@@ -4741,6 +4768,25 @@ fn format_pane_alive_reminder(pane_ids: &[String]) -> String {
          complete — do not call it on the first turn just to exit.  Once \
          ALL panes are released, this reminder disappears and you can \
          reply with plain text again.\n\
+         \n\
+         **`task_done` means the user's objective is DEMONSTRABLY MET.** \
+         You must be able to point to concrete evidence in the pane \
+         that matches the task description: passing tests, a numerical \
+         threshold hit, a file committed, an output matching the \
+         spec.  A summary that says \"unable to fully resolve\", \
+         \"precision stuck at 0.7 (target was 0.99)\", \"escalating to \
+         user / PISA tools\", \"needs next-session effort\", or \"work \
+         handed off\" is NOT a completed task — it's a blocked task, \
+         and releasing it with `task_done` hides the blocker from the \
+         user.  When Claude is genuinely blocked (missing expertise, \
+         missing tooling, external dependency, numerical goal not met \
+         after exhausting approaches), DO NOT call `task_done`; \
+         instead emit a text reply that names the concrete blocker so \
+         the user can decide whether to continue steering, switch \
+         strategies, or release manually via `/release`.  This is the \
+         same escalation-as-text-reply escape hatch covered by the \
+         \"Make decisions; do not bounce them to the user\" section \
+         above — applied here to the specific release decision.\n\
          \n\
          **Multi-step plan (≥3 steps).**  For tasks with three or more \
          distinct steps, maintain a plan as a markdown checklist inside \
@@ -8213,6 +8259,42 @@ mod tests {
                  cover for a missing vocabulary row"
             );
         }
+    }
+
+    #[test]
+    fn pane_alive_reminder_blocks_task_done_when_goal_not_met() {
+        // Regression guard for the prompt clause that stops the
+        // supervisor from calling `task_done` when Claude bailed out
+        // with "unable to resolve" / "escalating to user".  This was
+        // added after a live incident in window 6 where the supervisor
+        // released a pane with a summary that said the precision goal
+        // (Cosine >= 0.99) had NOT been met (actual: 0.698) and the
+        // user only learned about the blocker by scrolling through the
+        // pane tail.
+        //
+        // The prompt depends on the reader catching BOTH halves of
+        // the rule: (1) task_done means the objective is demonstrably
+        // met, and (2) blocker cases must be escalated via a text
+        // reply, not hidden inside a task_done summary.  Anchoring on
+        // distinctive substrings from each half.
+        let r = format_pane_alive_reminder(&["%54".into()]);
+        assert!(
+            r.contains("DEMONSTRABLY MET"),
+            "prompt must keep the demonstrably-met anchor — without it \
+             the supervisor drifts back to releasing blocked tasks with \
+             `task_done` when the executor bails out"
+        );
+        assert!(
+            r.contains("NOT a completed task"),
+            "prompt must keep the explicit \"NOT a completed task\" \
+             framing so the LLM matches the anti-pattern against its \
+             own draft summary before calling task_done"
+        );
+        assert!(
+            r.contains("DO NOT call `task_done`"),
+            "prompt must keep the directive telling the supervisor to \
+             escalate-as-text-reply instead of releasing a blocked task"
+        );
     }
 
     /// Direct-insert a TaskEntry (bypassing handle_claude_launch) and

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -319,6 +319,14 @@ pub enum Response {
         worktree_path: Option<String>,
         worktree_dirty: bool,
         pane_tail: String,
+        /// Wall-clock milliseconds between `/claude` launch (or resume)
+        /// and this release.  Rendered as `  duration: Xm Ys` under the
+        /// `[released …]` header so the user can see how long the
+        /// supervision loop ran.  `#[serde(default)]` so older clients
+        /// that omit the field can still deserialise pre-upgrade
+        /// daemon outputs in tests and replay fixtures.
+        #[serde(default)]
+        elapsed_ms: u64,
     },
     /// The [`Request::ClaudeLaunch`] was rejected because adding the requested
     /// panes would exceed the configured maximum.
@@ -339,6 +347,31 @@ pub enum Response {
 // ---------------------------------------------------------------------------
 // Frame helpers
 // ---------------------------------------------------------------------------
+
+/// Render a duration in milliseconds as a compact human-readable
+/// string: `"1h 4m 27s"`, `"14m 2s"`, `"37s"`, or `"312ms"` for sub-
+/// second values.  Used by the release UI (`format_task_released`) and
+/// by the inbox archive body so both surfaces agree on the wording.
+///
+/// Zero-padding is deliberately omitted — `"14m 2s"` reads more
+/// naturally than `"14m 02s"` in the chat transcript and we're
+/// rendering for humans, not sort keys.
+pub fn format_duration_ms(ms: u64) -> String {
+    if ms < 1000 {
+        return format!("{ms}ms");
+    }
+    let total_secs = ms / 1000;
+    let s = total_secs % 60;
+    let m = (total_secs / 60) % 60;
+    let h = total_secs / 3600;
+    if h > 0 {
+        format!("{h}h {m}m {s}s")
+    } else if m > 0 {
+        format!("{m}m {s}s")
+    } else {
+        format!("{s}s")
+    }
+}
 
 /// Write one `Response` frame as a JSON line to `writer`.
 pub async fn write_frame<W>(writer: &mut W, frame: &Response) -> anyhow::Result<()>
@@ -1008,6 +1041,7 @@ mod tests {
             worktree_path: Some("/tmp/x".into()),
             worktree_dirty: true,
             pane_tail: "$ echo done\n".into(),
+            elapsed_ms: 123_456,
         };
         let json = serde_json::to_string(&r).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -1019,6 +1053,7 @@ mod tests {
         assert_eq!(v["worktree_path"], "/tmp/x");
         assert_eq!(v["worktree_dirty"], true);
         assert_eq!(v["pane_tail"], "$ echo done\n");
+        assert_eq!(v["elapsed_ms"], 123_456);
 
         let back: Response = serde_json::from_str(&json).unwrap();
         let Response::TaskReleased {
@@ -1029,6 +1064,7 @@ mod tests {
             worktree_path,
             worktree_dirty,
             pane_tail,
+            elapsed_ms,
         } = back
         else {
             panic!("expected TaskReleased");
@@ -1040,6 +1076,21 @@ mod tests {
         assert_eq!(worktree_path.as_deref(), Some("/tmp/x"));
         assert!(worktree_dirty);
         assert_eq!(pane_tail, "$ echo done\n");
+        assert_eq!(elapsed_ms, 123_456);
+    }
+
+    #[test]
+    fn task_released_legacy_payload_without_elapsed_ms_deserialises() {
+        // #[serde(default)] lets pre-upgrade daemon fixtures (no
+        // elapsed_ms field) round-trip; confirms the client can still
+        // parse old replay logs and inbox archives.
+        let legacy = r#"{"type":"task_released","pane_id":"%7","resources_freed":[],"tag":null,"summary":null,"worktree_path":null,"worktree_dirty":false,"pane_tail":""}"#;
+        let Response::TaskReleased { elapsed_ms, .. } =
+            serde_json::from_str(legacy).expect("legacy payload must parse")
+        else {
+            panic!("expected TaskReleased");
+        };
+        assert_eq!(elapsed_ms, 0);
     }
 
     #[tokio::test]
@@ -1059,5 +1110,35 @@ mod tests {
         let s = String::from_utf8(buf).unwrap();
         let v: serde_json::Value = serde_json::from_str(s.trim_end()).unwrap();
         assert_eq!(v["chunk"], "streamed");
+    }
+
+    #[test]
+    fn format_duration_ms_sub_second() {
+        assert_eq!(format_duration_ms(0), "0ms");
+        assert_eq!(format_duration_ms(312), "312ms");
+        assert_eq!(format_duration_ms(999), "999ms");
+    }
+
+    #[test]
+    fn format_duration_ms_seconds_only() {
+        assert_eq!(format_duration_ms(1_000), "1s");
+        assert_eq!(format_duration_ms(37_500), "37s");
+        assert_eq!(format_duration_ms(59_999), "59s");
+    }
+
+    #[test]
+    fn format_duration_ms_minutes_and_seconds() {
+        assert_eq!(format_duration_ms(60_000), "1m 0s");
+        assert_eq!(format_duration_ms(14 * 60_000 + 2_000), "14m 2s");
+        assert_eq!(format_duration_ms(59 * 60_000 + 59_000), "59m 59s");
+    }
+
+    #[test]
+    fn format_duration_ms_hours_minutes_seconds() {
+        assert_eq!(format_duration_ms(3_600_000), "1h 0m 0s");
+        assert_eq!(
+            format_duration_ms(3_600_000 + 4 * 60_000 + 27_000),
+            "1h 4m 27s"
+        );
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -319,12 +319,18 @@ pub enum Response {
         worktree_path: Option<String>,
         worktree_dirty: bool,
         pane_tail: String,
-        /// Wall-clock milliseconds between `/claude` launch (or resume)
-        /// and this release.  Rendered as `  duration: Xm Ys` under the
-        /// `[released …]` header so the user can see how long the
-        /// supervision loop ran.  `#[serde(default)]` so older clients
-        /// that omit the field can still deserialise pre-upgrade
-        /// daemon outputs in tests and replay fixtures.
+        /// Monotonic elapsed milliseconds between `/claude` launch (or
+        /// resume) and this release, derived from `Instant::elapsed()`
+        /// on the daemon's `TaskEntry.created_at`.  Unaffected by wall-
+        /// clock / timezone adjustments on the host.  Rendered as
+        /// `  duration: Xm Ys` under the `[released …]` header so the
+        /// user can see how long the supervision loop ran.  The daemon
+        /// rounds sub-millisecond durations up to `1` so `0` is
+        /// reserved for "field absent" on legacy payloads — see the
+        /// client's zero-suppression in `format_task_released`.
+        /// `#[serde(default)]` so older clients that omit the field
+        /// can still deserialise pre-upgrade daemon outputs in tests
+        /// and replay fixtures.
         #[serde(default)]
         elapsed_ms: u64,
     },


### PR DESCRIPTION
## Summary

Two fixes driven by a real incident observed in window 6 of a live amaebi session:

1. **Duration in release output.** The `[released %…]` block now shows a `  duration: Xm Ys` line right below the header so users can see how long a `/claude` supervision loop ran.
2. **Stop premature `task_done`.** Tightens the supervisor prompt so `task_done` is reserved for objectives that are demonstrably met; blocked-on-external-tooling / "unable to resolve" cases must be escalated via a text reply instead of hidden inside a `task_done` summary.

## Motivation

From the window 6 capture: supervisor released pane %75 with a summary that said *precision is 0.698, target was >0.99, need PISA tools* — the user only learned the task hadn't succeeded by scrolling through the pane tail. Also: no way to tell at a glance that the loop ran for 15 minutes vs 30 seconds.

## Part A — duration

`Response::TaskReleased` gains `elapsed_ms: u64` (`#[serde(default)]` for backcompat).  Daemon computes it from `entry.created_at: Instant` (previously unused).  New `ipc::format_duration_ms` renders `312ms` / `37s` / `14m 2s` / `1h 4m 27s`.  `format_task_released` prints it under the header; the inbox archive body picks up a matching row so post-hoc snapshots match the live chat shape.

Duration line is skipped when `elapsed_ms == 0`, so legacy replay fixtures (no field) don't produce `duration: 0s`.

## Part B — `task_done` tightening

`format_pane_alive_reminder` gains an explicit "`task_done` means the user's objective is DEMONSTRABLY MET" clause.  Calls out anti-patterns ("unable to resolve", "stuck at X (target was Y)", "escalating to user", "needs next-session effort", "handed off") as NOT completed tasks.  Directs the supervisor to emit a text reply naming the concrete blocker instead — same escape hatch pattern as the existing "Make decisions; do not bounce them to the user" clause.

New `pane_alive_reminder_blocks_task_done_when_goal_not_met` prompt-shape anchor test pins three load-bearing phrases (`DEMONSTRABLY MET`, `NOT a completed task`, `DO NOT call task_done`) so a future prompt edit can't silently soften the clause back.

## Test plan

- [x] 7 new unit tests (4 `format_duration_ms_*` buckets + 2 `format_task_released_duration_*` render/suppress + 1 `task_released_legacy_payload_without_elapsed_ms_deserialises` + 1 `pane_alive_reminder_blocks_task_done_when_goal_not_met`)
- [x] All existing `format_task_released_*` tests updated to pass explicit `0` for `elapsed_ms`
- [x] `cargo test --bin amaebi` — 694 pass
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings` clean
- [x] `scripts/next-version.sh --check` — `OK 2026.5.23`

## Risks / tradeoffs

- **Prompt tightening is opinionated.** "Objective met" is fuzzier than the tool-every-turn rule, so there's a small risk the supervisor becomes too reluctant to release on genuinely-complete-but-informally-stated tasks.  Mitigated by concrete examples in the prompt; easy to relax later if we see false negatives.
- **`elapsed_ms: u64` is additive and backcompat** via `#[serde(default)]`: old clients silently ignore the field, old fixtures deserialise to `0` and skip the render.

## Relation to other PRs

Independent of PR #157 (plan checklist) and PR #158 (branch-mode versioning).  Lands cleanly on master either before or after them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
