### PR TITLE
fix(tui): clear alt-screen on entry to prevent ghost characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.5.33"
+version = "2026.6.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.5.33"
+version = "2026.6.1"
 edition = "2021"
 
 [[bin]]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -165,6 +165,9 @@ pub async fn run_chat_tui(
     let _guard = TerminalGuard::enter()?;
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::new(backend).context("creating ratatui terminal")?;
+    terminal
+        .clear()
+        .context("clearing terminal on alt-screen entry")?;
 
     let cwd_str = cwd.to_string_lossy().into_owned();
     let mut state = AppState::new(session_id.clone(), model.clone(), socket.clone(), cwd_str);


### PR DESCRIPTION
## Summary

TUI startup occasionally leaves ghost characters from the shell's
prior output bleeding into the ratatui frame (observed: title rendered
as `amaebia──` instead of ` amaebi ──` — a stray `a` from the shell
prompt `~/amaebi$`).

## Root cause

`EnterAlternateScreen` switches to the alt buffer but does not clear
it.  If the alt buffer retained content from a previous alt-screen
occupant (or was never fully zeroed by the terminal emulator), those
bytes survive until the first `draw()` overwrites each cell.  Any cell
that the TUI leaves "unchanged" (e.g. a border segment at the same
position as a pre-existing character) can show the ghost.

## Fix

One line: `terminal.clear()` immediately after `Terminal::new()`.
Issues a physical `ClearAll` + `MoveTo(0,0)` so the alt buffer is
blank before the first render frame.

## Test plan

- [x] cargo test (800 passed)
- [x] cargo fmt / clippy clean
- [x] Manual: fill terminal with `XXX...THIS MUST VANISH...XXX` then
  launch TUI — zero bleed-through, title clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)