### PR TITLE
feat(bedrock): support OpenAI GPT models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.6.4"
+version = "2026.6.5"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.6.4"
+version = "2026.6.5"
 edition = "2021"
 
 [[bin]]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,6 +170,11 @@ Unprefixed names first consult `~/.amaebi/config.json` user aliases, then
 the built-in Bedrock alias table (`src/provider.rs:64`), and otherwise
 default to Bedrock (see `resolve_with_aliases` in `src/provider.rs`).
 
+Bedrock OpenAI aliases follow AWS's split endpoints: `gpt-oss-20b` and
+`gpt-oss-120b` resolve to `bedrock-runtime` ConverseStream IDs, while
+`gpt-5.4` and `gpt-5.5` route through Bedrock Mantle's OpenAI-compatible
+Responses path.
+
 The default (`DEFAULT_MODEL` at `src/provider.rs:105`) is
 `claude-sonnet-4.6[1m]`. The `[1m]` suffix opts into Bedrock's 1M-context
 beta. Copilot ignores the suffix.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,7 +167,7 @@ provider backends (`src/provider.rs`):
 - `copilot/<model>` → `src/copilot.rs`
 
 Unprefixed names first consult `~/.amaebi/config.json` user aliases, then
-the built-in Bedrock alias table (`src/provider.rs:64`), and otherwise
+the built-in `BEDROCK_ALIASES` table, and otherwise
 default to Bedrock (see `resolve_with_aliases` in `src/provider.rs`).
 
 Bedrock OpenAI aliases follow AWS's split endpoints: `gpt-oss-20b` and
@@ -175,7 +175,7 @@ Bedrock OpenAI aliases follow AWS's split endpoints: `gpt-oss-20b` and
 `gpt-5.4` and `gpt-5.5` route through Bedrock Mantle's OpenAI-compatible
 Responses path.
 
-The default (`DEFAULT_MODEL` at `src/provider.rs:105`) is
+The default (`DEFAULT_MODEL` in `src/provider.rs`) is
 `claude-sonnet-4.6[1m]`. The `[1m]` suffix opts into Bedrock's 1M-context
 beta. Copilot ignores the suffix.
 

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -30,8 +30,9 @@ amaebi ask --model gpt-5.5 "hello"
 amaebi chat --model copilot/gpt-4o
 ```
 
-The default is `claude-sonnet-4.6[1m]` (see `src/provider.rs:105`). The `[1m]`
-suffix opts into Bedrock's 1M-context beta. Copilot ignores the suffix.
+The default is `claude-sonnet-4.6[1m]` (see `DEFAULT_MODEL` in
+`src/provider.rs`). The `[1m]` suffix opts into Bedrock's 1M-context beta.
+Copilot ignores the suffix.
 
 OpenAI models on Bedrock are available as built-in aliases. `gpt-oss-20b` and
 `gpt-oss-120b` use the `bedrock-runtime` ConverseStream model IDs. `gpt-5.4`

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -25,11 +25,18 @@ amaebi chat
 
 ```bash
 amaebi ask --model bedrock/claude-sonnet-4.6 "hello"
+amaebi ask --model gpt-oss-120b "hello"
+amaebi ask --model gpt-5.5 "hello"
 amaebi chat --model copilot/gpt-4o
 ```
 
 The default is `claude-sonnet-4.6[1m]` (see `src/provider.rs:105`). The `[1m]`
 suffix opts into Bedrock's 1M-context beta. Copilot ignores the suffix.
+
+OpenAI models on Bedrock are available as built-in aliases. `gpt-oss-20b` and
+`gpt-oss-120b` use the `bedrock-runtime` ConverseStream model IDs. `gpt-5.4`
+and `gpt-5.5` use Bedrock Mantle's OpenAI-compatible Responses endpoint
+(`bedrock-mantle.<region>.api.aws/openai/v1/responses`).
 
 Resolution order: `--model` flag → `AMAEBI_MODEL` env → default.
 

--- a/src/bedrock.rs
+++ b/src/bedrock.rs
@@ -86,6 +86,46 @@ fn converse_stream_endpoint(region: &str, model_id: &str) -> String {
     format!("https://bedrock-runtime.{region}.amazonaws.com/model/{encoded_model}/converse-stream")
 }
 
+/// Returns true for OpenAI models that must use Bedrock Mantle Responses.
+fn requires_mantle_responses(model_id: &str) -> bool {
+    model_id == "openai.gpt-5" || model_id.starts_with("openai.gpt-5.")
+}
+
+/// Returns true for OpenAI gpt-oss Mantle model IDs.
+///
+/// The bedrock-runtime IDs include a version suffix (`-1:0`) and continue to
+/// use ConverseStream.  The suffix-free IDs are Mantle IDs and should go to
+/// the OpenAI-compatible Responses endpoint.
+fn is_mantle_gpt_oss_model(model_id: &str) -> bool {
+    matches!(model_id, "openai.gpt-oss-20b" | "openai.gpt-oss-120b")
+}
+
+/// Returns true when a Bedrock model ID should be invoked through the
+/// OpenAI-compatible Bedrock Mantle Responses API.
+fn uses_bedrock_mantle_responses(model_id: &str) -> bool {
+    requires_mantle_responses(model_id) || is_mantle_gpt_oss_model(model_id)
+}
+
+/// Build the Bedrock Mantle base URL consumed by `responses::stream_openai_compatible`.
+///
+/// Most Mantle models use `https://bedrock-mantle.{region}.api.aws/v1`, but
+/// OpenAI GPT-5.x model cards specify the distinct `/openai/v1/responses`
+/// path.  Because the shared Responses client appends `/responses` to a
+/// `/v1` base URL, this function returns `/openai/v1` for GPT-5.x models.
+fn bedrock_mantle_base_url(region: &str, model_id: &str) -> String {
+    if let Ok(url) = std::env::var("AMAEBI_BEDROCK_MANTLE_URL") {
+        let trimmed = url.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    if requires_mantle_responses(model_id) {
+        format!("https://bedrock-mantle.{region}.api.aws/openai/v1")
+    } else {
+        format!("https://bedrock-mantle.{region}.api.aws/v1")
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Message format conversion: internal → Bedrock Converse
 // ---------------------------------------------------------------------------
@@ -1242,6 +1282,50 @@ where
     let token = read_bearer_token()?;
     let region = aws_region();
 
+    if uses_bedrock_mantle_responses(&spec.model_id) {
+        if spec.use_1m {
+            tracing::warn!(
+                display = %spec.display_name,
+                "1M context is not supported via Bedrock Mantle; proceeding with the model's standard context window"
+            );
+            write_frame(
+                writer,
+                &Response::Text {
+                    chunk: "[warning] 1M context ([1m]) is not supported via Bedrock Mantle; \
+                            proceeding with the model's standard context window.\n"
+                        .into(),
+                },
+            )
+            .await?;
+        }
+        if cache_ttl.is_some() {
+            tracing::debug!(
+                model_id = %spec.model_id,
+                "prompt cache TTL ignored for Bedrock Mantle Responses API"
+            );
+        }
+        let base_url = bedrock_mantle_base_url(&region, &spec.model_id);
+        tracing::debug!(
+            messages = messages.len(),
+            model = %spec.display_name,
+            model_id = %spec.model_id,
+            base_url = %base_url,
+            region = %region,
+            "sending Bedrock Mantle Responses request"
+        );
+        return crate::responses::stream_openai_compatible(
+            http,
+            &token,
+            &base_url,
+            &spec.model_id,
+            messages,
+            tools,
+            max_tokens,
+            writer,
+        )
+        .await;
+    }
+
     tracing::debug!(
         messages = messages.len(),
         model = %spec.display_name,
@@ -1358,6 +1442,53 @@ mod tests {
         ));
         assert!(!supports_1m_context("gpt-4o"));
         assert!(!supports_1m_context(""));
+    }
+
+    // ---- Bedrock Mantle routing -------------------------------------------
+
+    #[test]
+    fn mantle_routing_for_openai_responses_models() {
+        assert!(uses_bedrock_mantle_responses("openai.gpt-5.5"));
+        assert!(uses_bedrock_mantle_responses("openai.gpt-5.4"));
+        assert!(uses_bedrock_mantle_responses("openai.gpt-oss-120b"));
+        assert!(uses_bedrock_mantle_responses("openai.gpt-oss-20b"));
+
+        // Runtime IDs include the version suffix and should keep using
+        // bedrock-runtime ConverseStream.
+        assert!(!uses_bedrock_mantle_responses("openai.gpt-oss-120b-1:0"));
+        assert!(!uses_bedrock_mantle_responses("openai.gpt-oss-20b-1:0"));
+        assert!(!uses_bedrock_mantle_responses(
+            "us.anthropic.claude-sonnet-4-6"
+        ));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn mantle_base_url_uses_openai_path_for_gpt_5() {
+        std::env::remove_var("AMAEBI_BEDROCK_MANTLE_URL");
+        assert_eq!(
+            bedrock_mantle_base_url("us-east-2", "openai.gpt-5.5"),
+            "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn mantle_base_url_uses_standard_path_for_gpt_oss() {
+        std::env::remove_var("AMAEBI_BEDROCK_MANTLE_URL");
+        assert_eq!(
+            bedrock_mantle_base_url("us-east-1", "openai.gpt-oss-120b"),
+            "https://bedrock-mantle.us-east-1.api.aws/v1"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn mantle_base_url_test_override() {
+        std::env::set_var("AMAEBI_BEDROCK_MANTLE_URL", "http://mock:9999/openai/v1");
+        let url = bedrock_mantle_base_url("us-east-1", "openai.gpt-5.5");
+        std::env::remove_var("AMAEBI_BEDROCK_MANTLE_URL");
+        assert_eq!(url, "http://mock:9999/openai/v1");
     }
 
     // ---- build_additional_model_request_fields ------------------------------

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4824,7 +4824,7 @@ where
         Ok(r) => Ok(r),
         Err(e) => {
             let is_auth = e
-                .downcast_ref::<copilot::CopilotHttpError>()
+                .downcast_ref::<crate::responses::ResponsesHttpError>()
                 .is_some_and(|he| matches!(he.status.as_u16(), 401 | 403));
             if is_auth {
                 tracing::warn!(

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -851,7 +851,7 @@ mod tests {
     #[test]
     fn collect_pane_events_one_per_pane() {
         let now = now_secs();
-        let panes = vec![
+        let panes = [
             pane("%1", PaneStatus::Busy, true, now, Some("pr-1")),
             pane("%2", PaneStatus::Idle, false, now, None),
         ];
@@ -1036,7 +1036,15 @@ mod tests {
 
     /// Serialize a `ResourceLease` map via serde so tests can't drift from
     /// the real on-disk schema — construct typed structs, not JSON literals.
-    fn seed_resource_state(records: Vec<(&str, &str, LeaseStatus, Option<&str>, Option<&str>)>) {
+    type ResourceStateRecord<'a> = (
+        &'a str,
+        &'a str,
+        LeaseStatus,
+        Option<&'a str>,
+        Option<&'a str>,
+    );
+
+    fn seed_resource_state(records: Vec<ResourceStateRecord<'_>>) {
         let dir = crate::auth::amaebi_home().expect("home");
         std::fs::create_dir_all(&dir).expect("mkdir");
         let now = now_secs();

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -56,7 +56,7 @@ pub struct ModelSpec {
 /// provider model ID used by the selected Bedrock endpoint.
 ///
 /// To find the correct model ID, check the Bedrock console or run:
-///   `aws bedrock list-foundation-models --by-provider Anthropic`
+///   `aws bedrock list-foundation-models`
 const BEDROCK_ALIASES: &[(&str, &str)] = &[
     // OpenAI family.
     //

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -50,14 +50,25 @@ pub struct ModelSpec {
 
 /// Friendly alias → full Bedrock model ID.
 ///
-/// **Maintenance note**: when new Claude models are released on Bedrock,
+/// **Maintenance note**: when new Bedrock models are released,
 /// add a new entry here.  The alias is the short name users type on the
-/// CLI (e.g. `claude-sonnet-4.6`); the value is the cross-region
-/// inference model ID (with `us.` prefix).
+/// CLI (e.g. `claude-sonnet-4.6` or `gpt-oss-120b`); the value is the
+/// provider model ID used by the selected Bedrock endpoint.
 ///
 /// To find the correct model ID, check the Bedrock console or run:
 ///   `aws bedrock list-foundation-models --by-provider Anthropic`
 const BEDROCK_ALIASES: &[(&str, &str)] = &[
+    // OpenAI family.
+    //
+    // gpt-5.x is only available through Bedrock Mantle's OpenAI Responses API,
+    // while gpt-oss aliases use the bedrock-runtime model IDs so they continue
+    // to work through ConverseStream.  Users can still pass the Mantle IDs
+    // directly (for example, `bedrock/openai.gpt-oss-120b`) when they want the
+    // OpenAI-compatible endpoint.
+    ("gpt-5.5", "openai.gpt-5.5"),
+    ("gpt-5.4", "openai.gpt-5.4"),
+    ("gpt-oss-120b", "openai.gpt-oss-120b-1:0"),
+    ("gpt-oss-20b", "openai.gpt-oss-20b-1:0"),
     // Claude 4.7 family
     ("claude-opus-4.7", "us.anthropic.claude-opus-4-7"),
     // Claude 4.6 family (cross-region inference profiles — no `:0` suffix)
@@ -329,6 +340,24 @@ mod tests {
             resolve_bedrock_alias("claude-opus-4.6"),
             "us.anthropic.claude-opus-4-6-v1"
         );
+    }
+
+    #[test]
+    fn alias_openai_gpt_oss_runtime_models() {
+        assert_eq!(
+            resolve_bedrock_alias("gpt-oss-120b"),
+            "openai.gpt-oss-120b-1:0"
+        );
+        assert_eq!(
+            resolve_bedrock_alias("gpt-oss-20b"),
+            "openai.gpt-oss-20b-1:0"
+        );
+    }
+
+    #[test]
+    fn alias_openai_gpt_5_mantle_models() {
+        assert_eq!(resolve_bedrock_alias("gpt-5.5"), "openai.gpt-5.5");
+        assert_eq!(resolve_bedrock_alias("gpt-5.4"), "openai.gpt-5.4");
     }
 
     #[test]

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 use futures_util::StreamExt;
 use tokio::io::AsyncWriteExt;
 
-use crate::copilot::{CopilotHttpError, CopilotResponse, FinishReason, Message, ToolCall};
+use crate::copilot::{CopilotResponse, FinishReason, Message, ToolCall};
 use crate::ipc::{write_frame, Response};
 use crate::retry::{backoff_delay, parse_retry_after_header};
 
@@ -44,9 +44,40 @@ fn responses_endpoint(base_url: &str) -> String {
             return format!("{base}/v1/responses");
         }
     }
-    format!("{}/v1/responses", base_url.trim_end_matches('/'))
+    let base = base_url.trim_end_matches('/');
+    if base.ends_with("/responses") {
+        base.to_owned()
+    } else if base.ends_with("/v1") {
+        format!("{base}/responses")
+    } else {
+        format!("{base}/v1/responses")
+    }
 }
 const MAX_RETRIES: u32 = 3;
+
+/// An HTTP error response from an OpenAI-compatible Responses API.
+#[derive(Debug)]
+pub struct ResponsesHttpError {
+    pub status: reqwest::StatusCode,
+    pub body: String,
+}
+
+impl std::fmt::Display for ResponsesHttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let body = &self.body;
+        match body.char_indices().nth(200) {
+            None => write!(f, "Responses API returned {}: {}", self.status, body),
+            Some((byte_idx, _)) => write!(
+                f,
+                "Responses API returned {}: {}...",
+                self.status,
+                &body[..byte_idx]
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ResponsesHttpError {}
 
 // ---------------------------------------------------------------------------
 // Message format conversion: Chat Completions → Responses API
@@ -189,6 +220,7 @@ async fn send_with_retry(
     messages: &[Message],
     tools: &[serde_json::Value],
     max_tokens: usize,
+    use_copilot_headers: bool,
 ) -> Result<reqwest::Response> {
     let input = to_responses_input(messages);
     let responses_tools = to_responses_tools(tools);
@@ -210,19 +242,20 @@ async fn send_with_retry(
 
     let mut attempt = 0u32;
     loop {
-        let result = http
+        let mut req = http
             .post(&url)
             .header("Authorization", format!("Bearer {token}"))
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
-            .header("User-Agent", concat!("amaebi/", env!("CARGO_PKG_VERSION")))
-            .header("Copilot-Integration-Id", "vscode-chat")
-            .header("Editor-Version", "vscode/1.90.0")
-            .header("X-Initiator", initiator)
-            .header("Openai-Intent", "conversation-edits")
-            .json(&body)
-            .send()
-            .await;
+            .header("User-Agent", concat!("amaebi/", env!("CARGO_PKG_VERSION")));
+        if use_copilot_headers {
+            req = req
+                .header("Copilot-Integration-Id", "vscode-chat")
+                .header("Editor-Version", "vscode/1.90.0")
+                .header("X-Initiator", initiator)
+                .header("Openai-Intent", "conversation-edits");
+        }
+        let result = req.json(&body).send().await;
 
         match result {
             Ok(resp) if resp.status().is_success() => return Ok(resp),
@@ -231,7 +264,7 @@ async fn send_with_retry(
                 if attempt >= MAX_RETRIES {
                     let status = resp.status();
                     let body_text = resp.text().await.unwrap_or_default();
-                    return Err(anyhow::Error::new(CopilotHttpError {
+                    return Err(anyhow::Error::new(ResponsesHttpError {
                         status,
                         body: body_text,
                     }));
@@ -253,7 +286,7 @@ async fn send_with_retry(
                 if attempt >= MAX_RETRIES {
                     let status = resp.status();
                     let body_text = resp.text().await.unwrap_or_default();
-                    return Err(anyhow::Error::new(CopilotHttpError {
+                    return Err(anyhow::Error::new(ResponsesHttpError {
                         status,
                         body: body_text,
                     }));
@@ -273,7 +306,7 @@ async fn send_with_retry(
             Ok(resp) => {
                 let status = resp.status();
                 let body_text = resp.text().await.unwrap_or_default();
-                return Err(anyhow::Error::new(CopilotHttpError {
+                return Err(anyhow::Error::new(ResponsesHttpError {
                     status,
                     body: body_text,
                 }));
@@ -540,7 +573,41 @@ where
         model,
         "sending chat request via Responses API"
     );
-    let resp = send_with_retry(http, token, base_url, model, messages, tools, max_tokens).await?;
+    let resp = send_with_retry(
+        http, token, base_url, model, messages, tools, max_tokens, true,
+    )
+    .await?;
+    parse_responses_stream(resp, writer).await
+}
+
+/// Send a streaming request to an OpenAI-compatible Responses API endpoint.
+///
+/// This is used for Amazon Bedrock Mantle, whose wire format is OpenAI
+/// Responses-compatible but does not accept Copilot-specific request headers.
+#[allow(clippy::too_many_arguments)]
+pub async fn stream_openai_compatible<W>(
+    http: &reqwest::Client,
+    token: &str,
+    base_url: &str,
+    model: &str,
+    messages: &[Message],
+    tools: &[serde_json::Value],
+    max_tokens: usize,
+    writer: &mut W,
+) -> Result<CopilotResponse>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    tracing::debug!(
+        messages = messages.len(),
+        model,
+        base_url,
+        "sending chat request via OpenAI-compatible Responses API"
+    );
+    let resp = send_with_retry(
+        http, token, base_url, model, messages, tools, max_tokens, false,
+    )
+    .await?;
     parse_responses_stream(resp, writer).await
 }
 
@@ -552,6 +619,38 @@ where
 mod tests {
     use super::*;
     use crate::copilot::{ApiToolCall, ApiToolCallFunction};
+
+    // ---- responses_endpoint ------------------------------------------------
+
+    #[test]
+    #[serial_test::serial]
+    fn responses_endpoint_appends_v1_for_root_base_url() {
+        std::env::remove_var("AMAEBI_COPILOT_URL");
+        assert_eq!(
+            responses_endpoint("https://bedrock-mantle.us-east-1.api.aws"),
+            "https://bedrock-mantle.us-east-1.api.aws/v1/responses"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn responses_endpoint_accepts_v1_base_url() {
+        std::env::remove_var("AMAEBI_COPILOT_URL");
+        assert_eq!(
+            responses_endpoint("https://bedrock-mantle.us-east-2.api.aws/openai/v1"),
+            "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn responses_endpoint_accepts_full_responses_url() {
+        std::env::remove_var("AMAEBI_COPILOT_URL");
+        assert_eq!(
+            responses_endpoint("http://mock:9999/openai/v1/responses"),
+            "http://mock:9999/openai/v1/responses"
+        );
+    }
 
     // ---- to_responses_input ------------------------------------------------
 

--- a/tests/support/helpers.rs
+++ b/tests/support/helpers.rs
@@ -645,6 +645,7 @@ impl LongChatConnection {
     }
 
     /// Send a Steer request on this connection (same socket as the Chat).
+    #[allow(dead_code)]
     pub async fn steer(&mut self, session_id: &str, message: &str) -> Result<()> {
         let req = Request::Steer {
             session_id: session_id.to_string(),


### PR DESCRIPTION
## Summary
- add Bedrock aliases for OpenAI gpt-oss and gpt-5 models
- route Bedrock Mantle-only GPT models through the OpenAI-compatible Responses API
- reuse the Responses API backend without Copilot-specific headers for Bedrock Mantle
- fix existing all-target clippy warnings

## Usage
OpenAI models are exposed through AWS Bedrock model aliases:

```bash
amaebi ask --model gpt-oss-120b "hello"
amaebi ask --model gpt-oss-20b "hello"
amaebi ask --model gpt-5.5 "hello"
amaebi ask --model gpt-5.4 "hello"
amaebi chat --model gpt-5.5
```

The same aliases can be passed with an explicit Bedrock provider prefix:

```bash
amaebi ask --model bedrock/gpt-5.5 "hello"
```

In an interactive `amaebi chat` session, switch models with `/model <model>`:

```text
/model gpt-5.5
/model gpt-oss-120b
/model bedrock/gpt-5.4
```

Use bare `/model` to show the current model. To set a default for new commands, use `AMAEBI_MODEL`:

```bash
export AMAEBI_MODEL=gpt-5.5
amaebi chat
```

Alias routing:
- `gpt-oss-120b` and `gpt-oss-20b` use Bedrock Runtime ConverseStream model IDs.
- `gpt-5.5` and `gpt-5.4` use Bedrock Mantle OpenAI-compatible Responses.

Requires AWS credentials, region configuration, and model access in the selected Bedrock region.

## Verification
- cargo clippy --all-targets -- -D warnings
- cargo test
- ./scripts/next-version.sh --check
- GitHub CI: success
- ./scripts/test.sh (local only blocked: dev image amaebi-dev:bookworm-slim not found)