### PR TITLE
fix(pane): reap zombie lease records before capacity check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.26"
+version = "2026.5.27"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.26"
+version = "2026.5.27"
 edition = "2021"
 
 [[bin]]

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -532,6 +532,41 @@ pub fn ensure_idle_panes(needed: usize) -> Result<()> {
 fn ensure_idle_panes_locked(needed: usize) -> Result<()> {
     let mut state = read_state_unlocked()?;
 
+    // Reap zombie lease records BEFORE any capacity math.  If the user
+    // closed tmux panes directly (e.g. `:kill-pane`, window closed in
+    // another tool), `tmux-state.json` still carries those entries until
+    // a heartbeat / release event touches them — and in the typical
+    // workflow that never happens, so they accumulate forever.  Without
+    // reaping first, `total` below would include dead panes and we'd
+    // reject a fresh `/claude` with a misleading "capacity reached"
+    // even when tmux itself has plenty of room.
+    //
+    // If `tmux list-panes -a` fails (tmux not installed, no server,
+    // transient error), log and skip reaping rather than failing the
+    // whole request — we'd rather preserve the existing ledger under
+    // uncertainty than risk wiping it based on an empty / wrong list.
+    // The capacity check below still runs on the un-reaped state, so
+    // behavior in that edge case is exactly the old (pre-fix) behavior.
+    match tmux_list_all_panes_sync() {
+        Ok(live) => {
+            let zombies = reap_zombies(&mut state, &live);
+            if !zombies.is_empty() {
+                tracing::info!(
+                    count = zombies.len(),
+                    ids = ?zombies,
+                    "reaped zombie pane lease records before capacity check"
+                );
+                // Persist the reap so subsequent callers (and dashboards)
+                // see the cleaned ledger.  Safe under the caller-held
+                // LOCK_EX.
+                write_state_unlocked(&state)?;
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "skipping zombie reap; keeping existing ledger");
+        }
+    }
+
     let idle_count = state
         .values()
         .filter(|l| l.effective_status() == PaneStatus::Idle)
@@ -761,6 +796,61 @@ pub fn mark_claude_started(pane_id: &str) -> Result<()> {
 // ---------------------------------------------------------------------------
 // Private tmux helpers (sync, safe to call inside spawn_blocking / flock)
 // ---------------------------------------------------------------------------
+
+/// Run `tmux list-panes -a -F "#{pane_id}"` and return every live pane ID
+/// across all sessions as a set.  Used by `reap_zombies` to drop lease
+/// records that point at panes the user closed behind amaebi's back —
+/// without this, `tmux-state.json` accumulates entries indefinitely and
+/// eventually saturates `MAX_PANES` even though the tmux server has
+/// nothing left on them.
+///
+/// Tests can bypass the real tmux call by setting the
+/// `AMAEBI_TEST_TMUX_PANES_OVERRIDE` env var to a whitespace-separated
+/// list of pane ids (e.g. `"%0 %1 %2"`).  Empty string means "tmux
+/// reports no live panes", which lets tests exercise the all-zombies
+/// path without shelling out.
+fn tmux_list_all_panes_sync() -> Result<std::collections::HashSet<String>> {
+    if let Ok(override_str) = std::env::var("AMAEBI_TEST_TMUX_PANES_OVERRIDE") {
+        return Ok(override_str
+            .split_whitespace()
+            .map(str::to_string)
+            .collect());
+    }
+    let output = std::process::Command::new("tmux")
+        .args(["list-panes", "-a", "-F", "#{pane_id}"])
+        .output()
+        .context("spawning tmux list-panes -a")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("tmux list-panes -a failed: {stderr}");
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// Drop lease records whose `pane_id` is no longer present in `live`.
+/// Returns the removed pane ids in insertion order (HashMap iteration
+/// order is arbitrary but stable within one process, which is enough
+/// for unit tests).
+///
+/// Pure function — takes the live-pane set as a parameter so tests can
+/// inject any set they like without touching a real tmux server.  The
+/// caller is responsible for obtaining `live` (production path uses
+/// [`tmux_list_all_panes_sync`]; tests build it by hand).
+fn reap_zombies(state: &mut PaneState, live: &std::collections::HashSet<String>) -> Vec<String> {
+    let zombies: Vec<String> = state
+        .keys()
+        .filter(|k| !live.contains(*k))
+        .cloned()
+        .collect();
+    for z in &zombies {
+        state.remove(z);
+    }
+    zombies
+}
 
 /// Run `tmux list-windows -F "#{window_id}"` and return a list of window IDs.
 fn tmux_list_windows_sync() -> Result<Vec<String>> {
@@ -1235,11 +1325,18 @@ mod tests {
             let _guard = crate::test_utils::with_temp_home();
             // Fill all MAX_PANES slots with Busy leases.
             let mut state: PaneState = HashMap::new();
+            let mut ids = Vec::with_capacity(MAX_PANES);
             for i in 0..MAX_PANES {
                 let pid = format!("%{i}");
                 state.insert(pid.clone(), make_busy(&pid, "@0", None));
+                ids.push(pid);
             }
             write_state_unlocked(&state).expect("seed state");
+
+            // Tell the zombie-reap step that every seeded pane is still
+            // alive in tmux — without this it would drop them all and
+            // the capacity check would pass instead of failing.
+            std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", ids.join(" "));
 
             // Acquiring the lock before calling the internal helper so we can
             // test the logic without real tmux.
@@ -1247,6 +1344,8 @@ mod tests {
             lock.lock_exclusive().expect("flock");
             let result = ensure_idle_panes_locked(1);
             lock.unlock().expect("unlock");
+
+            std::env::remove_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE");
 
             let err = result.expect_err("should be Err");
             let cap = err.downcast_ref::<CapacityError>().expect("CapacityError");
@@ -1264,14 +1363,137 @@ mod tests {
             state.insert("%1".to_string(), make_idle("%1", "@0"));
             write_state_unlocked(&state).expect("seed state");
 
+            // Mark the seeded panes as live so the reap leaves them alone.
+            unsafe {
+                std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", "%0 %1");
+            }
+
             let lock = open_lock_file().expect("open lock");
             lock.lock_exclusive().expect("flock");
-            // 2 idle panes, need 2 → no-op, no tmux calls.
+            // 2 idle panes, need 2 → no-op, no new tmux windows created.
             let result = ensure_idle_panes_locked(2);
             lock.unlock().expect("unlock");
 
-            result.expect("should succeed without calling tmux");
+            std::env::remove_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE");
+
+            result.expect("should succeed without creating new windows");
         }
+    }
+
+    #[test]
+    fn ensure_idle_panes_reaps_zombies_before_capacity_check() {
+        // End-to-end regression for the window-6 bug (2026-05-10):
+        // ledger has MAX_PANES entries, but only a handful are still
+        // alive in tmux.  Before the fix, this would reject with
+        // CapacityError because `total == MAX_PANES`; after the fix,
+        // the zombies are reaped first and capacity is judged against
+        // what's actually live.  We don't exercise the tmux-window
+        // creation path (that requires a real tmux); instead we ask
+        // for `needed = <idle count>` so no deficit remains and the
+        // function short-circuits at the idle-count check.
+        let _guard = crate::test_utils::with_temp_home();
+        let mut state: PaneState = HashMap::new();
+        // 2 live + 14 zombies = 16 entries total (saturated ledger).
+        for i in 0..2 {
+            let pid = format!("%live{i}");
+            state.insert(pid.clone(), make_idle(&pid, "@0"));
+        }
+        for i in 0..14 {
+            let pid = format!("%zombie{i}");
+            state.insert(pid.clone(), make_idle(&pid, "@0"));
+        }
+        assert_eq!(state.len(), MAX_PANES, "seed must saturate MAX_PANES");
+        write_state_unlocked(&state).expect("seed state");
+
+        // tmux only reports the 2 live panes — the 14 zombies were
+        // closed behind amaebi's back.
+        unsafe {
+            std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", "%live0 %live1");
+        }
+
+        let lock = open_lock_file().expect("open lock");
+        lock.lock_exclusive().expect("flock");
+        // Need 2 idle panes; we have 2 live idle after reap → Ok.
+        let result = ensure_idle_panes_locked(2);
+        lock.unlock().expect("unlock");
+
+        unsafe {
+            std::env::remove_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE");
+        }
+
+        result.expect("reap should drop the 14 zombies; 2 live idle is enough");
+
+        // Persisted ledger must now have only the live entries — if
+        // the reap didn't write through, the next launch would see a
+        // saturated state again.
+        let reloaded = read_state_unlocked().expect("reload state");
+        assert_eq!(reloaded.len(), 2);
+        assert!(reloaded.contains_key("%live0"));
+        assert!(reloaded.contains_key("%live1"));
+    }
+
+    // ── reap_zombies ─────────────────────────────────────────────────────
+    //
+    // `reap_zombies` is the pure predicate behind the zombie cleanup now
+    // performed at the top of `ensure_idle_panes_locked`.  Before this
+    // fix, `tmux-state.json` accumulated lease records for panes the
+    // user had closed directly in tmux — the ledger eventually hit 16
+    // entries and blocked every new `/claude` with a misleading
+    // "capacity reached" even though tmux had plenty of room.  These
+    // tests pin the three interesting cases.
+
+    #[test]
+    fn reap_zombies_removes_entries_not_in_live_set() {
+        let mut state: PaneState = HashMap::new();
+        state.insert("%0".into(), make_idle("%0", "@0"));
+        state.insert("%1".into(), make_busy("%1", "@1", None));
+        state.insert("%2".into(), make_idle("%2", "@2"));
+        // Only %0 and %2 are still alive in tmux.  %1 is a zombie
+        // (user closed it in tmux without releasing through amaebi).
+        let live: std::collections::HashSet<String> =
+            ["%0".to_string(), "%2".to_string()].into_iter().collect();
+
+        let removed = reap_zombies(&mut state, &live);
+
+        assert_eq!(removed, vec!["%1".to_string()]);
+        assert!(!state.contains_key("%1"));
+        assert!(state.contains_key("%0"));
+        assert!(state.contains_key("%2"));
+    }
+
+    #[test]
+    fn reap_zombies_noop_when_state_matches_live() {
+        // If every ledger entry is still alive, reap must not touch
+        // anything and must return an empty vec.  This is the common
+        // hot path — we don't want to pay a write on every
+        // `ensure_idle_panes_locked` call.
+        let mut state: PaneState = HashMap::new();
+        state.insert("%0".into(), make_idle("%0", "@0"));
+        state.insert("%1".into(), make_idle("%1", "@0"));
+        let live: std::collections::HashSet<String> =
+            ["%0".to_string(), "%1".to_string()].into_iter().collect();
+
+        let removed = reap_zombies(&mut state, &live);
+
+        assert!(removed.is_empty());
+        assert_eq!(state.len(), 2);
+    }
+
+    #[test]
+    fn reap_zombies_clears_all_when_tmux_is_empty() {
+        // Defensive: if tmux was restarted and returns no panes at all,
+        // every ledger entry is a zombie.  reap must empty the state
+        // rather than leaving stale records that would immediately
+        // re-saturate capacity on the next launch.
+        let mut state: PaneState = HashMap::new();
+        state.insert("%9".into(), make_busy("%9", "@0", None));
+        state.insert("%8".into(), make_idle("%8", "@0"));
+        let live: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        let removed = reap_zombies(&mut state, &live);
+
+        assert_eq!(removed.len(), 2);
+        assert!(state.is_empty());
     }
 
     #[test]

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -808,8 +808,12 @@ pub fn mark_claude_started(pane_id: &str) -> Result<()> {
 /// `AMAEBI_TEST_TMUX_PANES_OVERRIDE` env var to a whitespace-separated
 /// list of pane ids (e.g. `"%0 %1 %2"`).  Empty string means "tmux
 /// reports no live panes", which lets tests exercise the all-zombies
-/// path without shelling out.
+/// path without shelling out.  The override is gated behind `#[cfg(test)]`
+/// so production builds always shell out to real tmux — a stray env var
+/// in the daemon's environment must never be able to drop legitimate
+/// lease records.
 fn tmux_list_all_panes_sync() -> Result<std::collections::HashSet<String>> {
+    #[cfg(test)]
     if let Ok(override_str) = std::env::var("AMAEBI_TEST_TMUX_PANES_OVERRIDE") {
         return Ok(override_str
             .split_whitespace()
@@ -832,9 +836,11 @@ fn tmux_list_all_panes_sync() -> Result<std::collections::HashSet<String>> {
 }
 
 /// Drop lease records whose `pane_id` is no longer present in `live`.
-/// Returns the removed pane ids in insertion order (HashMap iteration
-/// order is arbitrary but stable within one process, which is enough
-/// for unit tests).
+/// Returns the removed pane ids in unspecified order (the implementation
+/// iterates `state.keys()`, and `std::collections::HashMap` iteration
+/// order is arbitrary and may change across runs / hash-seed rotations).
+/// Unit tests that care about membership assert with sets / `contains`,
+/// not positional equality.
 ///
 /// Pure function — takes the live-pane set as a parameter so tests can
 /// inject any set they like without touching a real tmux server.  The
@@ -1364,9 +1370,7 @@ mod tests {
             write_state_unlocked(&state).expect("seed state");
 
             // Mark the seeded panes as live so the reap leaves them alone.
-            unsafe {
-                std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", "%0 %1");
-            }
+            std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", "%0 %1");
 
             let lock = open_lock_file().expect("open lock");
             lock.lock_exclusive().expect("flock");
@@ -1407,9 +1411,7 @@ mod tests {
 
         // tmux only reports the 2 live panes — the 14 zombies were
         // closed behind amaebi's back.
-        unsafe {
-            std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", "%live0 %live1");
-        }
+        std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", "%live0 %live1");
 
         let lock = open_lock_file().expect("open lock");
         lock.lock_exclusive().expect("flock");
@@ -1417,9 +1419,7 @@ mod tests {
         let result = ensure_idle_panes_locked(2);
         lock.unlock().expect("unlock");
 
-        unsafe {
-            std::env::remove_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE");
-        }
+        std::env::remove_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE");
 
         result.expect("reap should drop the 14 zombies; 2 live idle is enough");
 

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -964,6 +964,30 @@ pub(crate) fn seed_state_for_test(lease: PaneLease) -> Result<()> {
 mod tests {
     use super::*;
 
+    /// RAII guard that sets `AMAEBI_TEST_TMUX_PANES_OVERRIDE` on construction
+    /// and unconditionally removes it on drop — including unwinding drops
+    /// caused by a test assertion panicking.  Without this, a panic between
+    /// `set_var` and `remove_var` would leave the env var set for the rest
+    /// of the test process, making unrelated tests' zombie reap behavior
+    /// order-dependent on whichever test panicked first.  Tests that use
+    /// this guard are also tagged `#[serial_test::serial]` because the env
+    /// var is process-global — two parallel holders would clobber each
+    /// other regardless of RAII cleanup.
+    struct TmuxOverride;
+
+    impl TmuxOverride {
+        fn set(panes: &str) -> Self {
+            std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", panes);
+            Self
+        }
+    }
+
+    impl Drop for TmuxOverride {
+        fn drop(&mut self) {
+            std::env::remove_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE");
+        }
+    }
+
     fn make_idle(pane_id: &str, window_id: &str) -> PaneLease {
         PaneLease::new_idle(pane_id.to_string(), window_id.to_string())
     }
@@ -1326,6 +1350,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn ensure_idle_panes_capacity_exceeded_returns_err() {
         {
             let _guard = crate::test_utils::with_temp_home();
@@ -1341,8 +1366,9 @@ mod tests {
 
             // Tell the zombie-reap step that every seeded pane is still
             // alive in tmux — without this it would drop them all and
-            // the capacity check would pass instead of failing.
-            std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", ids.join(" "));
+            // the capacity check would pass instead of failing.  RAII
+            // guard clears the env var even if the asserts below panic.
+            let _override = TmuxOverride::set(&ids.join(" "));
 
             // Acquiring the lock before calling the internal helper so we can
             // test the logic without real tmux.
@@ -1350,8 +1376,6 @@ mod tests {
             lock.lock_exclusive().expect("flock");
             let result = ensure_idle_panes_locked(1);
             lock.unlock().expect("unlock");
-
-            std::env::remove_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE");
 
             let err = result.expect_err("should be Err");
             let cap = err.downcast_ref::<CapacityError>().expect("CapacityError");
@@ -1361,6 +1385,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn ensure_idle_panes_noop_when_enough_idle() {
         {
             let _guard = crate::test_utils::with_temp_home();
@@ -1370,7 +1395,7 @@ mod tests {
             write_state_unlocked(&state).expect("seed state");
 
             // Mark the seeded panes as live so the reap leaves them alone.
-            std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", "%0 %1");
+            let _override = TmuxOverride::set("%0 %1");
 
             let lock = open_lock_file().expect("open lock");
             lock.lock_exclusive().expect("flock");
@@ -1378,13 +1403,12 @@ mod tests {
             let result = ensure_idle_panes_locked(2);
             lock.unlock().expect("unlock");
 
-            std::env::remove_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE");
-
             result.expect("should succeed without creating new windows");
         }
     }
 
     #[test]
+    #[serial_test::serial]
     fn ensure_idle_panes_reaps_zombies_before_capacity_check() {
         // End-to-end regression for the window-6 bug (2026-05-10):
         // ledger has MAX_PANES entries, but only a handful are still
@@ -1410,16 +1434,15 @@ mod tests {
         write_state_unlocked(&state).expect("seed state");
 
         // tmux only reports the 2 live panes — the 14 zombies were
-        // closed behind amaebi's back.
-        std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", "%live0 %live1");
+        // closed behind amaebi's back.  RAII guard clears the env var
+        // even if the asserts below panic.
+        let _override = TmuxOverride::set("%live0 %live1");
 
         let lock = open_lock_file().expect("open lock");
         lock.lock_exclusive().expect("flock");
         // Need 2 idle panes; we have 2 live idle after reap → Ok.
         let result = ensure_idle_panes_locked(2);
         lock.unlock().expect("unlock");
-
-        std::env::remove_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE");
 
         result.expect("reap should drop the 14 zombies; 2 live idle is enough");
 

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -529,9 +529,40 @@ pub fn ensure_idle_panes(needed: usize) -> Result<()> {
     result
 }
 
-fn ensure_idle_panes_locked(needed: usize) -> Result<()> {
+/// Read the pane state, drop records whose `pane_id` is no longer in
+/// tmux, and persist the cleaned state if anything was removed.  Used as
+/// the first step of any capacity / availability decision so downstream
+/// math is never inflated by panes the user closed behind amaebi's back.
+///
+/// Tmux failure (not installed, no server, transient error) degrades to
+/// "keep existing ledger": we'd rather preserve a stale ledger than
+/// wipe it based on an empty / wrong list.  Callers see the pre-fix
+/// behavior on that edge, which is strictly no-worse than the old code.
+///
+/// Must be called with the pane-state flock held LOCK_EX (same contract
+/// as `write_state_unlocked`).
+fn reap_zombies_and_load_state_unlocked() -> Result<PaneState> {
     let mut state = read_state_unlocked()?;
+    match tmux_list_all_panes_sync() {
+        Ok(live) => {
+            let zombies = reap_zombies(&mut state, &live);
+            if !zombies.is_empty() {
+                tracing::info!(
+                    count = zombies.len(),
+                    ids = ?zombies,
+                    "reaped zombie pane lease records"
+                );
+                write_state_unlocked(&state)?;
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "skipping zombie reap; keeping existing ledger");
+        }
+    }
+    Ok(state)
+}
 
+fn ensure_idle_panes_locked(needed: usize) -> Result<()> {
     // Reap zombie lease records BEFORE any capacity math.  If the user
     // closed tmux panes directly (e.g. `:kill-pane`, window closed in
     // another tool), `tmux-state.json` still carries those entries until
@@ -540,32 +571,7 @@ fn ensure_idle_panes_locked(needed: usize) -> Result<()> {
     // reaping first, `total` below would include dead panes and we'd
     // reject a fresh `/claude` with a misleading "capacity reached"
     // even when tmux itself has plenty of room.
-    //
-    // If `tmux list-panes -a` fails (tmux not installed, no server,
-    // transient error), log and skip reaping rather than failing the
-    // whole request — we'd rather preserve the existing ledger under
-    // uncertainty than risk wiping it based on an empty / wrong list.
-    // The capacity check below still runs on the un-reaped state, so
-    // behavior in that edge case is exactly the old (pre-fix) behavior.
-    match tmux_list_all_panes_sync() {
-        Ok(live) => {
-            let zombies = reap_zombies(&mut state, &live);
-            if !zombies.is_empty() {
-                tracing::info!(
-                    count = zombies.len(),
-                    ids = ?zombies,
-                    "reaped zombie pane lease records before capacity check"
-                );
-                // Persist the reap so subsequent callers (and dashboards)
-                // see the cleaned ledger.  Safe under the caller-held
-                // LOCK_EX.
-                write_state_unlocked(&state)?;
-            }
-        }
-        Err(e) => {
-            tracing::warn!(error = %e, "skipping zombie reap; keeping existing ledger");
-        }
-    }
+    let mut state = reap_zombies_and_load_state_unlocked()?;
 
     let idle_count = state
         .values()
@@ -689,8 +695,13 @@ pub fn ensure_and_acquire_idle(
         //     worktree.is_some(), so those panes won't actually be selected.
         //     Counting them as available suppresses expansion and leads to
         //     "no idle panes available" instead.
-        // If none are available, expand the pool with a new blank pane.
-        let state = read_state_unlocked()?;
+        // Reap zombies first so `available` / `total_idle` reflect only
+        // panes tmux still knows about — otherwise a ledger bloated with
+        // zombie Idle entries would make `ensure_idle_panes_locked`
+        // receive a `needed = total_idle + 1` way larger than we really
+        // want, producing spurious `CapacityError` (or over-creation)
+        // once the reap inside that function shrinks `idle_count`.
+        let state = reap_zombies_and_load_state_unlocked()?;
         let available = state
             .values()
             .filter(|l| {
@@ -965,26 +976,32 @@ mod tests {
     use super::*;
 
     /// RAII guard that sets `AMAEBI_TEST_TMUX_PANES_OVERRIDE` on construction
-    /// and unconditionally removes it on drop — including unwinding drops
-    /// caused by a test assertion panicking.  Without this, a panic between
-    /// `set_var` and `remove_var` would leave the env var set for the rest
-    /// of the test process, making unrelated tests' zombie reap behavior
-    /// order-dependent on whichever test panicked first.  Tests that use
+    /// and restores the prior value (or removes it if unset) on drop — even
+    /// when the drop is caused by a panicking assertion.  Tests that use
     /// this guard are also tagged `#[serial_test::serial]` because the env
-    /// var is process-global — two parallel holders would clobber each
-    /// other regardless of RAII cleanup.
-    struct TmuxOverride;
+    /// var is process-global; two parallel holders would clobber each
+    /// other regardless of RAII cleanup.  Capturing the prior value means
+    /// nested holders and pre-set environments (CI harness, dev shell) are
+    /// left untouched, so cleanup is never a silent mutation of the outer
+    /// scope.
+    struct TmuxOverride {
+        prior: Option<std::ffi::OsString>,
+    }
 
     impl TmuxOverride {
         fn set(panes: &str) -> Self {
+            let prior = std::env::var_os("AMAEBI_TEST_TMUX_PANES_OVERRIDE");
             std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", panes);
-            Self
+            Self { prior }
         }
     }
 
     impl Drop for TmuxOverride {
         fn drop(&mut self) {
-            std::env::remove_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE");
+            match self.prior.take() {
+                Some(v) => std::env::set_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE", v),
+                None => std::env::remove_var("AMAEBI_TEST_TMUX_PANES_OVERRIDE"),
+            }
         }
     }
 
@@ -1453,6 +1470,49 @@ mod tests {
         assert_eq!(reloaded.len(), 2);
         assert!(reloaded.contains_key("%live0"));
         assert!(reloaded.contains_key("%live1"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn ensure_and_acquire_idle_reaps_zombies_before_counting_available() {
+        // Regression for the round-3 review comment: before the fix,
+        // `ensure_and_acquire_idle` computed `available` / `total_idle`
+        // from the pre-reap state, so a ledger bloated with zombie Idle
+        // entries would (a) mask the fact that no live pane is usable
+        // or (b) pass `needed = total_idle + 1` through to
+        // `ensure_idle_panes_locked` with an inflated value, producing
+        // spurious CapacityError once that function's internal reap
+        // shrank idle_count.
+        //
+        // This test pins the "reap before counting" contract in the
+        // cheap end-to-end case: 2 zombies + 1 live blank idle pane.
+        // After reap, `available = 1` (the live blank), so no expansion
+        // is needed and `acquire_first_idle_locked` selects the live
+        // pane without touching real tmux.
+        let _guard = crate::test_utils::with_temp_home();
+        let mut state: PaneState = HashMap::new();
+        state.insert("%live".into(), make_idle("%live", "@0"));
+        state.insert("%zombie0".into(), make_idle("%zombie0", "@0"));
+        state.insert("%zombie1".into(), make_idle("%zombie1", "@0"));
+        write_state_unlocked(&state).expect("seed state");
+
+        let _override = TmuxOverride::set("%live");
+
+        let (pane_id, had_claude) = ensure_and_acquire_idle("t", "s", None).expect("acquire");
+
+        assert_eq!(pane_id, "%live", "must pick the live pane, not a zombie");
+        assert!(!had_claude);
+
+        let reloaded = read_state_unlocked().expect("reload");
+        assert!(
+            !reloaded.contains_key("%zombie0") && !reloaded.contains_key("%zombie1"),
+            "zombies must be reaped before acquisition"
+        );
+        assert_eq!(
+            reloaded["%live"].effective_status(),
+            PaneStatus::Busy,
+            "acquired pane must be marked busy"
+        );
     }
 
     // ── reap_zombies ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`/claude` was refusing new launches with \"capacity limit reached: max_panes=16\" even after the user closed most panes in tmux.  Root cause: `~/.amaebi/tmux-state.json` is only ever cleaned on `release_lease` / heartbeat, so panes killed directly in tmux leave zombie records that saturate the `MAX_PANES` ledger forever.

This PR reaps zombie records at the top of `ensure_idle_panes_locked` — the single entry point for pane acquisition — before any capacity math runs.

## Observed (window-6 capture, 2026-05-10)

```
> /claude --resource sim-9901 ...
[error] capacity limit reached: max_panes=16, busy=1, requested=1; free existing panes to continue
```

`busy=1` was already a giveaway — the ledger counted `total=state.len()=16`, not `busy`.  Inspection:

```
tmux-state.json: 16 entries
tmux list-panes -a: 4 alive
zombies:          12
```

## Fix

`ensure_idle_panes_locked` now calls `tmux_list_all_panes_sync()` first, diffs the ledger, and drops entries whose `pane_id` no longer exists in tmux.  The cleaned state is persisted under the caller-held `LOCK_EX` so subsequent callers (and dashboards) see the fresh ledger.

- **Pure `reap_zombies(state, live)`** — the zombie-set diff is testable without a tmux server.
- **`AMAEBI_TEST_TMUX_PANES_OVERRIDE`** — tests inject any pane list via env var; keeps unit tests hermetic.
- **Tmux failure is non-fatal** — if `tmux list-panes -a` errors (no server, transient failure), we log and skip reaping.  That degrades to the pre-fix behaviour for that edge (preferable over risking a full ledger wipe on a transient).

## Tests

- `reap_zombies_removes_entries_not_in_live_set` — basic differential.
- `reap_zombies_noop_when_state_matches_live` — hot path stays write-free.
- `reap_zombies_clears_all_when_tmux_is_empty` — tmux-restart edge.
- `ensure_idle_panes_reaps_zombies_before_capacity_check` — end-to-end regression: seed a saturated ledger (2 live + 14 zombies), override tmux to report only the 2 live ones, assert `ensure_idle_panes_locked(2)` succeeds and the ledger shrinks to 2 entries.

Existing `ensure_idle_panes_capacity_exceeded_returns_err` and `ensure_idle_panes_noop_when_enough_idle` tests now set `AMAEBI_TEST_TMUX_PANES_OVERRIDE` to their seeded ids so the new reap doesn't touch them.

## Cost / compatibility

- One extra `tmux list-panes -a` fork per `ensure_idle_panes_locked` call (low ms).
- No wire-protocol change.
- Live (pre-existing) ledger is unaffected if every pane is alive.

## Test plan

- [x] `cargo test --bin amaebi` — 711 pass (was 707 + 4 new)
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings` clean
- [x] `scripts/next-version.sh --check` — \`OK 2026.5.27\`
- [x] Manually reaped the user's live `tmux-state.json` (12 zombies) as the immediate workaround before landing this PR; confirmed subsequent `/claude` launches accept capacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)