### PR TITLE
feat(claude): create worktree before distillation for correct investigation context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.6.3"
+version = "2026.6.4"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.6.3"
+version = "2026.6.4"
 edition = "2021"
 
 [[bin]]

--- a/src/agent_server.rs
+++ b/src/agent_server.rs
@@ -340,7 +340,8 @@ impl acp::Agent for AmaebiAgent {
                 | Response::CapacityError { .. }
                 | Response::TagGenerated { .. }
                 | Response::DistilledPromptReady { .. }
-                | Response::PaneReserved { .. } => {
+                | Response::PaneReserved { .. }
+                | Response::WorktreeCreated { .. } => {
                     // ACP mode never issues these scheduler / pre-launch flows.
                     tracing::debug!("unexpected pane/tag scheduler response in ACP mode");
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -3299,12 +3299,14 @@ pub(crate) async fn distill_claude_tasks(
         // Pre-create worktree so distillation investigates the same
         // starting point the downstream Claude will operate in.
         let mut branch: Option<String> = None;
+        let mut created_worktree = false;
         if task.resume_pane.is_none() && task.worktree.is_none() {
             sink.on_status(&format!("[distill] creating worktree for tag {}", task.tag));
             match create_worktree_request(socket, &task.tag, &task_cwd, &task.description).await {
                 Ok((path, br)) => {
                     task.worktree = Some(path);
                     branch = Some(br);
+                    created_worktree = true;
                 }
                 Err(e) => {
                     sink.on_status(&format!(
@@ -3312,6 +3314,10 @@ pub(crate) async fn distill_claude_tasks(
                     ));
                 }
             }
+        } else if let Some(ref wt) = task.worktree {
+            // Resolve branch from pre-existing worktree so the distilled
+            // prompt can reference the correct branch name.
+            branch = resolve_worktree_branch(wt).await;
         }
 
         // Use the worktree as the investigation directory if available.
@@ -3344,6 +3350,18 @@ pub(crate) async fn distill_claude_tasks(
                     if let Err(re) = release_reserved_pane(socket, &pid).await {
                         sink.on_status(&format!("[distill] also failed to release {pid}: {re:#}"));
                     }
+                }
+                // Clean up auto-created worktree so it doesn't orphan.
+                if created_worktree {
+                    if let Some(ref wt) = task.worktree {
+                        let wt = wt.clone();
+                        let cwd = task_cwd.clone();
+                        let _ = tokio::task::spawn_blocking(move || {
+                            remove_worktree_and_branch(&wt, &cwd);
+                        })
+                        .await;
+                    }
+                    task.worktree = None;
                 }
                 // Mark the task for skip via empty description; caller
                 // filters those out before ClaudeLaunch.  Empty was
@@ -3512,6 +3530,49 @@ pub(crate) async fn create_worktree_request(
         }
     }
     result.ok_or_else(|| anyhow::anyhow!("CreateWorktree: no WorktreeCreated frame received"))
+}
+
+/// Resolve the current branch of an existing worktree via `git rev-parse`.
+async fn resolve_worktree_branch(worktree: &str) -> Option<String> {
+    let wt = worktree.to_owned();
+    tokio::task::spawn_blocking(move || {
+        std::process::Command::new("git")
+            .args(["-C", &wt, "rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .and_then(|o| {
+                let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                if s.is_empty() || s == "HEAD" {
+                    None
+                } else {
+                    Some(s)
+                }
+            })
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+/// Best-effort removal of a worktree and its associated branch.
+fn remove_worktree_and_branch(worktree: &str, repo_cwd: &str) {
+    let branch = std::path::Path::new(worktree)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(str::to_string);
+    let removed = std::process::Command::new("git")
+        .args(["-C", repo_cwd, "worktree", "remove", "--force", worktree])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if removed {
+        if let Some(ref br) = branch {
+            let _ = std::process::Command::new("git")
+                .args(["-C", repo_cwd, "branch", "-D", br])
+                .output();
+        }
+    }
 }
 
 /// Reserve a pane via the daemon so a long pre-launch flow can hold the

--- a/src/client.rs
+++ b/src/client.rs
@@ -1399,7 +1399,8 @@ pub async fn run(socket: PathBuf, prompt: String, model: Option<String>) -> Resu
                     | Response::CapacityError { .. }
                     | Response::TagGenerated { .. }
                     | Response::DistilledPromptReady { .. }
-                    | Response::PaneReserved { .. } => {
+                    | Response::PaneReserved { .. }
+                    | Response::WorktreeCreated { .. } => {
                         // Not expected in a normal Chat response stream.
                         tracing::debug!("unexpected pane/tag scheduler response in chat loop");
                     }
@@ -2650,7 +2651,8 @@ pub async fn run_resume(
                     | Response::CapacityError { .. }
                     | Response::TagGenerated { .. }
                     | Response::DistilledPromptReady { .. }
-                    | Response::PaneReserved { .. } => {
+                    | Response::PaneReserved { .. }
+                    | Response::WorktreeCreated { .. } => {
                         tracing::debug!("unexpected pane/tag scheduler response in resume loop");
                     }
                     Response::ModelSwitched { .. } => {
@@ -3294,11 +3296,41 @@ pub(crate) async fn distill_claude_tasks(
             None
         };
 
+        // Pre-create worktree so distillation investigates the same
+        // starting point the downstream Claude will operate in.
+        let mut branch: Option<String> = None;
+        if task.resume_pane.is_none() && task.worktree.is_none() {
+            sink.on_status(&format!("[distill] creating worktree for tag {}", task.tag));
+            match create_worktree_request(socket, &task.tag, &task_cwd, &task.description).await {
+                Ok((path, br)) => {
+                    task.worktree = Some(path);
+                    branch = Some(br);
+                }
+                Err(e) => {
+                    sink.on_status(&format!(
+                        "[distill] worktree creation failed: {e:#}; distilling from main repo"
+                    ));
+                }
+            }
+        }
+
+        // Use the worktree as the investigation directory if available.
+        let distill_cwd = task.worktree.as_deref().unwrap_or(&task_cwd).to_string();
+
         sink.on_status(&format!(
             "[distill] investigating codebase for tag {} (this may take a minute)",
             task.tag
         ));
-        match distill_claude_prompt(socket, &task.description, &task_cwd, model, sink).await {
+        match distill_claude_prompt(
+            socket,
+            &task.description,
+            &distill_cwd,
+            model,
+            branch.as_deref(),
+            sink,
+        )
+        .await
+        {
             Ok(prompt) => {
                 task.description = prompt;
                 sink.on_status(&format!("[distill] tag {} done", task.tag));
@@ -3372,6 +3404,7 @@ pub(crate) async fn distill_claude_prompt(
     brief: &str,
     cwd: &str,
     model: &str,
+    branch: Option<&str>,
     sink: &mut dyn DistillSink,
 ) -> Result<String> {
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -3383,6 +3416,7 @@ pub(crate) async fn distill_claude_prompt(
         brief: brief.to_string(),
         cwd: cwd.to_string(),
         model: model.to_string(),
+        branch: branch.map(String::from),
     };
     let mut line = serde_json::to_string(&req).context("serialising DistillClaudePrompt")?;
     line.push('\n');
@@ -3431,6 +3465,53 @@ pub(crate) async fn distill_claude_prompt(
         anyhow::bail!("distillation failed: {message}");
     }
     anyhow::bail!("distillation finished without emitting a prompt");
+}
+
+/// Pre-create a git worktree via the daemon.  Returns `(path, branch)`.
+pub(crate) async fn create_worktree_request(
+    socket: &std::path::Path,
+    tag: &str,
+    client_cwd: &str,
+    description: &str,
+) -> Result<(String, String)> {
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    let stream = UnixStream::connect(socket)
+        .await
+        .context("connecting to daemon for CreateWorktree")?;
+    let (reader, mut writer) = tokio::io::split(stream);
+    let req = Request::CreateWorktree {
+        tag: tag.to_string(),
+        client_cwd: client_cwd.to_string(),
+        description: description.to_string(),
+    };
+    let mut line = serde_json::to_string(&req).context("serialising CreateWorktree")?;
+    line.push('\n');
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .context("sending CreateWorktree")?;
+    let mut lines = BufReader::new(reader).lines();
+    let mut result: Option<(String, String)> = None;
+    loop {
+        let Some(reply) = lines
+            .next_line()
+            .await
+            .context("reading CreateWorktree response")?
+        else {
+            break;
+        };
+        let frame: Response =
+            serde_json::from_str(&reply).context("parsing CreateWorktree frame")?;
+        match frame {
+            Response::WorktreeCreated { path, branch } => result = Some((path, branch)),
+            Response::Done => break,
+            Response::Error { message } => {
+                anyhow::bail!("create_worktree: {message}");
+            }
+            _ => {}
+        }
+    }
+    result.ok_or_else(|| anyhow::anyhow!("CreateWorktree: no WorktreeCreated frame received"))
 }
 
 /// Reserve a pane via the daemon so a long pre-launch flow can hold the

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -982,8 +982,22 @@ async fn handle_connection_inner(
                     .await?;
             }
 
-            Request::DistillClaudePrompt { brief, cwd, model } => {
-                handle_distill_claude_prompt(&writer, &state, conn_id, brief, cwd, model).await?;
+            Request::DistillClaudePrompt {
+                brief,
+                cwd,
+                model,
+                branch,
+            } => {
+                handle_distill_claude_prompt(&writer, &state, conn_id, brief, cwd, model, branch)
+                    .await?;
+            }
+
+            Request::CreateWorktree {
+                tag,
+                client_cwd,
+                description,
+            } => {
+                handle_create_worktree(&writer, tag, client_cwd, description).await?;
             }
 
             Request::ReservePane {
@@ -1211,8 +1225,9 @@ async fn handle_distill_claude_prompt(
     brief: String,
     cwd: String,
     model: String,
+    branch: Option<String>,
 ) -> Result<()> {
-    let system_prompt = build_distillation_system_prompt(&cwd);
+    let system_prompt = build_distillation_system_prompt(&cwd, branch.as_deref());
     let user_msg = format!(
         "User's brief description for /claude:\n\n{brief}\n\n\
          Working directory: {cwd}\n\n\
@@ -1282,21 +1297,22 @@ async fn handle_distill_claude_prompt(
 /// System prompt for the `/claude` distillation loop.  Tells the LLM
 /// what `/replyreview`-grade output should look like and what tools it
 /// has.  Kept outside the handler so it can be unit-tested for shape.
-fn build_distillation_system_prompt(cwd: &str) -> String {
+fn build_distillation_system_prompt(cwd: &str, branch: Option<&str>) -> String {
+    let branch_display = branch.unwrap_or("(auto-created feature branch)");
     format!(
         "You are amaebi's prompt distiller.  The user typed `/claude \"<brief>\"` and your \
          job is to convert that brief into a self-contained prompt that a downstream Claude \
          Code session will execute.\n\n\
-         Your investigation directory: {cwd}\n\n\
+         Your investigation directory: {cwd}\n\
+         Feature branch: `{branch_display}`\n\n\
          CRITICAL — worktree isolation:\n\
-         The downstream Claude session will be launched in an auto-created git worktree \
-         (a fresh branch forked from the relevant base), NOT in {cwd} directly.  Therefore:\n\
-         - Do NOT include \"Working directory: {cwd}\" or any `cd` instructions in the \
+         The downstream Claude session will run in this SAME worktree on branch \
+         `{branch_display}`, NOT in the main repository directly.  Therefore:\n\
+         - Do NOT include \"Working directory: ...\" or any `cd` instructions in the \
            distilled prompt.  The downstream Claude is already in the correct worktree.\n\
          - Use RELATIVE file paths (from the repo root) when naming files to modify.\n\
-         - If the task references a specific branch, mention the branch name so the \
-           downstream Claude can verify it checked out correctly, but do NOT tell it to \
-           `cd` anywhere.\n\n\
+         - The downstream Claude must commit and push ONLY to branch `{branch_display}` — \
+           NEVER to master/main.  Include this constraint in the distilled prompt.\n\n\
          Procedure:\n\
          1. Use `shell_command` and `read_file` to investigate the codebase.  Look for the \
             files / functions / tests / scripts the brief actually touches.  Run `git status`, \
@@ -1325,7 +1341,10 @@ fn build_distillation_system_prompt(cwd: &str) -> String {
          - Loop until green: instruct the downstream Claude to iterate — fix, test, \
            and repeat — until ALL acceptance criteria pass.  A single attempt that \
            fails the criteria is not acceptable; Claude must debug and retry.\n\
-         - Constraints: list the hard rules (CI, branching, etc.) that apply.\n\
+         - Constraints: list the hard rules (CI, branching, etc.) that apply.  \
+           In particular, the downstream Claude is on branch `{branch_display}` — it \
+           must NEVER push or commit to the main branch (master/main).  All work stays \
+           on the feature branch; merging is the user's responsibility.\n\
          - No absolute paths to the source repo: use relative paths from repo root.\n\
          - No meta-commentary: the prompt is read by Claude as the FIRST user message; do \
            not include phrases like 'I have analyzed your code' or 'here is the prompt'.\n\n\
@@ -1385,6 +1404,46 @@ async fn handle_release_pane(
         .map_err(|e| anyhow::anyhow!("release_pane spawn_blocking panicked: {e}"))?;
     let mut w = writer.lock().await;
     write_frame(&mut *w, &Response::Done).await.ok();
+    Ok(())
+}
+
+/// Handle `Request::CreateWorktree`: pre-create a git worktree before
+/// distillation so the LLM can investigate inside it.
+async fn handle_create_worktree(
+    writer: &Arc<tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    tag: String,
+    client_cwd: String,
+    description: String,
+) -> Result<()> {
+    let result = tokio::task::spawn_blocking(move || {
+        let ctx = gather_task_context(Some(&client_cwd), &description);
+        let wt_path = create_task_worktree(&tag, Some(&client_cwd), ctx.start_branch.as_deref())?;
+        let branch = wt_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or(&tag)
+            .to_owned();
+        Ok::<_, anyhow::Error>((wt_path.to_string_lossy().into_owned(), branch))
+    })
+    .await
+    .context("create_worktree spawn_blocking panicked")?;
+
+    let mut w = writer.lock().await;
+    match result {
+        Ok((path, branch)) => {
+            write_frame(&mut *w, &Response::WorktreeCreated { path, branch }).await?;
+        }
+        Err(e) => {
+            write_frame(
+                &mut *w,
+                &Response::Error {
+                    message: format!("CreateWorktree failed: {e:#}"),
+                },
+            )
+            .await?;
+        }
+    }
+    write_frame(&mut *w, &Response::Done).await?;
     Ok(())
 }
 
@@ -8796,9 +8855,14 @@ mod tests {
 
     #[test]
     fn distillation_system_prompt_mentions_emit_tool_and_cwd() {
-        let p = build_distillation_system_prompt("/tmp/repo");
+        let p = build_distillation_system_prompt("/tmp/repo", Some("fix-foo-abc123"));
         // Working directory must be interpolated, not left as a placeholder.
         assert!(p.contains("/tmp/repo"), "cwd must be in prompt: {p}");
+        // Branch name must be injected when provided.
+        assert!(
+            p.contains("fix-foo-abc123"),
+            "branch name must be in prompt: {p}"
+        );
         // The terminator tool must be named explicitly so the LLM knows
         // how to end its turn.
         assert!(
@@ -8822,7 +8886,7 @@ mod tests {
         // Critical for downstream fidelity: the distilled output is
         // injected as Claude's first user turn verbatim, so adding
         // "here is the prompt I prepared:" wraps would break framing.
-        let p = build_distillation_system_prompt("/x");
+        let p = build_distillation_system_prompt("/x", None);
         assert!(
             p.to_lowercase().contains("no meta-commentary")
                 || p.to_lowercase().contains("verbatim"),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1312,7 +1312,7 @@ fn build_distillation_system_prompt(cwd: &str, branch: Option<&str>) -> String {
            distilled prompt.  The downstream Claude is already in the correct worktree.\n\
          - Use RELATIVE file paths (from the repo root) when naming files to modify.\n\
          - The downstream Claude must commit and push ONLY to branch `{branch_display}` — \
-           NEVER to master/main.  Include this constraint in the distilled prompt.\n\n\
+           NEVER to any other branch.  Include this constraint in the distilled prompt.\n\n\
          Procedure:\n\
          1. Use `shell_command` and `read_file` to investigate the codebase.  Look for the \
             files / functions / tests / scripts the brief actually touches.  Run `git status`, \
@@ -1343,8 +1343,8 @@ fn build_distillation_system_prompt(cwd: &str, branch: Option<&str>) -> String {
            fails the criteria is not acceptable; Claude must debug and retry.\n\
          - Constraints: list the hard rules (CI, branching, etc.) that apply.  \
            In particular, the downstream Claude is on branch `{branch_display}` — it \
-           must NEVER push or commit to the main branch (master/main).  All work stays \
-           on the feature branch; merging is the user's responsibility.\n\
+           must NEVER push or commit to any other branch.  All work stays on \
+           `{branch_display}`; merging is the user's responsibility.\n\
          - No absolute paths to the source repo: use relative paths from repo root.\n\
          - No meta-commentary: the prompt is read by Claude as the FIRST user message; do \
            not include phrases like 'I have analyzed your code' or 'here is the prompt'.\n\n\

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1298,21 +1298,51 @@ async fn handle_distill_claude_prompt(
 /// what `/replyreview`-grade output should look like and what tools it
 /// has.  Kept outside the handler so it can be unit-tested for shape.
 fn build_distillation_system_prompt(cwd: &str, branch: Option<&str>) -> String {
-    let branch_display = branch.unwrap_or("(auto-created feature branch)");
+    let branch_header = match branch {
+        Some(br) => format!("Feature branch: `{br}`\n\n"),
+        None => String::new(),
+    };
+    let isolation_block = match branch {
+        Some(br) => format!(
+            "CRITICAL — worktree isolation:\n\
+             The downstream Claude session will run in this SAME worktree on branch \
+             `{br}`, NOT in the main repository directly.  Therefore:\n\
+             - Do NOT include \"Working directory: ...\" or any `cd` instructions in the \
+               distilled prompt.  The downstream Claude is already in the correct worktree.\n\
+             - Use RELATIVE file paths (from the repo root) when naming files to modify.\n\
+             - The downstream Claude must commit and push ONLY to branch `{br}` — \
+               NEVER to any other branch.  Include this constraint in the distilled prompt.\n\n"
+        ),
+        None => format!(
+            "CRITICAL — worktree isolation:\n\
+             The downstream Claude session will be launched in an auto-created git worktree \
+             (a fresh branch forked from the relevant base), NOT in {cwd} directly.  Therefore:\n\
+             - Do NOT include \"Working directory: {cwd}\" or any `cd` instructions in the \
+               distilled prompt.  The downstream Claude is already in the correct worktree.\n\
+             - Use RELATIVE file paths (from the repo root) when naming files to modify.\n\
+             - The downstream Claude must NEVER push to main or master — only push to \
+               the current feature branch for its task.  Include this constraint in the \
+               distilled prompt.\n\n"
+        ),
+    };
+    let branch_constraint = match branch {
+        Some(br) => format!(
+            "In particular, the downstream Claude is on branch `{br}` — it \
+             must NEVER push or commit to any other branch.  All work stays on \
+             `{br}`; merging is the user's responsibility."
+        ),
+        None => "In particular, the downstream Claude must NEVER push to main or \
+                 master — only push to the current feature branch for its task; \
+                 merging is the user's responsibility."
+            .to_string(),
+    };
     format!(
         "You are amaebi's prompt distiller.  The user typed `/claude \"<brief>\"` and your \
          job is to convert that brief into a self-contained prompt that a downstream Claude \
          Code session will execute.\n\n\
          Your investigation directory: {cwd}\n\
-         Feature branch: `{branch_display}`\n\n\
-         CRITICAL — worktree isolation:\n\
-         The downstream Claude session will run in this SAME worktree on branch \
-         `{branch_display}`, NOT in the main repository directly.  Therefore:\n\
-         - Do NOT include \"Working directory: ...\" or any `cd` instructions in the \
-           distilled prompt.  The downstream Claude is already in the correct worktree.\n\
-         - Use RELATIVE file paths (from the repo root) when naming files to modify.\n\
-         - The downstream Claude must commit and push ONLY to branch `{branch_display}` — \
-           NEVER to any other branch.  Include this constraint in the distilled prompt.\n\n\
+         {branch_header}\
+         {isolation_block}\
          Procedure:\n\
          1. Use `shell_command` and `read_file` to investigate the codebase.  Look for the \
             files / functions / tests / scripts the brief actually touches.  Run `git status`, \
@@ -1342,9 +1372,7 @@ fn build_distillation_system_prompt(cwd: &str, branch: Option<&str>) -> String {
            and repeat — until ALL acceptance criteria pass.  A single attempt that \
            fails the criteria is not acceptable; Claude must debug and retry.\n\
          - Constraints: list the hard rules (CI, branching, etc.) that apply.  \
-           In particular, the downstream Claude is on branch `{branch_display}` — it \
-           must NEVER push or commit to any other branch.  All work stays on \
-           `{branch_display}`; merging is the user's responsibility.\n\
+           {branch_constraint}\n\
          - No absolute paths to the source repo: use relative paths from repo root.\n\
          - No meta-commentary: the prompt is read by Claude as the FIRST user message; do \
            not include phrases like 'I have analyzed your code' or 'here is the prompt'.\n\n\

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -234,6 +234,26 @@ pub enum Request {
         /// Chat model to use for the distillation loop.  Caller passes the
         /// outer chat's current model so /model state is honoured.
         model: String,
+        /// Feature branch name the downstream Claude session will operate on.
+        /// Injected into the distillation system prompt so the distilled
+        /// output can reference the correct branch.
+        #[serde(default)]
+        branch: Option<String>,
+    },
+    /// Pre-create a git worktree for a task before distillation.
+    ///
+    /// The daemon creates the worktree (using `create_task_worktree`) and
+    /// responds with [`Response::WorktreeCreated`].  The client can then
+    /// pass the worktree path as `cwd` to [`Request::DistillClaudePrompt`]
+    /// so the LLM investigates the correct starting point.
+    CreateWorktree {
+        /// Notebook tag — used as the worktree directory prefix.
+        tag: String,
+        /// Client working directory — the git repo to fork from.
+        client_cwd: String,
+        /// Task description — used to extract PR number and resolve the
+        /// base branch to fork from.
+        description: String,
     },
     /// Reserve a tmux pane up-front so a long-running pre-launch flow
     /// (notably `Request::DistillClaudePrompt` for `/claude --resume-pane
@@ -396,6 +416,14 @@ pub enum Response {
     /// Reply to [`Request::ReservePane`] confirming the lease was acquired.
     /// Always followed by [`Response::Done`].
     PaneReserved { pane_id: String },
+    /// A worktree was successfully created in response to
+    /// [`Request::CreateWorktree`].
+    WorktreeCreated {
+        /// Absolute path to the new worktree directory.
+        path: String,
+        /// Git branch name created for this worktree (e.g. `"fix-foo-ab12cd34"`).
+        branch: String,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1223,4 +1223,99 @@ mod tests {
             "1h 4m 27s"
         );
     }
+
+    // ---- CreateWorktree / WorktreeCreated legacy compat ----------------------
+
+    #[test]
+    fn distill_claude_prompt_legacy_without_branch_field() {
+        // A client built before the `branch` field was added sends
+        // DistillClaudePrompt without it.  The new daemon must accept
+        // this payload via `#[serde(default)]` and default to None.
+        let legacy = r#"{"type":"distill_claude_prompt","brief":"fix the bug","cwd":"/tmp/repo","model":"sonnet"}"#;
+        let back: Request = serde_json::from_str(legacy).expect("legacy must parse");
+        let Request::DistillClaudePrompt {
+            brief,
+            cwd,
+            model,
+            branch,
+        } = back
+        else {
+            panic!("expected DistillClaudePrompt");
+        };
+        assert_eq!(brief, "fix the bug");
+        assert_eq!(cwd, "/tmp/repo");
+        assert_eq!(model, "sonnet");
+        assert!(branch.is_none(), "branch must default to None");
+    }
+
+    #[test]
+    fn distill_claude_prompt_with_branch_round_trip() {
+        let req = Request::DistillClaudePrompt {
+            brief: "add feature".into(),
+            cwd: "/wt/feat-xyz".into(),
+            model: "opus".into(),
+            branch: Some("feat-xyz-ab12cd34".into()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "distill_claude_prompt");
+        assert_eq!(v["branch"], "feat-xyz-ab12cd34");
+
+        let back: Request = serde_json::from_str(&json).unwrap();
+        let Request::DistillClaudePrompt { branch, .. } = back else {
+            panic!("expected DistillClaudePrompt");
+        };
+        assert_eq!(branch.as_deref(), Some("feat-xyz-ab12cd34"));
+    }
+
+    #[test]
+    fn create_worktree_request_round_trip() {
+        let req = Request::CreateWorktree {
+            tag: "fix-bug".into(),
+            client_cwd: "/home/user/repo".into(),
+            description: "fix the crash on startup".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "create_worktree");
+        assert_eq!(v["tag"], "fix-bug");
+        assert_eq!(v["client_cwd"], "/home/user/repo");
+        assert_eq!(v["description"], "fix the crash on startup");
+
+        let back: Request = serde_json::from_str(&json).unwrap();
+        let Request::CreateWorktree {
+            tag,
+            client_cwd,
+            description,
+        } = back
+        else {
+            panic!("expected CreateWorktree");
+        };
+        assert_eq!(tag, "fix-bug");
+        assert_eq!(client_cwd, "/home/user/repo");
+        assert_eq!(description, "fix the crash on startup");
+    }
+
+    #[test]
+    fn worktree_created_response_round_trip() {
+        let r = Response::WorktreeCreated {
+            path: "/home/user/.amaebi/worktrees/repo/fix-bug-ab12cd34".into(),
+            branch: "fix-bug-ab12cd34".into(),
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "worktree_created");
+        assert_eq!(
+            v["path"],
+            "/home/user/.amaebi/worktrees/repo/fix-bug-ab12cd34"
+        );
+        assert_eq!(v["branch"], "fix-bug-ab12cd34");
+
+        let back: Response = serde_json::from_str(&json).unwrap();
+        let Response::WorktreeCreated { path, branch } = back else {
+            panic!("expected WorktreeCreated");
+        };
+        assert_eq!(path, "/home/user/.amaebi/worktrees/repo/fix-bug-ab12cd34");
+        assert_eq!(branch, "fix-bug-ab12cd34");
+    }
 }


### PR DESCRIPTION
## Summary
- Pre-create a git worktree before distillation so the LLM investigates the same starting point the downstream Claude session will operate in (`CreateWorktree` / `WorktreeCreated` IPC pair)
- Pass the feature branch name into the distillation system prompt so the distilled output references the correct branch (with `#[serde(default)]` for backward compat with older clients)
- Clean up auto-created worktree on distillation failure; resolve branch from pre-existing worktrees

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test ipc` — 46 tests pass (including new legacy compat tests)
- [x] `cargo test distill` — 7 tests pass
- [x] `scripts/next-version.sh --check` — OK 2026.6.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)