### PR TITLE
fix(tools): tmux_wait ignores spinner + elapsed-time animations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.29"
+version = "2026.5.30"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.29"
+version = "2026.5.30"
 edition = "2021"
 
 [[bin]]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -880,7 +880,13 @@ pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                 "description": "Poll a tmux pane until its output has been stable for idle_secs, \
                                 then return the final pane content. Use this instead of calling \
                                 tmux_capture_pane in a loop while waiting for a long-running command \
-                                (e.g. a build) to finish.",
+                                (e.g. a build) to finish. Stability is measured against a normalized \
+                                view of the capture: spinner glyphs and runs of ASCII digits are \
+                                collapsed before comparison, so live TUI animations (spinners, \
+                                elapsed-time counters, token counts, percentage tickers) do not \
+                                count as activity. Real text changes — new lines, new tool-call \
+                                names, generated prose — still register and reset the idle timer. \
+                                The returned string is the raw, un-normalized capture.",
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -343,7 +343,6 @@ async fn tmux_wait(args: serde_json::Value) -> Result<String> {
     let poll_secs = args["poll_interval_secs"].as_u64().unwrap_or(2).max(1);
 
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
-    let mut last_content = String::new();
     let mut last_normalized = String::new();
     let mut stable_since = tokio::time::Instant::now();
 
@@ -377,10 +376,9 @@ async fn tmux_wait(args: serde_json::Value) -> Result<String> {
 
         if normalized != last_normalized {
             last_normalized = normalized;
-            last_content = content;
             stable_since = tokio::time::Instant::now();
         } else if stable_since.elapsed().as_secs() >= idle_secs {
-            return Ok(last_content);
+            return Ok(content);
         }
 
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -295,6 +295,41 @@ async fn tmux_send_key(args: serde_json::Value) -> Result<String> {
     Ok(format!("sent key {key:?} to pane {target}"))
 }
 
+/// Normalize a pane capture so live-UI animations don't masquerade as
+/// activity.  Claude Code's TUI cycles a spinner glyph every poll and
+/// re-renders elapsed-time counters every second (`(4m 35s)`, `↓ 5.8k
+/// tokens`, `Running… (1m 6s)`); a byte-exact comparison therefore
+/// never converges and `tmux_wait` blocks until `timeout_secs`.
+///
+/// Strategy: collapse every run of ASCII digits to a single `0` and
+/// every known spinner glyph to `*`.  Real content changes (new lines,
+/// new tool calls, text generation) still differ after normalization
+/// because the surrounding non-digit, non-spinner characters change.
+fn normalize_for_idle_check(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_digit = false;
+    for c in s.chars() {
+        match c {
+            '✶' | '✻' | '✷' | '✸' | '✹' | '✺' | '✦' | '✧' | '⠋' | '⠙' | '⠹' | '⠸' | '⠼' | '⠴'
+            | '⠦' | '⠧' | '⠇' | '⠏' => {
+                out.push('*');
+                prev_digit = false;
+            }
+            d if d.is_ascii_digit() => {
+                if !prev_digit {
+                    out.push('0');
+                }
+                prev_digit = true;
+            }
+            other => {
+                out.push(other);
+                prev_digit = false;
+            }
+        }
+    }
+    out
+}
+
 /// Poll a tmux pane until its output has been stable for `idle_secs`, then
 /// return the final pane content.
 ///
@@ -309,6 +344,7 @@ async fn tmux_wait(args: serde_json::Value) -> Result<String> {
 
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
     let mut last_content = String::new();
+    let mut last_normalized = String::new();
     let mut stable_since = tokio::time::Instant::now();
 
     loop {
@@ -337,8 +373,10 @@ async fn tmux_wait(args: serde_json::Value) -> Result<String> {
             );
         }
         let content = String::from_utf8_lossy(&output.stdout).into_owned();
+        let normalized = normalize_for_idle_check(&content);
 
-        if content != last_content {
+        if normalized != last_normalized {
+            last_normalized = normalized;
             last_content = content;
             stable_since = tokio::time::Instant::now();
         } else if stable_since.elapsed().as_secs() >= idle_secs {
@@ -1670,6 +1708,53 @@ mod tests {
         .await
         .unwrap();
         assert!(result.starts_with("timeout:"), "got: {result}");
+    }
+
+    // ---- tmux_wait normalize_for_idle_check --------------------------------
+
+    #[test]
+    fn normalize_collapses_elapsed_timer_runs() {
+        let a = "✻ Comparing… (4m 35s · ↓ 5.8k tokens)";
+        let b = "✻ Comparing… (4m 36s · ↓ 5.8k tokens)";
+        assert_eq!(
+            normalize_for_idle_check(a),
+            normalize_for_idle_check(b),
+            "ticking elapsed-time counter should not register as activity"
+        );
+    }
+
+    #[test]
+    fn normalize_collapses_spinner_glyph() {
+        let a = "✶ thinking…";
+        let b = "✻ thinking…";
+        let c = "✷ thinking…";
+        assert_eq!(normalize_for_idle_check(a), normalize_for_idle_check(b));
+        assert_eq!(normalize_for_idle_check(b), normalize_for_idle_check(c));
+    }
+
+    #[test]
+    fn normalize_collapses_running_timer() {
+        let a = "  ⎿  Running… (1m 1s)";
+        let b = "  ⎿  Running… (1m 6s)";
+        assert_eq!(normalize_for_idle_check(a), normalize_for_idle_check(b));
+    }
+
+    #[test]
+    fn normalize_preserves_real_text_changes() {
+        let a = "● Bash(echo hello)";
+        let b = "● Bash(echo world)";
+        assert_ne!(
+            normalize_for_idle_check(a),
+            normalize_for_idle_check(b),
+            "non-numeric, non-spinner text changes must still differ"
+        );
+    }
+
+    #[test]
+    fn normalize_treats_new_lines_as_activity() {
+        let a = "● step 1";
+        let b = "● step 1\n● step 2";
+        assert_ne!(normalize_for_idle_check(a), normalize_for_idle_check(b));
     }
 
     // ---- tmux_send_text / tmux_send_key split ------------------------------


### PR DESCRIPTION
## Summary

`tmux_wait` polled the pane and compared captures byte-for-byte.  When the
target pane runs Claude Code (or any TUI with a live spinner / elapsed-time
counter), every poll differs and `stable_since` resets every loop — so
`tmux_wait` never converges and just blocks until `timeout_secs` (default
600s).

Observed today on window 5: the supervisor LLM had been parked in
`tmux_wait` for 2+ minutes against an idle inner-claude pane.  The only
changes between captures were:

```
✻ Comparing… (5m 5s · ↓ 5.8k tokens)
✻ Comparing… (5m 6s · ↓ 5.8k tokens)
  ⎿  Running… (1m 1s)
  ⎿  Running… (1m 6s)
```

## Fix

Normalize the capture before comparing:
- collapse runs of ASCII digits → single `0` (kills `5m 5s` vs `5m 6s` etc.)
- collapse known spinner glyphs (`✶ ✻ ✷ ✸ ✹ ✺ ✦ ✧ ⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏`) → `*`

Real activity (new lines, new tool-call names, new words) still differs
after normalization.  The raw last-seen content is still returned to the
LLM unchanged.

## Test plan

- [x] `cargo test --bin amaebi` — 790 passed (5 new unit tests on the normalizer)
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [ ] Manual: rebuild `./amaebi`, restart daemon in window 4, observe whether window 5 supervisor unblocks within `idle_secs` of inner-claude going idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)