### PR TITLE
fix(chat): reject slash commands typed as a mid-turn steer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.25"
+version = "2026.5.26"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.25"
+version = "2026.5.26"
 edition = "2021"
 
 [[bin]]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1397,19 +1397,37 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
             steer_line = next_stdin_line(&mut stdin_lines) => {
                 match steer_line {
                     Some(text) if !text.trim().is_empty() => {
-                        // steer_pending is already true (set on Ctrl-C); just send the request.
-                        let steer_req = Request::Steer {
-                            session_id: session_id_copy.clone(),
-                            message: text,
-                        };
-                        let mut frame =
-                            serde_json::to_string(&steer_req).context("serializing Steer")?;
-                        frame.push('\n');
-                        // If the daemon has already finished and closed the
-                        // connection, the write will fail — swallow the error
-                        // so the response loop can drain normally.
-                        let _ = writer.write_all(frame.as_bytes()).await;
-                        let _ = writer.flush().await;
+                        // Guard: slash commands typed during an in-flight turn
+                        // would otherwise be shipped as a plain-text steer and
+                        // silently concatenated onto the ongoing conversation,
+                        // which is how an impatient `/claude --resource ...`
+                        // ended up asking the supervisor LLM to do the task
+                        // itself instead of launching a pane (observed
+                        // 2026-05-09).  Slash commands are a client-side
+                        // concern routed through `parse_slash_command` at
+                        // top-of-turn; refuse them mid-turn with a message
+                        // that explains the retry path.
+                        if parse_slash_command(&text).is_some() {
+                            let msg = "[error] slash commands cannot be used as \
+                                       a mid-turn steer.  Wait for the current \
+                                       reply to finish, then retype the command.\n";
+                            let _ = stdout.write_all(msg.as_bytes()).await;
+                            let _ = stdout.flush().await;
+                        } else {
+                            // steer_pending is already true (set on Ctrl-C); just send the request.
+                            let steer_req = Request::Steer {
+                                session_id: session_id_copy.clone(),
+                                message: text,
+                            };
+                            let mut frame =
+                                serde_json::to_string(&steer_req).context("serializing Steer")?;
+                            frame.push('\n');
+                            // If the daemon has already finished and closed the
+                            // connection, the write will fail — swallow the error
+                            // so the response loop can drain normally.
+                            let _ = writer.write_all(frame.as_bytes()).await;
+                            let _ = writer.flush().await;
+                        }
                     }
                     Some(_) => {
                         // Empty or whitespace-only line (e.g. bare Enter) — if a steer
@@ -2539,16 +2557,29 @@ pub async fn run_resume(
             steer_line = next_stdin_line(&mut stdin_lines) => {
                 match steer_line {
                     Some(text) if !text.trim().is_empty() => {
-                        // steer_pending already set on Ctrl-C; just send the request.
-                        let steer_req = Request::Steer {
-                            session_id: session_uuid.clone(),
-                            message: text,
-                        };
-                        let mut frame = serde_json::to_string(&steer_req)
-                            .context("serializing Steer")?;
-                        frame.push('\n');
-                        let _ = writer.write_all(frame.as_bytes()).await;
-                        let _ = writer.flush().await;
+                        // Same mid-turn slash-command guard as `run_chat_loop`
+                        // (see the sibling steer_line arm for the full
+                        // rationale): a slash command typed while the resumed
+                        // turn is still streaming would be posted as a plain
+                        // text steer and corrupt the conversation.
+                        if parse_slash_command(&text).is_some() {
+                            let msg = "[error] slash commands cannot be used as \
+                                       a mid-turn steer.  Wait for the current \
+                                       reply to finish, then retype the command.\n";
+                            let _ = stdout.write_all(msg.as_bytes()).await;
+                            let _ = stdout.flush().await;
+                        } else {
+                            // steer_pending already set on Ctrl-C; just send the request.
+                            let steer_req = Request::Steer {
+                                session_id: session_uuid.clone(),
+                                message: text,
+                            };
+                            let mut frame = serde_json::to_string(&steer_req)
+                                .context("serializing Steer")?;
+                            frame.push('\n');
+                            let _ = writer.write_all(frame.as_bytes()).await;
+                            let _ = writer.flush().await;
+                        }
                     }
                     Some(_) => {
                         // Empty or whitespace-only line — if a steer is pending,
@@ -4389,6 +4420,39 @@ mod tests {
     fn parse_claude_false_positive_prefix_rejected() {
         assert!(parse_slash_command("/claudefoo").is_none());
         assert!(parse_slash_command("/claude--help").is_none());
+    }
+
+    // Regression guard for the mid-turn slash-command rejection in
+    // `run_chat_loop` / `run_resume`.  Both loops refuse to forward a
+    // stdin line as a `Request::Steer` when `parse_slash_command`
+    // recognises it — if that predicate ever stopped matching any of
+    // these shapes, an impatient user re-typing a command during an
+    // in-flight turn would silently corrupt the conversation by
+    // shipping "/claude --resource ..." as a plain steer message (the
+    // original bug from 2026-05-09).  The loops don't have easy unit
+    // tests of their own, so we anchor the shared predicate here.
+    #[test]
+    fn parse_slash_command_matches_every_routable_shape() {
+        for input in [
+            "/claude",
+            "/claude  ",
+            "/claude \"do the thing\"",
+            "/claude --resource sim-9903 重构 dispatcher",
+            "/claude --resume-pane %54",
+            "/model",
+            "/model claude-opus-4.6[1m]",
+            "/release %54",
+            "/release all --clean",
+            "/replyreview 157",
+            "/replyreview 157 158",
+        ] {
+            assert!(
+                parse_slash_command(input).is_some(),
+                "parse_slash_command({input:?}) must return Some so the \
+                 mid-turn steer guard rejects it instead of forwarding it \
+                 as plain text"
+            );
+        }
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1420,7 +1420,14 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                             let _ = stdout.write_all(msg.as_bytes()).await;
                             let _ = stdout.flush().await;
                         } else {
-                            // steer_pending is already true (set on Ctrl-C); just send the request.
+                            // The stdin reader runs whenever stdin is a TTY,
+                            // so this arm fires both during an in-flight
+                            // turn (steer) and after Ctrl-C while
+                            // `steer_pending` is true.  Either way the
+                            // daemon treats `Request::Steer` the same way
+                            // — append to the current conversation — so we
+                            // forward the raw line without branching on
+                            // `steer_pending`.
                             let steer_req = Request::Steer {
                                 session_id: session_id_copy.clone(),
                                 message: text,
@@ -2217,6 +2224,38 @@ pub async fn run_chat_loop(
                                     frame.push('\n');
                                     let _ = write_half.write_all(frame.as_bytes()).await;
                                 }
+                                steer_pending = false;
+                                last_ctrl_c = None;
+                            } else if parse_slash_command(trimmed).is_some() {
+                                // Same mid-turn slash-command guard as the
+                                // `steer_line` arms in `run` / `run_resume`:
+                                // a `/claude` / `/release` / `/replyreview`
+                                // typed as a Ctrl-C correction would be
+                                // shipped to the daemon as a plain-text
+                                // Steer and silently corrupt the running
+                                // turn (observed 2026-05-09).  Refuse it
+                                // and treat like an empty-line cancel so
+                                // the daemon's post-Interrupt wait resolves
+                                // and the session resumes.
+                                let msg = concat!(
+                                    "[error] slash commands cannot be used as a mid-turn steer.\n",
+                                    "        Wait for the current reply to finish, then retype the command.\n",
+                                );
+                                let _ = stdout.write_all(msg.as_bytes()).await;
+                                let _ = stdout.flush().await;
+                                steer_pending = false;
+                                last_ctrl_c = None;
+                                // Flush buffered text through md_buf now
+                                // that the steer is cancelled — same tail
+                                // as the empty-line branch below.
+                                for chunk in steer_text_buf.drain(..) {
+                                    md_buf.push(&chunk);
+                                    while let Some(ready) = md_buf.flush_if_ready() {
+                                        let out = render_markdown(&ready);
+                                        let _ = stdout.write_all(out.as_bytes()).await;
+                                    }
+                                }
+                                let _ = stdout.flush().await;
                             } else {
                                 let steer_req = Request::Steer {
                                     session_id: session_id.clone(),
@@ -2226,9 +2265,9 @@ pub async fn run_chat_loop(
                                     frame.push('\n');
                                     let _ = write_half.write_all(frame.as_bytes()).await;
                                 }
+                                steer_pending = false;
+                                last_ctrl_c = None;
                             }
-                            steer_pending = false;
-                            last_ctrl_c = None;
                         }
                         // Empty line — cancel steer.
                         Ok(Ok(Some(_))) => {
@@ -2563,16 +2602,17 @@ pub async fn run_resume(
             steer_line = next_stdin_line(&mut stdin_lines) => {
                 match steer_line {
                     Some(text) if !text.trim().is_empty() => {
-                        // Same mid-turn slash-command guard as `run_chat_loop`
-                        // (see the sibling steer_line arm for the full
-                        // rationale): a slash command typed while the resumed
-                        // turn is still streaming would be posted as a plain
-                        // text steer and corrupt the conversation.
+                        // Same mid-turn slash-command guard as the
+                        // `steer_line` arm in `run` (see there for the
+                        // full rationale): a slash command typed while
+                        // the resumed turn is still streaming would be
+                        // posted as a plain text steer and corrupt the
+                        // conversation.
                         if parse_slash_command(&text).is_some() {
-                            // Same formatting fix as the chat-loop arm: `\`
-                            // line continuations swallow the newline, so use
-                            // explicit `\n` to break the message across two
-                            // lines.
+                            // Formatting mirrors the sibling arm in `run`:
+                            // `\` line continuations swallow the newline, so
+                            // use explicit `\n` to break the message across
+                            // two lines.
                             let msg = concat!(
                                 "[error] slash commands cannot be used as a mid-turn steer.\n",
                                 "        Wait for the current reply to finish, then retype the command.\n",
@@ -2580,7 +2620,11 @@ pub async fn run_resume(
                             let _ = stdout.write_all(msg.as_bytes()).await;
                             let _ = stdout.flush().await;
                         } else {
-                            // steer_pending already set on Ctrl-C; just send the request.
+                            // The stdin reader fires on any line typed
+                            // during a streaming turn, not only after
+                            // Ctrl-C; `steer_pending` may be either true
+                            // or false here.  The daemon appends to the
+                            // current conversation either way.
                             let steer_req = Request::Steer {
                                 session_id: session_uuid.clone(),
                                 message: text,
@@ -4434,16 +4478,19 @@ mod tests {
     }
 
     // Regression guard for the mid-turn slash-command rejection in
-    // `run_chat_loop` / `run_resume`.  The guard asks
-    // `parse_slash_command(&text).is_some()` before forwarding stdin as
-    // a `Request::Steer`, so it must recognise every command *prefix*
-    // — including shapes that are themselves parse errors (like bare
-    // `/claude`, asserted in `parse_claude_bare_returns_err`).  A bare
-    // `/claude` is not "routable" in the dispatch sense, but it IS
-    // something the user typed as a slash command and must not be
-    // silently reshipped as plain-text steer.  The loops don't have
-    // easy unit tests of their own, so this anchors the shared
-    // predicate the guard relies on.
+    // the three steer pathways: `run`'s and `run_resume`'s
+    // `steer_line` arms (stdin-driven mid-turn line) and
+    // `run_chat_loop`'s `steer_result` arm (Ctrl-C-driven correction
+    // line).  All three ask `parse_slash_command(...).is_some()`
+    // before forwarding as a `Request::Steer`, so the predicate must
+    // recognise every command *prefix* — including shapes that are
+    // themselves parse errors (like bare `/claude`, asserted in
+    // `parse_claude_bare_returns_err`).  A bare `/claude` is not
+    // "routable" in the dispatch sense, but it IS something the user
+    // typed as a slash command and must not be silently reshipped as
+    // plain-text steer.  The loops don't have easy unit tests of
+    // their own, so this anchors the shared predicate the guard
+    // relies on.
     #[test]
     fn parse_slash_command_recognises_every_command_shape() {
         for input in [

--- a/src/client.rs
+++ b/src/client.rs
@@ -1408,9 +1408,15 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                         // top-of-turn; refuse them mid-turn with a message
                         // that explains the retry path.
                         if parse_slash_command(&text).is_some() {
-                            let msg = "[error] slash commands cannot be used as \
-                                       a mid-turn steer.  Wait for the current \
-                                       reply to finish, then retype the command.\n";
+                            // `\` line continuations collapse the newline AND
+                            // preserve leading spaces, producing one long run-
+                            // on line.  Use explicit `\n` + spaces so the
+                            // rendered output actually wraps the way the PR
+                            // description claims.
+                            let msg = concat!(
+                                "[error] slash commands cannot be used as a mid-turn steer.\n",
+                                "        Wait for the current reply to finish, then retype the command.\n",
+                            );
                             let _ = stdout.write_all(msg.as_bytes()).await;
                             let _ = stdout.flush().await;
                         } else {
@@ -2563,9 +2569,14 @@ pub async fn run_resume(
                         // turn is still streaming would be posted as a plain
                         // text steer and corrupt the conversation.
                         if parse_slash_command(&text).is_some() {
-                            let msg = "[error] slash commands cannot be used as \
-                                       a mid-turn steer.  Wait for the current \
-                                       reply to finish, then retype the command.\n";
+                            // Same formatting fix as the chat-loop arm: `\`
+                            // line continuations swallow the newline, so use
+                            // explicit `\n` to break the message across two
+                            // lines.
+                            let msg = concat!(
+                                "[error] slash commands cannot be used as a mid-turn steer.\n",
+                                "        Wait for the current reply to finish, then retype the command.\n",
+                            );
                             let _ = stdout.write_all(msg.as_bytes()).await;
                             let _ = stdout.flush().await;
                         } else {
@@ -4423,16 +4434,18 @@ mod tests {
     }
 
     // Regression guard for the mid-turn slash-command rejection in
-    // `run_chat_loop` / `run_resume`.  Both loops refuse to forward a
-    // stdin line as a `Request::Steer` when `parse_slash_command`
-    // recognises it — if that predicate ever stopped matching any of
-    // these shapes, an impatient user re-typing a command during an
-    // in-flight turn would silently corrupt the conversation by
-    // shipping "/claude --resource ..." as a plain steer message (the
-    // original bug from 2026-05-09).  The loops don't have easy unit
-    // tests of their own, so we anchor the shared predicate here.
+    // `run_chat_loop` / `run_resume`.  The guard asks
+    // `parse_slash_command(&text).is_some()` before forwarding stdin as
+    // a `Request::Steer`, so it must recognise every command *prefix*
+    // — including shapes that are themselves parse errors (like bare
+    // `/claude`, asserted in `parse_claude_bare_returns_err`).  A bare
+    // `/claude` is not "routable" in the dispatch sense, but it IS
+    // something the user typed as a slash command and must not be
+    // silently reshipped as plain-text steer.  The loops don't have
+    // easy unit tests of their own, so this anchors the shared
+    // predicate the guard relies on.
     #[test]
-    fn parse_slash_command_matches_every_routable_shape() {
+    fn parse_slash_command_recognises_every_command_shape() {
         for input in [
             "/claude",
             "/claude  ",

--- a/src/client.rs
+++ b/src/client.rs
@@ -1419,6 +1419,20 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                             );
                             let _ = stdout.write_all(msg.as_bytes()).await;
                             let _ = stdout.flush().await;
+                            // If a steer was pending (Ctrl-C path), treat the
+                            // rejected slash command like an empty-line cancel
+                            // so the buffered daemon output can flush — the
+                            // user told to "wait for the current reply to
+                            // finish" needs to actually see it finish.
+                            // Without this the CLI would stay in
+                            // `steer_pending=true` forever (no `SteerAck`
+                            // will ever arrive) and look hung.
+                            if steer_pending {
+                                steer_pending = false;
+                                last_ctrl_c = None;
+                                flush_steer_buffer(&mut steer_buffer, &mut buffer_truncated, &mut stdout).await?;
+                                buffer_truncated = false;
+                            }
                         } else {
                             // The stdin reader runs whenever stdin is a TTY,
                             // so this arm fires both during an in-flight
@@ -2619,6 +2633,18 @@ pub async fn run_resume(
                             );
                             let _ = stdout.write_all(msg.as_bytes()).await;
                             let _ = stdout.flush().await;
+                            // Same Ctrl-C-path cleanup as the sibling arm
+                            // in `run`: if `steer_pending` is true, the
+                            // rejected slash command is effectively a
+                            // cancel — otherwise output stays buffered
+                            // forever (no `SteerAck` will arrive) and the
+                            // session looks hung.
+                            if steer_pending {
+                                steer_pending = false;
+                                last_ctrl_c = None;
+                                flush_steer_buffer(&mut steer_buffer, &mut buffer_truncated, &mut stdout).await?;
+                                buffer_truncated = false;
+                            }
                         } else {
                             // The stdin reader fires on any line typed
                             // during a streaming turn, not only after


### PR DESCRIPTION
## Summary

Slash commands typed while a previous turn is still streaming were silently demoted to plain-text steer messages.  This PR rejects them with a clear error and tells the user to retype once the current reply finishes.

## Repro / root cause

Observed window-6 capture on 2026-05-09:

```
> hello
> /claude --resource sim-9903 重构现在的dispatcher...
Hello! How can I help you today?Let me first look at the current state of the workspace...
[supervisor LLM now runs shell_command + edit_file and refactors ~200 lines directly]
```

The user hit Enter on `/claude …` before `hello`'s reply finished.  `run_chat_loop`'s `tokio::select!` had two arms active (daemon response stream + stdin reader); the stdin arm fired first and wrapped the line in `Request::Steer { message: "/claude --resource ..." }` and shipped it to the daemon as a mid-turn user message.

The daemon appended it to conversation history, the supervisor LLM read it as "also do this refactor", and started editing files directly — the exact anti-pattern the pane-alive prompt forbids, except the prompt never applied because **no `/claude` launch ever happened** (no pane assigned, no resource reserved).

Slash-command parsing is a client-side concern run at the **top** of each turn (`parse_slash_command` in `run_chat_loop`, `run_ask_loop`).  The mid-turn `steer_line` arm had no such check, so every slash command typed mid-turn was silently demoted to steer text.

## Fix

In both `run_chat_loop` and `run_resume`'s `steer_line` arms, check `parse_slash_command(&text).is_some()` before sending `Request::Steer`.  If the line looks like a slash command, print

    [error] slash commands cannot be used as a mid-turn steer.
            Wait for the current reply to finish, then retype the command.

and drop the line.  Non-slash text steers behave exactly as before.

## Why reject-with-message, not defer-until-Done?

- No queue infrastructure exists for \"pending user requests\"; building one for this single case adds state + background-magic risk.
- User can retype once the turn lands — cheap and unambiguous.

A future enhancement could queue + auto-dispatch; that's worth its own PR with its own cancellation semantics.

## Tests

Added `parse_slash_command_matches_every_routable_shape` in `src/client.rs` tests.  It pins that the shared predicate (`parse_slash_command`) matches every routable slash-command shape:

- `/claude`, `/claude  `, `/claude \"desc\"`, `/claude --resource sim-9903 …`, `/claude --resume-pane %54`
- `/model`, `/model claude-opus-4.6[1m]`
- `/release %54`, `/release all --clean`
- `/replyreview 157`, `/replyreview 157 158`

The two `steer_line` arms share this predicate; if it ever stopped matching one of these (new `/claude` flag, renamed command), the guard would silently regress without the anchor.

## Test plan

- [x] `cargo test --bin amaebi` — 707 pass (706 + 1 new)
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings` clean
- [x] `scripts/next-version.sh --check` — `OK 2026.5.26`

🤖 Generated with [Claude Code](https://claude.com/claude-code)