### PR TITLE
feat(claude): LLM distillation of /claude briefs into detailed prompts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.31"
+version = "2026.5.32"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.31"
+version = "2026.5.32"
 edition = "2021"
 
 [[bin]]

--- a/src/agent_server.rs
+++ b/src/agent_server.rs
@@ -338,8 +338,10 @@ impl acp::Agent for AmaebiAgent {
                 }
                 Response::PaneAssigned { .. }
                 | Response::CapacityError { .. }
-                | Response::TagGenerated { .. } => {
-                    // ACP mode never sends ClaudeLaunch/GenerateTag.
+                | Response::TagGenerated { .. }
+                | Response::DistilledPromptReady { .. }
+                | Response::PaneReserved { .. } => {
+                    // ACP mode never issues these scheduler / pre-launch flows.
                     tracing::debug!("unexpected pane/tag scheduler response in ACP mode");
                 }
                 Response::TaskReleased { .. } => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1073,6 +1073,31 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
         // before ClaudeLaunch so pane/worktree/notebook all use the
         // resolved tag from the start.
         resolve_missing_tags(&socket, &mut tasks, &cwd_str).await?;
+        // Distill briefs into detailed prompts before launch.  Streams
+        // the LLM's investigation to stderr so the user sees what's
+        // happening.  One-shot ask has no chat session id; pass the
+        // task tag as a placeholder so reserve_pane works for
+        // --resume-pane.
+        let chat_session_for_distill = format!("ask-{}", uuid::Uuid::new_v4());
+        let mut sink = StderrDistillSink;
+        if let Err(e) = distill_claude_tasks(
+            &socket,
+            &mut tasks,
+            &cwd_str,
+            &chat_session_for_distill,
+            &model,
+            &mut sink,
+        )
+        .await
+        {
+            eprintln!("[error] distillation pre-flight: {e:#}");
+            return Ok(());
+        }
+        tasks.retain(|t| !t.description.trim().is_empty());
+        if tasks.is_empty() {
+            eprintln!("[error] all /claude tasks failed distillation");
+            return Ok(());
+        }
         // One-shot `amaebi ask "/claude ..."` never sends SupervisePanes,
         // so there is no holder lifecycle to tie a notebook lease to.
         // Skip the lease by leaving session_id/repo_dir as None — matches
@@ -1372,7 +1397,9 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                     }
                     Response::PaneAssigned { .. }
                     | Response::CapacityError { .. }
-                    | Response::TagGenerated { .. } => {
+                    | Response::TagGenerated { .. }
+                    | Response::DistilledPromptReady { .. }
+                    | Response::PaneReserved { .. } => {
                         // Not expected in a normal Chat response stream.
                         tracing::debug!("unexpected pane/tag scheduler response in chat loop");
                     }
@@ -1713,7 +1740,34 @@ pub async fn run_chat_loop(
                     stdout.flush().await?;
                     continue 'session;
                 }
-                // Keyed by tag — used to look up the original description
+                // Distill briefs into detailed prompts before launch.
+                // Investigation streams to stderr so the user sees the
+                // model walk through the codebase before Claude starts.
+                let mut sink = StderrDistillSink;
+                if let Err(e) = distill_claude_tasks(
+                    &socket,
+                    &mut tasks,
+                    &cwd_str,
+                    &session_id,
+                    &model,
+                    &mut sink,
+                )
+                .await
+                {
+                    let msg = format!("[error] distillation pre-flight: {e:#}\n");
+                    stdout.write_all(msg.as_bytes()).await?;
+                    stdout.flush().await?;
+                    continue 'session;
+                }
+                tasks.retain(|t| !t.description.trim().is_empty());
+                if tasks.is_empty() {
+                    stdout
+                        .write_all(b"[error] all /claude tasks failed distillation\n")
+                        .await?;
+                    stdout.flush().await?;
+                    continue 'session;
+                }
+                // Keyed by tag — used to look up the distilled description
                 // when daemon replies with PaneAssigned.  Tag is resolved
                 // (Haiku or `--tag` override) before tasks land here, so
                 // it's a stable id for the supervision handoff.
@@ -2594,7 +2648,9 @@ pub async fn run_resume(
                     }
                     Response::PaneAssigned { .. }
                     | Response::CapacityError { .. }
-                    | Response::TagGenerated { .. } => {
+                    | Response::TagGenerated { .. }
+                    | Response::DistilledPromptReady { .. }
+                    | Response::PaneReserved { .. } => {
                         tracing::debug!("unexpected pane/tag scheduler response in resume loop");
                     }
                     Response::ModelSwitched { .. } => {
@@ -3182,6 +3238,281 @@ pub(crate) async fn resolve_missing_tags(
             other => {
                 anyhow::bail!("unexpected daemon frame for GenerateTag: {other:?}");
             }
+        }
+    }
+    Ok(())
+}
+
+/// Run the `/claude` pre-launch flow on each task: optionally reserve a
+/// `--resume-pane` slot, then distill the brief into a detailed Claude
+/// Code prompt.  On success replaces `task.description` with the
+/// distilled text.  On failure for any task surfaces the error via
+/// `sink.on_status` and skips that task (caller chooses whether to
+/// continue with remaining tasks or abort).  Reserved panes are
+/// released on distillation failure so leases never leak.
+///
+/// `model` is the client's current chat model — distillation runs on
+/// the same model so /model state is honoured.
+///
+/// Returns `Ok(())` when every task either succeeded or had its lease
+/// rolled back cleanly.  Returns `Err` only on an underlying IPC
+/// failure that prevented attempting the next task.
+pub(crate) async fn distill_claude_tasks(
+    socket: &std::path::Path,
+    tasks: &mut [ClaudeTask],
+    client_cwd: &str,
+    chat_session_id: &str,
+    model: &str,
+    sink: &mut dyn DistillSink,
+) -> Result<()> {
+    for task in tasks.iter_mut() {
+        let task_cwd = task.cwd.clone().unwrap_or_else(|| client_cwd.to_string());
+
+        // Reserve the resume pane up front so other commands can't grab
+        // it during the (potentially minutes-long) distillation run.
+        let reserved_pane: Option<String> = if let Some(pid) = task.resume_pane.clone() {
+            sink.on_status(&format!(
+                "[distill] reserving pane {pid} for tag {}",
+                task.tag
+            ));
+            match reserve_pane(
+                socket,
+                &pid,
+                &task.tag,
+                chat_session_id,
+                task.worktree.as_deref(),
+            )
+            .await
+            {
+                Ok(()) => Some(pid),
+                Err(e) => {
+                    sink.on_status(&format!("[distill] reserve {pid} failed: {e:#}"));
+                    continue;
+                }
+            }
+        } else {
+            None
+        };
+
+        sink.on_status(&format!(
+            "[distill] investigating codebase for tag {} (this may take a minute)",
+            task.tag
+        ));
+        match distill_claude_prompt(socket, &task.description, &task_cwd, model, sink).await {
+            Ok(prompt) => {
+                task.description = prompt;
+                sink.on_status(&format!("[distill] tag {} done", task.tag));
+            }
+            Err(e) => {
+                sink.on_status(&format!(
+                    "[distill] tag {} failed: {e:#}; skipping launch",
+                    task.tag
+                ));
+                if let Some(pid) = reserved_pane {
+                    if let Err(re) = release_reserved_pane(socket, &pid).await {
+                        sink.on_status(&format!("[distill] also failed to release {pid}: {re:#}"));
+                    }
+                }
+                // Mark the task for skip via empty description; caller
+                // filters those out before ClaudeLaunch.  Empty was
+                // already invalid upstream of parse, so no risk of
+                // accidentally launching an empty task.
+                task.description.clear();
+                continue;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `DistillSink` impl for the classic CLI: prints Text/ToolUse to
+/// stderr in real time so the user sees the investigation as the
+/// model runs.  Used by `run_chat_loop` and the one-shot ask path so
+/// `/claude` distillation looks the same in both classic UIs.
+pub(crate) struct StderrDistillSink;
+impl DistillSink for StderrDistillSink {
+    fn on_text(&mut self, chunk: &str) {
+        eprint!("{chunk}");
+        let _ = std::io::Write::flush(&mut std::io::stderr());
+    }
+    fn on_tool_use(&mut self, name: &str, detail: &str) {
+        let line = if detail.is_empty() {
+            format!("\n[distill tool] {name}\n")
+        } else {
+            format!("\n[distill tool] {name} {detail}\n")
+        };
+        eprint!("{line}");
+        let _ = std::io::Write::flush(&mut std::io::stderr());
+    }
+    fn on_status(&mut self, line: &str) {
+        eprintln!("{line}");
+    }
+}
+
+/// Sink for streaming Text / ToolUse frames during a distillation run
+/// so the caller (CLI vs TUI) can route them to the appropriate UI.
+/// Both methods are best-effort — failure to display a frame must not
+/// abort the distillation.
+pub(crate) trait DistillSink {
+    fn on_text(&mut self, chunk: &str);
+    fn on_tool_use(&mut self, name: &str, detail: &str);
+    fn on_status(&mut self, line: &str);
+}
+
+/// Send `Request::DistillClaudePrompt` to the daemon, drain Text /
+/// ToolUse frames into `sink` so the user can watch the investigation,
+/// and return the distilled prompt on success.
+///
+/// Uses a dedicated short-lived connection — same pattern as
+/// `resolve_missing_tags` / `resolve_replyreview_tasks` — so the
+/// distillation traffic doesn't fight the main chat connection for
+/// stream multiplexing.
+pub(crate) async fn distill_claude_prompt(
+    socket: &std::path::Path,
+    brief: &str,
+    cwd: &str,
+    model: &str,
+    sink: &mut dyn DistillSink,
+) -> Result<String> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    let stream = UnixStream::connect(socket)
+        .await
+        .context("connecting to daemon for DistillClaudePrompt")?;
+    let (reader, mut writer) = tokio::io::split(stream);
+    let req = Request::DistillClaudePrompt {
+        brief: brief.to_string(),
+        cwd: cwd.to_string(),
+        model: model.to_string(),
+    };
+    let mut line = serde_json::to_string(&req).context("serialising DistillClaudePrompt")?;
+    line.push('\n');
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .context("sending DistillClaudePrompt")?;
+
+    let mut lines = BufReader::new(reader).lines();
+    let mut distilled: Option<String> = None;
+    let mut last_error: Option<String> = None;
+    loop {
+        let line_opt = lines
+            .next_line()
+            .await
+            .context("reading DistillClaudePrompt response")?;
+        let Some(reply) = line_opt else {
+            break;
+        };
+        let frame: Response =
+            serde_json::from_str(&reply).context("parsing DistillClaudePrompt frame")?;
+        match frame {
+            Response::Text { chunk } => sink.on_text(&chunk),
+            Response::ToolUse { name, detail } => sink.on_tool_use(&name, &detail),
+            Response::Compacting => sink.on_status("[compacting]"),
+            Response::ModelSwitched { model } => {
+                sink.on_status(&format!("[model switched: {model}]"))
+            }
+            Response::DistilledPromptReady { prompt } => {
+                distilled = Some(prompt);
+            }
+            Response::Done => break,
+            Response::Error { message } => {
+                last_error = Some(message);
+                // keep draining; daemon will follow with Done
+            }
+            // Other frame kinds (PaneAssigned, TagGenerated, etc.) are
+            // not expected on the distillation channel — ignore.
+            _ => {}
+        }
+    }
+    if let Some(prompt) = distilled {
+        return Ok(prompt);
+    }
+    if let Some(message) = last_error {
+        anyhow::bail!("distillation failed: {message}");
+    }
+    anyhow::bail!("distillation finished without emitting a prompt");
+}
+
+/// Reserve a pane via the daemon so a long pre-launch flow can hold the
+/// slot.  Mirrors `acquire_lease` shape so the eventual `ClaudeLaunch`
+/// is a no-op rather than a contention.  Caller must pair with
+/// `release_reserved_pane` on failure.
+pub(crate) async fn reserve_pane(
+    socket: &std::path::Path,
+    pane_id: &str,
+    tag: &str,
+    session_id: &str,
+    worktree: Option<&str>,
+) -> Result<()> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    let stream = UnixStream::connect(socket)
+        .await
+        .context("connecting to daemon for ReservePane")?;
+    let (reader, mut writer) = tokio::io::split(stream);
+    let req = Request::ReservePane {
+        pane_id: pane_id.to_string(),
+        tag: tag.to_string(),
+        session_id: session_id.to_string(),
+        worktree: worktree.map(str::to_string),
+    };
+    let mut line = serde_json::to_string(&req).context("serialising ReservePane")?;
+    line.push('\n');
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .context("sending ReservePane")?;
+    let mut lines = BufReader::new(reader).lines();
+    let mut reserved = false;
+    loop {
+        let Some(reply) = lines
+            .next_line()
+            .await
+            .context("reading ReservePane response")?
+        else {
+            break;
+        };
+        let frame: Response = serde_json::from_str(&reply).context("parsing ReservePane frame")?;
+        match frame {
+            Response::PaneReserved { .. } => reserved = true,
+            Response::Done => break,
+            Response::Error { message } => {
+                anyhow::bail!("reserve_pane: {message}");
+            }
+            _ => {}
+        }
+    }
+    if !reserved {
+        anyhow::bail!("reserve_pane: daemon closed without confirming reservation");
+    }
+    Ok(())
+}
+
+/// Release a previously reserved pane.  Idempotent on the daemon side,
+/// so a release on an already-idle pane is a no-op.
+pub(crate) async fn release_reserved_pane(socket: &std::path::Path, pane_id: &str) -> Result<()> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    let stream = UnixStream::connect(socket)
+        .await
+        .context("connecting to daemon for ReleasePane")?;
+    let (reader, mut writer) = tokio::io::split(stream);
+    let req = Request::ReleasePane {
+        pane_id: pane_id.to_string(),
+    };
+    let mut line = serde_json::to_string(&req).context("serialising ReleasePane")?;
+    line.push('\n');
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .context("sending ReleasePane")?;
+    let mut lines = BufReader::new(reader).lines();
+    while let Some(reply) = lines
+        .next_line()
+        .await
+        .context("reading ReleasePane response")?
+    {
+        let frame: Response = serde_json::from_str(&reply).context("parsing ReleasePane frame")?;
+        if matches!(frame, Response::Done) {
+            break;
         }
     }
     Ok(())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -981,6 +981,23 @@ async fn handle_connection_inner(
                 handle_claude_release(&writer, &state, conn_id, target, clean_worktree, summary)
                     .await?;
             }
+
+            Request::DistillClaudePrompt { brief, cwd, model } => {
+                handle_distill_claude_prompt(&writer, &state, conn_id, brief, cwd, model).await?;
+            }
+
+            Request::ReservePane {
+                pane_id,
+                tag,
+                session_id,
+                worktree,
+            } => {
+                handle_reserve_pane(&writer, pane_id, tag, session_id, worktree).await?;
+            }
+
+            Request::ReleasePane { pane_id } => {
+                handle_release_pane(&writer, pane_id).await?;
+            }
         }
     }
 
@@ -1176,6 +1193,175 @@ async fn handle_claude_release(
 
     let mut w = writer.lock().await;
     write_frame(&mut *w, &Response::Done).await?;
+    Ok(())
+}
+
+/// Handle `Request::DistillClaudePrompt`: run a bounded agentic loop
+/// in `cwd` with the read-only investigation toolset + the
+/// `emit_distilled_prompt` terminator, then ship the produced prompt
+/// back as `Response::DistilledPromptReady` followed by `Response::Done`.
+///
+/// Streams Text / ToolUse frames during the run so the user sees the
+/// investigation in real time (matching the chat UX).  Failure modes
+/// emit `Response::Error` then `Response::Done`.
+async fn handle_distill_claude_prompt(
+    writer: &Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    state: &Arc<DaemonState>,
+    conn_id: ConnId,
+    brief: String,
+    cwd: String,
+    model: String,
+) -> Result<()> {
+    let system_prompt = build_distillation_system_prompt(&cwd);
+    let user_msg = format!(
+        "User's brief description for /claude:\n\n{brief}\n\n\
+         Working directory: {cwd}\n\n\
+         Investigate the codebase, then call `emit_distilled_prompt` exactly once \
+         with the full Claude Code prompt."
+    );
+    let messages = vec![Message::system(system_prompt), Message::user(user_msg)];
+
+    // Open a private steer channel; distillation has no user steer surface yet.
+    let (_steer_tx, mut steer_rx) = tokio::sync::mpsc::channel::<Option<String>>(8);
+
+    // Hold the writer for the whole loop; run_agentic_loop streams frames
+    // through it.  The lock is taken exclusively for this distillation call.
+    let mut w = writer.lock().await;
+    let result = run_agentic_loop_with_mode(
+        state,
+        &model,
+        messages,
+        &mut *w,
+        &mut steer_rx,
+        tools::ToolMode::Distill,
+        None,
+        Some(conn_id),
+    )
+    .await;
+    drop(w);
+
+    match result {
+        Ok((final_text, _, _, _)) if !final_text.trim().is_empty() => {
+            let mut w = writer.lock().await;
+            write_frame(
+                &mut *w,
+                &Response::DistilledPromptReady { prompt: final_text },
+            )
+            .await
+            .ok();
+            write_frame(&mut *w, &Response::Done).await.ok();
+        }
+        Ok(_) => {
+            let mut w = writer.lock().await;
+            write_frame(
+                &mut *w,
+                &Response::Error {
+                    message: "distillation finished without emitting a prompt".to_string(),
+                },
+            )
+            .await
+            .ok();
+            write_frame(&mut *w, &Response::Done).await.ok();
+        }
+        Err(e) => {
+            let mut w = writer.lock().await;
+            write_frame(
+                &mut *w,
+                &Response::Error {
+                    message: format!("distillation failed: {e:#}"),
+                },
+            )
+            .await
+            .ok();
+            write_frame(&mut *w, &Response::Done).await.ok();
+        }
+    }
+    Ok(())
+}
+
+/// System prompt for the `/claude` distillation loop.  Tells the LLM
+/// what `/replyreview`-grade output should look like and what tools it
+/// has.  Kept outside the handler so it can be unit-tested for shape.
+fn build_distillation_system_prompt(cwd: &str) -> String {
+    format!(
+        "You are amaebi's prompt distiller.  The user typed `/claude \"<brief>\"` and your \
+         job is to convert that brief into a self-contained prompt that a downstream Claude \
+         Code session will execute.\n\n\
+         Working directory: {cwd}\n\n\
+         Procedure:\n\
+         1. Use `shell_command` and `read_file` to investigate the codebase.  Look for the \
+            files / functions / tests / scripts the brief actually touches.  Run `git status`, \
+            `git log --oneline -10`, `ls`, `grep`, etc.  Read the most relevant files in full.\n\
+         2. Decide concretely what Claude Code should do — file paths, key functions, the \
+            execution plan in steps, the verification commands (tests, benchmarks, builds), \
+            and the hard constraints (no force push, don't skip CI hooks, keep main repo on \
+            master, etc.).\n\
+         3. Call `emit_distilled_prompt` EXACTLY ONCE with the final prompt as a single \
+            string.  That call ends your work — no further turns will run after it.\n\n\
+         Output requirements for the distilled prompt:\n\
+         - Self-contained: the downstream Claude session does NOT see this conversation.\n\
+         - Concrete: name file paths and functions, not vague areas.\n\
+         - Action-oriented: numbered steps the inner Claude can follow.\n\
+         - Verification: at least one test / benchmark / build command Claude must run.\n\
+         - Constraints: list the hard rules (CI, branching, etc.) that apply.\n\
+         - No meta-commentary: the prompt is read by Claude as the FIRST user message; do \
+           not include phrases like 'I have analyzed your code' or 'here is the prompt'.\n\n\
+         You have NO write tools — `edit_file` and tmux pane mutators are not available.  \
+         You investigate; Claude executes."
+    )
+}
+
+/// Handle `Request::ReservePane`: acquire a pane lease so a long-running
+/// pre-launch flow can hold the slot.  Responds with `PaneReserved` + `Done`
+/// or `Error` + `Done`.
+async fn handle_reserve_pane(
+    writer: &Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    pane_id: String,
+    tag: String,
+    session_id: String,
+    worktree: Option<String>,
+) -> Result<()> {
+    let res = tokio::task::spawn_blocking(move || {
+        crate::pane_lease::acquire_lease(&pane_id, &tag, &session_id, worktree.as_deref())
+            .map(|_| pane_id)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("reserve_pane spawn_blocking panicked: {e}"))?;
+
+    let mut w = writer.lock().await;
+    match res {
+        Ok(pane_id) => {
+            write_frame(&mut *w, &Response::PaneReserved { pane_id })
+                .await
+                .ok();
+            write_frame(&mut *w, &Response::Done).await.ok();
+        }
+        Err(e) => {
+            write_frame(
+                &mut *w,
+                &Response::Error {
+                    message: format!("reserve_pane failed: {e:#}"),
+                },
+            )
+            .await
+            .ok();
+            write_frame(&mut *w, &Response::Done).await.ok();
+        }
+    }
+    Ok(())
+}
+
+/// Handle `Request::ReleasePane`: release a previously reserved lease.
+/// Idempotent — releasing an already-idle pane succeeds silently.
+async fn handle_release_pane(
+    writer: &Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    pane_id: String,
+) -> Result<()> {
+    let _ = tokio::task::spawn_blocking(move || crate::pane_lease::release_lease(&pane_id))
+        .await
+        .map_err(|e| anyhow::anyhow!("release_pane spawn_blocking panicked: {e}"))?;
+    let mut w = writer.lock().await;
+    write_frame(&mut *w, &Response::Done).await.ok();
     Ok(())
 }
 
@@ -4854,7 +5040,7 @@ fn format_pane_alive_reminder(pane_ids: &[String]) -> String {
 pub(crate) async fn run_agentic_loop<W>(
     state: &DaemonState,
     model: &str,
-    mut messages: Vec<Message>,
+    messages: Vec<Message>,
     writer: &mut W,
     steer_rx: &mut tokio::sync::mpsc::Receiver<Option<String>>,
     include_spawn_agent: bool,
@@ -4864,11 +5050,44 @@ pub(crate) async fn run_agentic_loop<W>(
 where
     W: AsyncWriteExt + Unpin,
 {
-    let schemas = tools::tool_schemas(include_spawn_agent);
-    let final_text;
+    run_agentic_loop_with_mode(
+        state,
+        model,
+        messages,
+        writer,
+        steer_rx,
+        tools::ToolMode::Chat {
+            include_spawn_agent,
+        },
+        session_id,
+        conn_id,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run_agentic_loop_with_mode<W>(
+    state: &DaemonState,
+    model: &str,
+    mut messages: Vec<Message>,
+    writer: &mut W,
+    steer_rx: &mut tokio::sync::mpsc::Receiver<Option<String>>,
+    tool_mode: tools::ToolMode,
+    session_id: Option<&str>,
+    conn_id: Option<ConnId>,
+) -> Result<(String, usize, Vec<Message>, String)>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    let schemas = tools::tool_schemas(tool_mode);
+    let mut final_text = String::new();
     let mut tools_were_used = false;
     let mut conclusion_nudge_sent = false;
-    let mut last_prompt_tokens: usize;
+    // Initialised to 0 to cover the early-exit path (distillation
+    // emits prompt before any model response sets this).  Overwritten
+    // on every model turn in the normal flow.
+    #[allow(unused_assignments)]
+    let mut last_prompt_tokens: usize = 0;
     // Mutable so switch_model tool calls can change the model mid-session.
     let mut current_model = model.to_string();
     // Circuit breaker: once we exhaust MAX_CONSECUTIVE_COMPACT_FAILURES in a row
@@ -4922,7 +5141,13 @@ where
     let mut read_cache: std::collections::HashMap<std::path::PathBuf, ((u128, u64), String)> =
         Default::default();
 
-    loop {
+    // Distillation early-exit accumulator: when the LLM (in
+    // ToolMode::Distill) calls `emit_distilled_prompt`, the post-op
+    // captures the prompt here and breaks 'outer.  Stays None on every
+    // other code path so the normal Chat flow is unaffected.
+    let mut distilled_capture: Option<String> = None;
+
+    'outer: loop {
         // Drain any steering corrections that arrived since the last model
         // call (covers non-tool turns and the time between tool completion
         // and the next iteration).
@@ -5643,6 +5868,17 @@ where
                             None
                         };
 
+                        // Snapshot emit_distilled_prompt args before execute consumes
+                        // them.  This tool is the distillation analogue of task_done:
+                        // pure-echo body, real side-effect (early-exit + ship payload
+                        // back to caller as final_text) lives here.
+                        let distilled_prompt: Option<String> = if tc.name == "emit_distilled_prompt"
+                        {
+                            args["prompt"].as_str().map(str::to_string)
+                        } else {
+                            None
+                        };
+
                         let result = match state.executor.execute(&tc.name, args).await {
                             Ok(output) => {
                                 tracing::debug!(
@@ -5681,6 +5917,16 @@ where
                         };
 
                         messages.push(Message::tool_result(&tc.id, result));
+
+                        // emit_distilled_prompt post-op: stash the prompt on the
+                        // outer accumulator and break the whole loop.  The caller
+                        // (handle_distill_claude_prompt) reads it from final_text.
+                        // Only triggered when the schema is exposed, i.e. when
+                        // ToolMode::Distill was passed in.
+                        if let Some(prompt) = distilled_prompt {
+                            distilled_capture = Some(prompt);
+                            break 'outer;
+                        }
 
                         // task_done post-op: the tool body is a pure echo, so the
                         // actual release of leases and TaskReleased streaming
@@ -5759,6 +6005,13 @@ where
                 break;
             }
         }
+    }
+
+    // Distillation path: the LLM called `emit_distilled_prompt`, the
+    // post-op stashed the payload and broke `'outer`.  Surface it via
+    // `final_text` so the caller can ship it as Response::DistilledPromptReady.
+    if let Some(prompt) = distilled_capture {
+        final_text = prompt;
     }
 
     Ok((final_text, last_prompt_tokens, messages, current_model))
@@ -8469,5 +8722,43 @@ mod tests {
     #[test]
     fn strip_tui_chrome_empty_input() {
         assert_eq!(strip_tui_chrome(""), "");
+    }
+
+    // ---- distillation system prompt -----------------------------------------
+
+    #[test]
+    fn distillation_system_prompt_mentions_emit_tool_and_cwd() {
+        let p = build_distillation_system_prompt("/tmp/repo");
+        // Working directory must be interpolated, not left as a placeholder.
+        assert!(p.contains("/tmp/repo"), "cwd must be in prompt: {p}");
+        // The terminator tool must be named explicitly so the LLM knows
+        // how to end its turn.
+        assert!(
+            p.contains("emit_distilled_prompt"),
+            "prompt must reference the emit tool: {p}"
+        );
+        // Investigation discipline cues — these guard against future
+        // edits that water down the instructions.
+        assert!(
+            p.to_lowercase().contains("investigate"),
+            "prompt must instruct investigation: {p}"
+        );
+        assert!(
+            p.to_lowercase().contains("verification"),
+            "prompt must instruct verification commands: {p}"
+        );
+    }
+
+    #[test]
+    fn distillation_system_prompt_forbids_meta_commentary() {
+        // Critical for downstream fidelity: the distilled output is
+        // injected as Claude's first user turn verbatim, so adding
+        // "here is the prompt I prepared:" wraps would break framing.
+        let p = build_distillation_system_prompt("/x");
+        assert!(
+            p.to_lowercase().contains("no meta-commentary")
+                || p.to_lowercase().contains("verbatim"),
+            "prompt must forbid meta-commentary or assert verbatim use: {p}"
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1654,8 +1654,16 @@ async fn handle_claude_launch(
             task.resume_pane
         {
             // --- resume-pane path ---
+            //
+            // The lease was already acquired by the `Request::ReservePane`
+            // pre-flight that wrapped distillation, so we don't call
+            // `acquire_lease` here — that would deadlock against ourselves
+            // (the lease is Busy, owned by the same caller).  We just
+            // validate the lease still describes a live `claude` pane,
+            // refresh the session_id to the launch-time placeholder, and
+            // bump the heartbeat.  On any probe failure we release the
+            // pre-flight lease so it doesn't sit Busy until TTL.
             let rp_owned = rp.clone();
-            let tid_for_lease = tag.clone();
             let sid_for_lease = sid_placeholder.clone();
             let probe = tokio::task::spawn_blocking(move || {
                     let state = pane_lease::read_state()?;
@@ -1712,12 +1720,10 @@ async fn handle_claude_launch(
                             "pane {rp_owned} is not currently running `claude` (tmux reports `{pane_current_command}`); drop --resume-pane and let the scheduler pick or start a new pane"
                         );
                     }
-                    pane_lease::acquire_lease(
-                        &rp_owned,
-                        &tid_for_lease,
-                        &sid_for_lease,
-                        Some(&wt),
-                    )?;
+                    // Refresh session_id + heartbeat on the existing lease.
+                    // Worktree/tag stay as written by ReservePane.
+                    pane_lease::update_session_id(&rp_owned, &sid_for_lease)?;
+                    pane_lease::heartbeat(&rp_owned)?;
                     Ok::<(String, bool, Option<String>), anyhow::Error>((rp_owned, true, Some(wt)))
                 })
                 .await
@@ -1726,6 +1732,11 @@ async fn handle_claude_launch(
             match probe {
                 Ok(triple) => triple,
                 Err(e) => {
+                    let pane_for_release = rp.clone();
+                    let _ = tokio::task::spawn_blocking(move || {
+                        pane_lease::release_lease(&pane_for_release)
+                    })
+                    .await;
                     let mut w = writer.lock().await;
                     write_frame(
                         &mut *w,

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -214,6 +214,48 @@ pub enum Request {
         #[serde(default)]
         summary: Option<String>,
     },
+    /// Ask the daemon to expand the user's brief `/claude` description into
+    /// a fully-detailed Claude Code prompt.
+    ///
+    /// Daemon spins up a bounded agentic loop with a read-only tool subset
+    /// plus the `emit_distilled_prompt` terminator.  The LLM investigates
+    /// the codebase under `cwd`, produces a self-contained prompt for
+    /// Claude Code, and emits it via `emit_distilled_prompt`.  The daemon
+    /// streams Text / ToolUse frames so the user sees the investigation in
+    /// real time, then ships [`Response::DistilledPromptReady`] followed by
+    /// [`Response::Done`].  Failure modes (tool errors, model timeouts) end
+    /// the stream with [`Response::Error`].
+    DistillClaudePrompt {
+        /// The user's original short description (`/claude "..."` argument).
+        brief: String,
+        /// Working directory the distillation should reason about — the
+        /// repo / worktree the downstream Claude pane will run in.
+        cwd: String,
+        /// Chat model to use for the distillation loop.  Caller passes the
+        /// outer chat's current model so /model state is honoured.
+        model: String,
+    },
+    /// Reserve a tmux pane up-front so a long-running pre-launch flow
+    /// (notably `Request::DistillClaudePrompt` for `/claude --resume-pane
+    /// %N`) can hold the slot before the actual `Request::ClaudeLaunch`.
+    ///
+    /// Mirrors the lease shape `acquire_lease` would set in `ClaudeLaunch`,
+    /// so the eventual launch call is a no-op rather than a contention.
+    /// Released via [`Request::ReleasePane`] on failure or replaced by the
+    /// real launch on success.  Daemon responds with [`Response::PaneReserved`]
+    /// or [`Response::Error`].
+    ReservePane {
+        pane_id: String,
+        tag: String,
+        session_id: String,
+        worktree: Option<String>,
+    },
+    /// Release a pane previously reserved via [`Request::ReservePane`].
+    /// Used by the client when the pre-launch flow aborts (distillation
+    /// failure, user cancel) so the lease doesn't leak.  Daemon responds
+    /// with [`Response::Done`] regardless of whether the pane was actually
+    /// reserved — release is idempotent.
+    ReleasePane { pane_id: String },
 }
 
 /// A single frame streamed from the daemon back to the client.
@@ -348,6 +390,12 @@ pub enum Response {
         /// Number of panes currently in Busy state.
         current_busy: usize,
     },
+    /// Reply to [`Request::DistillClaudePrompt`] carrying the distilled
+    /// prompt the LLM produced.  Always followed by [`Response::Done`].
+    DistilledPromptReady { prompt: String },
+    /// Reply to [`Request::ReservePane`] confirming the lease was acquired.
+    /// Always followed by [`Response::Done`].
+    PaneReserved { pane_id: String },
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pane_lease.rs
+++ b/src/pane_lease.rs
@@ -341,6 +341,14 @@ fn acquire_first_idle_locked(
 /// `worktree` conflicts with another Busy pane.  Used by
 /// `/claude --resume-pane <pane_id>` to target a specific pane instead of
 /// letting the scheduler pick one.
+///
+/// `worktree = None` means "do not change the existing worktree field".
+/// Passing `Some(_)` overwrites it.  This matters for the
+/// `Request::ReservePane` pre-flight (used by `/claude` distillation):
+/// the client doesn't know the resume-pane's worktree, and a previous
+/// `release_lease` deliberately preserved the field so resume-pane could
+/// find the worktree later.  An unconditional overwrite would clear that
+/// hint and break the subsequent `ClaudeLaunch` resume-pane probe.
 pub fn acquire_lease(
     pane_id: &str,
     tag: &str,
@@ -383,7 +391,9 @@ pub fn acquire_lease(
         lease.status = PaneStatus::Busy;
         lease.tag = Some(tag.to_string());
         lease.session_id = Some(session_id.to_string());
-        lease.worktree = worktree.map(str::to_string);
+        if let Some(wt) = worktree {
+            lease.worktree = Some(wt.to_string());
+        }
         lease.heartbeat_at = now_secs();
 
         write_state_unlocked(&state)?;
@@ -1143,6 +1153,50 @@ mod tests {
             let s = read_state_unlocked().expect("read back");
             assert_eq!(s["%0"].tag.as_deref(), Some("task-new"));
         }
+    }
+
+    #[test]
+    fn acquire_lease_with_none_worktree_preserves_existing() {
+        // Regression: `Request::ReservePane` (used by `/claude` distillation)
+        // calls `acquire_lease` with `worktree=None` because the client
+        // doesn't know the resume-pane's worktree.  An unconditional
+        // overwrite would clear the worktree set by a previous launch's
+        // `release_lease` (which intentionally preserves it) and break the
+        // subsequent `--resume-pane` probe with "pane has no associated
+        // worktree".
+        let _guard = crate::test_utils::with_temp_home();
+        let mut released = make_idle("%0", "@0");
+        released.worktree = Some("/tmp/wt-from-previous-launch".to_string());
+        released.has_claude = true;
+        let mut state: PaneState = HashMap::new();
+        state.insert("%0".to_string(), released);
+        write_state_unlocked(&state).expect("seed state");
+
+        acquire_lease("%0", "task-new", "sess-new", None).expect("acquire");
+
+        let s = read_state_unlocked().expect("read back");
+        assert_eq!(
+            s["%0"].worktree.as_deref(),
+            Some("/tmp/wt-from-previous-launch"),
+            "worktree must be preserved when caller passes None"
+        );
+        assert_eq!(s["%0"].tag.as_deref(), Some("task-new"));
+        assert_eq!(s["%0"].effective_status(), PaneStatus::Busy);
+    }
+
+    #[test]
+    fn acquire_lease_with_some_worktree_overwrites() {
+        let _guard = crate::test_utils::with_temp_home();
+        let mut prior = make_idle("%0", "@0");
+        prior.worktree = Some("/tmp/old".to_string());
+        let mut state: PaneState = HashMap::new();
+        state.insert("%0".to_string(), prior);
+        write_state_unlocked(&state).expect("seed state");
+
+        acquire_lease("%0", "task-new", "sess-new", Some("/tmp/new")).expect("acquire");
+
+        let s = read_state_unlocked().expect("read back");
+        assert_eq!(s["%0"].worktree.as_deref(), Some("/tmp/new"));
     }
 
     #[test]

--- a/src/sandbox/docker.rs
+++ b/src/sandbox/docker.rs
@@ -357,11 +357,13 @@ mod tests {
     /// lives in `tests/integration_tests.rs::spawn_agent_child_cannot_spawn`.
     #[tokio::test]
     async fn docker_spawn_agent_no_recursion() {
-        use crate::tools::{tool_schemas, LocalExecutor, ToolExecutor};
+        use crate::tools::{tool_schemas, LocalExecutor, ToolExecutor, ToolMode};
 
         // (1) Schema layer: child agents are built with include_spawn_agent=false
         // (see `tools::spawn_agent` when constructing `child_state`).
-        let schemas = tool_schemas(false);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: false,
+        });
         let has_spawn_agent = schemas
             .iter()
             .any(|s| s["function"]["name"].as_str() == Some("spawn_agent"));

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -130,6 +130,7 @@ impl ToolExecutor for LocalExecutor {
                 ),
             },
             "task_done" => task_done(args),
+            "emit_distilled_prompt" => emit_distilled_prompt(args),
             other => anyhow::bail!("unknown tool: {other}"),
         }
     }
@@ -508,6 +509,25 @@ fn task_done(args: serde_json::Value) -> Result<String> {
     Ok(format!("[task_done signalled pane={pane_id}]\n{summary}"))
 }
 
+/// `emit_distilled_prompt` is the distillation analogue of `task_done`:
+/// the tool body only validates and echoes; the daemon's agentic-loop
+/// dispatch recognises `name == "emit_distilled_prompt"`, extracts the
+/// `prompt` field, ships it back to the client as
+/// `Response::DistilledPromptReady`, and exits the loop.
+///
+/// Only available in the distillation agentic loop launched by
+/// `Request::DistillClaudePrompt` — the schema is gated on
+/// `ToolMode::Distill` in `tool_schemas`.
+fn emit_distilled_prompt(args: serde_json::Value) -> Result<String> {
+    let prompt = args["prompt"]
+        .as_str()
+        .context("emit_distilled_prompt: missing string argument 'prompt'")?;
+    if prompt.trim().is_empty() {
+        anyhow::bail!("emit_distilled_prompt: 'prompt' must be non-empty");
+    }
+    Ok(format!("[distilled prompt emitted, len={}]", prompt.len()))
+}
+
 async fn spawn_agent(args: serde_json::Value, ctx: &SpawnContext) -> Result<String> {
     let task = args["task"]
         .as_str()
@@ -772,11 +792,80 @@ async fn edit_file(args: serde_json::Value) -> Result<String> {
 // Tool schemas (OpenAI function-calling format)
 // ---------------------------------------------------------------------------
 
-/// Return the JSON schema array to include in a chat request.
+/// Which set of tools to expose to the LLM.
 ///
-/// Pass `include_spawn_agent = true` for the parent (daemon) context.
-/// Pass `false` for child agent loops to prevent recursive spawning.
-pub fn tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
+/// `Chat` is the everyday agentic loop: full tool set, optional
+/// `spawn_agent` for the parent connection, includes `task_done` so a
+/// `/claude` supervisor can release a pane.
+///
+/// `Distill` is the bounded loop launched by
+/// `Request::DistillClaudePrompt`: read-only investigation tools plus
+/// `emit_distilled_prompt`.  Excludes `edit_file`, `task_done`,
+/// `spawn_agent`, and the tmux pane-mutation tools so the distiller
+/// cannot accidentally start work it's only supposed to plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolMode {
+    Chat { include_spawn_agent: bool },
+    Distill,
+}
+
+/// Return the JSON schema array to include in a chat request.
+pub fn tool_schemas(mode: ToolMode) -> Vec<serde_json::Value> {
+    match mode {
+        ToolMode::Chat {
+            include_spawn_agent,
+        } => chat_tool_schemas(include_spawn_agent),
+        ToolMode::Distill => distill_tool_schemas(),
+    }
+}
+
+fn distill_tool_schemas() -> Vec<serde_json::Value> {
+    let all = chat_tool_schemas(false);
+    // Whitelist by name: investigation-only + the terminator.  The
+    // distiller is supposed to read code and produce a plan, not start
+    // editing or spawning.
+    let allowed = ["shell_command", "read_file", "emit_distilled_prompt"];
+    let mut filtered: Vec<serde_json::Value> = all
+        .into_iter()
+        .filter(|s| {
+            s["function"]["name"]
+                .as_str()
+                .map(|n| allowed.contains(&n))
+                .unwrap_or(false)
+        })
+        .collect();
+    // Append the distill-only emit tool (not present in the chat set).
+    filtered.push(serde_json::json!({
+        "type": "function",
+        "function": {
+            "name": "emit_distilled_prompt",
+            "description": "Emit the FINAL distilled prompt that will be injected into the \
+                            downstream Claude Code pane.  Call this exactly ONCE, after you \
+                            have finished investigating the codebase and decided what \
+                            Claude should actually do.  The string you pass becomes the \
+                            opening user message for that Claude session — write it as a \
+                            self-contained instruction (file paths, key functions, \
+                            verification commands, hard constraints).  Do NOT call this \
+                            speculatively before reading code; do NOT call it more than \
+                            once per session — the first call ends the distillation loop.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "The full prompt to inject into Claude Code.  No \
+                                        preamble, no meta-commentary — Claude will read \
+                                        this verbatim as its first user turn."
+                    }
+                },
+                "required": ["prompt"]
+            }
+        }
+    }));
+    filtered
+}
+
+fn chat_tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
     let mut schemas = vec![
         serde_json::json!({
             "type": "function",
@@ -1185,7 +1274,9 @@ mod tests {
 
     #[test]
     fn tool_schemas_have_expected_names() {
-        let schemas = tool_schemas(true);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        });
         let names: Vec<&str> = schemas
             .iter()
             .map(|s| s["function"]["name"].as_str().unwrap())
@@ -1208,7 +1299,9 @@ mod tests {
 
     #[test]
     fn tool_schemas_all_have_type_function() {
-        for schema in tool_schemas(true) {
+        for schema in tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        }) {
             assert_eq!(
                 schema["type"].as_str().unwrap(),
                 "function",
@@ -1220,7 +1313,9 @@ mod tests {
 
     #[test]
     fn tool_schemas_all_have_parameters_with_required_array() {
-        for schema in tool_schemas(true) {
+        for schema in tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        }) {
             let name = schema["function"]["name"].as_str().unwrap();
             assert!(
                 schema["function"]["parameters"]["required"].is_array(),
@@ -1233,7 +1328,9 @@ mod tests {
 
     #[test]
     fn spawn_agent_schema_has_extra_mounts() {
-        let schemas = tool_schemas(true);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        });
         let spawn = schemas
             .iter()
             .find(|s| s["function"]["name"].as_str() == Some("spawn_agent"))
@@ -1260,7 +1357,9 @@ mod tests {
 
     #[test]
     fn spawn_agent_schema_has_env() {
-        let schemas = tool_schemas(true);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        });
         let spawn = schemas
             .iter()
             .find(|s| s["function"]["name"].as_str() == Some("spawn_agent"))
@@ -1283,7 +1382,9 @@ mod tests {
 
     #[test]
     fn spawn_agent_schema_has_parallel() {
-        let schemas = tool_schemas(true);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        });
         let spawn = schemas
             .iter()
             .find(|s| s["function"]["name"].as_str() == Some("spawn_agent"))
@@ -1298,7 +1399,9 @@ mod tests {
 
     #[test]
     fn spawn_agent_schema_has_sandbox() {
-        let schemas = tool_schemas(true);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        });
         let spawn = schemas
             .iter()
             .find(|s| s["function"]["name"].as_str() == Some("spawn_agent"))
@@ -1533,7 +1636,9 @@ mod tests {
 
     #[test]
     fn tool_schemas_false_excludes_spawn_agent() {
-        let schemas = tool_schemas(false);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: false,
+        });
         let names: Vec<&str> = schemas
             .iter()
             .map(|s| s["function"]["name"].as_str().unwrap())
@@ -1550,7 +1655,9 @@ mod tests {
 
     #[test]
     fn tool_schemas_true_includes_spawn_agent() {
-        let schemas = tool_schemas(true);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        });
         let names: Vec<&str> = schemas
             .iter()
             .map(|s| s["function"]["name"].as_str().unwrap())
@@ -1765,7 +1872,9 @@ mod tests {
 
     #[test]
     fn tmux_send_text_schema_exists_and_takes_text() {
-        let schemas = tool_schemas(true);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        });
         let schema = schemas
             .iter()
             .find(|s| s["function"]["name"] == "tmux_send_text")
@@ -1783,7 +1892,9 @@ mod tests {
 
     #[test]
     fn tmux_send_key_schema_exists_and_takes_key() {
-        let schemas = tool_schemas(true);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        });
         let schema = schemas
             .iter()
             .find(|s| s["function"]["name"] == "tmux_send_key")
@@ -1797,7 +1908,9 @@ mod tests {
 
     #[test]
     fn tmux_send_keys_schema_removed() {
-        let schemas = tool_schemas(true);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        });
         assert!(
             schemas
                 .iter()
@@ -1833,7 +1946,9 @@ mod tests {
     fn switch_model_schema_present_in_all_modes() {
         // switch_model must always be available, regardless of include_spawn_agent.
         for include in [true, false] {
-            let schemas = tool_schemas(include);
+            let schemas = tool_schemas(ToolMode::Chat {
+                include_spawn_agent: include,
+            });
             let names: Vec<&str> = schemas
                 .iter()
                 .map(|s| s["function"]["name"].as_str().unwrap())
@@ -1847,7 +1962,9 @@ mod tests {
 
     #[test]
     fn switch_model_schema_has_required_model_param() {
-        let schemas = tool_schemas(true);
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        });
         let schema = schemas
             .iter()
             .find(|s| s["function"]["name"] == "switch_model")
@@ -1860,5 +1977,65 @@ mod tests {
             required_names.contains(&"model"),
             "switch_model must require 'model': {required_names:?}"
         );
+    }
+
+    // ---- emit_distilled_prompt + ToolMode::Distill schema gating -------------
+
+    #[test]
+    fn distill_mode_includes_emit_distilled_prompt_and_excludes_writes() {
+        let schemas = tool_schemas(ToolMode::Distill);
+        let names: Vec<&str> = schemas
+            .iter()
+            .map(|s| s["function"]["name"].as_str().unwrap())
+            .collect();
+        assert!(
+            names.contains(&"emit_distilled_prompt"),
+            "Distill mode must expose emit_distilled_prompt: {names:?}"
+        );
+        // Investigation tools allowed.
+        assert!(names.contains(&"shell_command"));
+        assert!(names.contains(&"read_file"));
+        // Mutation tools must NOT be present.
+        for forbidden in ["edit_file", "task_done", "spawn_agent", "tmux_send_text"] {
+            assert!(
+                !names.contains(&forbidden),
+                "Distill mode must NOT expose {forbidden}: {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn chat_mode_excludes_emit_distilled_prompt() {
+        // The terminator should ONLY appear in Distill mode — exposing it
+        // in Chat mode would let a regular agentic loop short-circuit
+        // itself by calling a tool meant for distillation.
+        for include in [true, false] {
+            let schemas = tool_schemas(ToolMode::Chat {
+                include_spawn_agent: include,
+            });
+            let names: Vec<&str> = schemas
+                .iter()
+                .map(|s| s["function"]["name"].as_str().unwrap())
+                .collect();
+            assert!(
+                !names.contains(&"emit_distilled_prompt"),
+                "Chat mode must NOT expose emit_distilled_prompt (include_spawn_agent={include}): {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn emit_distilled_prompt_validates_prompt_field() {
+        // Missing prompt → error
+        let r = emit_distilled_prompt(serde_json::json!({}));
+        assert!(r.is_err(), "missing prompt should error");
+        // Empty prompt → error (we don't want a no-op result)
+        let r = emit_distilled_prompt(serde_json::json!({"prompt": "   "}));
+        assert!(r.is_err(), "whitespace-only prompt should error");
+        // Valid prompt → echo with length
+        let r = emit_distilled_prompt(serde_json::json!({"prompt": "hello world"}));
+        assert!(r.is_ok());
+        let s = r.unwrap();
+        assert!(s.contains("len=11"), "result should report length: {s}");
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1769,6 +1769,35 @@ async fn dispatch_input(
 /// `Response::Done`.  Any pre-launch error (tag generation failure,
 /// IPC error) is surfaced to the transcript and `pending_claude`
 /// stays None so the next user input isn't blocked.
+/// One event captured from the distillation sink for later replay
+/// into the transcript.  Buffering decouples sink lifetime from the
+/// `&mut state` that owns the transcript so the borrow checker is
+/// happy.
+enum DistillEvent {
+    Text(String),
+    Tool { name: String, detail: String },
+    Status(String),
+}
+
+struct BufferingDistillSink<'a> {
+    buffer: &'a mut Vec<DistillEvent>,
+}
+
+impl crate::client::DistillSink for BufferingDistillSink<'_> {
+    fn on_text(&mut self, chunk: &str) {
+        self.buffer.push(DistillEvent::Text(chunk.to_string()));
+    }
+    fn on_tool_use(&mut self, name: &str, detail: &str) {
+        self.buffer.push(DistillEvent::Tool {
+            name: name.to_string(),
+            detail: detail.to_string(),
+        });
+    }
+    fn on_status(&mut self, line: &str) {
+        self.buffer.push(DistillEvent::Status(line.to_string()));
+    }
+}
+
 async fn launch_claude_tasks(
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     state: &mut AppState,
@@ -1788,7 +1817,50 @@ async fn launch_claude_tasks(
         return Ok(());
     }
 
-    // Snapshot tag → original description so the response handler
+    // Distill each task's brief into a detailed Claude Code prompt
+    // before launch.  Buffer all sink events into a Vec while the IPC
+    // helper holds an exclusive borrow on a sink, then drain into
+    // `state` once the helper returns — this lets us keep `&mut state`
+    // out of the sink (which would alias the live `&mut tasks`).
+    let mut buffered: Vec<DistillEvent> = Vec::new();
+    let pre = {
+        let mut sink = BufferingDistillSink {
+            buffer: &mut buffered,
+        };
+        let socket = state.socket_path.clone();
+        let cwd = state.cwd_str.clone();
+        let session_id = state.session_id.clone();
+        let model = state.model.clone();
+        crate::client::distill_claude_tasks(
+            &socket,
+            &mut tasks,
+            &cwd,
+            &session_id,
+            &model,
+            &mut sink,
+        )
+        .await
+    };
+    for ev in buffered {
+        match ev {
+            DistillEvent::Text(t) => state.push_assistant_chunk(&t),
+            DistillEvent::Tool { name, detail } => {
+                state.push_tool_line(format!("[distill tool] {name} {detail}"))
+            }
+            DistillEvent::Status(t) => state.push_system_line(t),
+        }
+    }
+    if let Err(e) = pre {
+        state.push_error_line(format!("[error] distillation pre-flight: {e:#}"));
+        return Ok(());
+    }
+    tasks.retain(|t| !t.description.trim().is_empty());
+    if tasks.is_empty() {
+        state.push_error_line("[error] all /claude tasks failed distillation".to_string());
+        return Ok(());
+    }
+
+    // Snapshot tag → distilled description so the response handler
     // can rebuild the [launched] block on Response::Done.
     let descriptions: std::collections::HashMap<String, String> = tasks
         .iter()


### PR DESCRIPTION
## Summary

`/claude "fix bug X"` no longer ships the brief verbatim to Claude
Code.  amaebi's LLM now runs a bounded agentic loop in the user's cwd,
investigates the codebase, and produces a self-contained
`/replyreview`-grade prompt that becomes Claude's first user turn.

## Before

```
> /claude "fix bug X in fmha"
        ↓ (verbatim + static git context)
inner Claude reads:
  === Repository context (injected by amaebi) ===
  Current branch : foo
  Recent commits : ...
  fix bug X in fmha
```

## After

```
> /claude "fix bug X in fmha"
        ↓ (amaebi LLM investigates the code)
amaebi → user (streamed):
  shell_command: git status
  read_file: src/fmha.rs
  shell_command: grep -rn 'kBlockM' src/
  ...
        ↓ (calls emit_distilled_prompt with detailed plan)
inner Claude reads:
  Implement the fix in src/fmha.rs:142-189 (the cu_seqlens dispatch).
  Steps:
    1. ...
  Verification: cargo test --bin amaebi --release
  Hard constraints: keep ~/amaebi on master, no force push, ...
```

## Implementation

- **`tools::ToolMode` enum** gates which schema the LLM sees.  Distill
  mode exposes `shell_command` + `read_file` + the new
  `emit_distilled_prompt` terminator only.  Chat mode unchanged.  All
  callers migrated to the new signature.
- **`emit_distilled_prompt`** tool: pure-echo body in `tools.rs`; real
  side effect (capture payload + early-exit the loop) lives in
  `run_agentic_loop_with_mode`, mirroring the `task_done` pattern.
- **`Request::DistillClaudePrompt`** → **`Response::DistilledPromptReady`**
  IPC.  Daemon builds a fixed system prompt + user brief, runs the
  bounded loop, ships the prompt back.  Streams Text / ToolUse frames
  during the run so the user sees the investigation live.
- **`Request::ReservePane`** / **`ReleasePane`** IPC so
  `/claude --resume-pane %X` holds the slot for the duration of
  distillation (can take minutes).  Distillation failure releases the
  lease so it never leaks.
- **`distill_claude_tasks` client helper** runs the per-task
  reserve-and-distill pre-flight for both CLI and TUI.  A
  `DistillSink` trait routes streamed frames into stderr (CLI) or the
  transcript (TUI).

## Test plan

- [x] 5 new unit tests on schema gating, tool validation, and
  system-prompt shape (795 total pass)
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [ ] Manual: `/claude "fix bug X"` from TUI — confirm investigation
  streams into transcript, distilled prompt lands in Claude pane
- [ ] Manual: `/claude --resume-pane %42 "..."` — confirm pane stays
  reserved during distillation, released cleanly on failure
- [ ] Manual: distillation that errors mid-loop — confirm graceful
  fallback (skip task, surface error, don't crash chat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)