### PR TITLE
fix(agent): bound distilled prompt length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.6.6"
+version = "2026.6.7"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.6.6"
+version = "2026.6.7"
 edition = "2021"
 
 [[bin]]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1272,11 +1272,14 @@ async fn handle_distill_claude_prompt(
         crate::ipc::AgentKind::Codex => "/codex",
     };
     let agent_name = agent_display_name(agent);
+    let target_lines = tools::DISTILLED_PROMPT_TARGET_LINES;
+    let max_lines = tools::MAX_DISTILLED_PROMPT_LINES;
     let user_msg = format!(
         "User's brief description for {command}:\n\n{brief}\n\n\
          Working directory: {cwd}\n\n\
          Investigate the codebase, then call `emit_distilled_prompt` exactly once \
-         with the full {agent_name} prompt."
+         with the concise {agent_name} prompt (target about {target_lines} lines, \
+         hard maximum {max_lines} lines)."
     );
     let messages = vec![Message::system(system_prompt), Message::user(user_msg)];
 
@@ -1397,6 +1400,8 @@ fn build_distillation_system_prompt(
                  merging is the user's responsibility."
         ),
     };
+    let target_lines = tools::DISTILLED_PROMPT_TARGET_LINES;
+    let max_lines = tools::MAX_DISTILLED_PROMPT_LINES;
     format!(
         "You are amaebi's prompt distiller.  The user typed `{command} \"<brief>\"` and your \
          job is to convert that brief into a self-contained prompt that a downstream {agent_name} \
@@ -1415,6 +1420,9 @@ fn build_distillation_system_prompt(
          3. Call `emit_distilled_prompt` EXACTLY ONCE with the final prompt as a single \
             string.  That call ends your work — no further turns will run after it.\n\n\
          Output requirements for the distilled prompt:\n\
+         - Length: target about {target_lines} lines; HARD MAXIMUM {max_lines} lines.  \
+           If you exceed {max_lines} lines, the tool call will fail.  Compress details \
+           instead of adding paragraphs.\n\
          - Self-contained: the downstream {agent_name} session does NOT see this conversation.\n\
          - Concrete: name file paths and functions, not vague areas.\n\
          - Action-oriented: numbered steps the inner {agent_name} can follow.\n\
@@ -6131,8 +6139,10 @@ where
                             None
                         };
 
+                        let mut tool_succeeded = false;
                         let result = match state.executor.execute(&tc.name, args).await {
                             Ok(output) => {
+                                tool_succeeded = true;
                                 tracing::debug!(
                                     tool = %tc.name,
                                     model = %current_model,
@@ -6175,7 +6185,7 @@ where
                         // (handle_distill_claude_prompt) reads it from final_text.
                         // Only triggered when the schema is exposed, i.e. when
                         // ToolMode::Distill was passed in.
-                        if let Some(prompt) = distilled_prompt {
+                        if let Some(prompt) = distilled_prompt.filter(|_| tool_succeeded) {
                             distilled_capture = Some(prompt);
                             break 'outer;
                         }
@@ -9033,6 +9043,10 @@ mod tests {
         assert!(
             p.to_lowercase().contains("verification"),
             "prompt must instruct verification commands: {p}"
+        );
+        assert!(
+            p.contains("target about 10 lines") && p.contains("HARD MAXIMUM 20 lines"),
+            "prompt must bound distilled prompt line count: {p}"
         );
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9045,7 +9045,13 @@ mod tests {
             "prompt must instruct verification commands: {p}"
         );
         assert!(
-            p.contains("target about 10 lines") && p.contains("HARD MAXIMUM 20 lines"),
+            p.contains(&format!(
+                "target about {} lines",
+                tools::DISTILLED_PROMPT_TARGET_LINES
+            )) && p.contains(&format!(
+                "HARD MAXIMUM {} lines",
+                tools::MAX_DISTILLED_PROMPT_LINES
+            )),
             "prompt must bound distilled prompt line count: {p}"
         );
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -7,6 +7,9 @@ use tokio::process::Command;
 
 use crate::sandbox::{docker::DockerSandboxConfig, DockerSandbox, NoopSandbox, Sandbox};
 
+pub(crate) const DISTILLED_PROMPT_TARGET_LINES: usize = 10;
+pub(crate) const MAX_DISTILLED_PROMPT_LINES: usize = 20;
+
 // ---------------------------------------------------------------------------
 // SpawnContext — shared state injected by the daemon for spawn_agent support
 // ---------------------------------------------------------------------------
@@ -595,6 +598,14 @@ fn emit_distilled_prompt(args: serde_json::Value) -> Result<String> {
     if prompt.trim().is_empty() {
         anyhow::bail!("emit_distilled_prompt: 'prompt' must be non-empty");
     }
+    let line_count = prompt.lines().count();
+    if line_count > MAX_DISTILLED_PROMPT_LINES {
+        anyhow::bail!(
+            "emit_distilled_prompt: 'prompt' has {line_count} lines; target about \
+             {DISTILLED_PROMPT_TARGET_LINES} lines and hard maximum is \
+             {MAX_DISTILLED_PROMPT_LINES}"
+        );
+    }
     Ok(format!("[distilled prompt emitted, len={}]", prompt.len()))
 }
 
@@ -909,23 +920,29 @@ fn distill_tool_schemas() -> Vec<serde_json::Value> {
         "type": "function",
         "function": {
             "name": "emit_distilled_prompt",
-            "description": "Emit the FINAL distilled prompt that will be injected into the \
-                            downstream Claude Code pane.  Call this exactly ONCE, after you \
-                            have finished investigating the codebase and decided what \
-                            Claude should actually do.  The string you pass becomes the \
-                            opening user message for that Claude session — write it as a \
-                            self-contained instruction (file paths, key functions, \
-                            verification commands, hard constraints).  Do NOT call this \
-                            speculatively before reading code; do NOT call it more than \
-                            once per session — the first call ends the distillation loop.",
+            "description": format!(
+                "Emit the FINAL distilled prompt that will be injected into the \
+                 downstream Claude Code pane. Call this exactly ONCE, after you \
+                 have finished investigating the codebase and decided what \
+                 Claude should actually do. Keep the prompt concise: target \
+                 about {DISTILLED_PROMPT_TARGET_LINES} lines, hard maximum \
+                 {MAX_DISTILLED_PROMPT_LINES} newline-separated lines. The \
+                 string you pass becomes the opening user message for that \
+                 Claude session. Do NOT call this speculatively before reading \
+                 code; do NOT call it more than once per session."
+            ),
             "parameters": {
                 "type": "object",
                 "properties": {
                     "prompt": {
                         "type": "string",
-                        "description": "The full prompt to inject into Claude Code.  No \
-                                        preamble, no meta-commentary — Claude will read \
-                                        this verbatim as its first user turn."
+                        "description": format!(
+                            "The concise prompt to inject into Claude Code. Target about \
+                             {DISTILLED_PROMPT_TARGET_LINES} lines; hard maximum \
+                             {MAX_DISTILLED_PROMPT_LINES} lines. No preamble, no \
+                             meta-commentary; Claude will read this verbatim as its \
+                             first user turn."
+                        )
                     }
                 },
                 "required": ["prompt"]
@@ -2141,5 +2158,21 @@ mod tests {
         assert!(r.is_ok());
         let s = r.unwrap();
         assert!(s.contains("len=11"), "result should report length: {s}");
+
+        // Exactly the hard line limit is allowed.
+        let max_line_prompt = (1..=MAX_DISTILLED_PROMPT_LINES)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let r = emit_distilled_prompt(serde_json::json!({"prompt": max_line_prompt}));
+        assert!(r.is_ok(), "prompt at line limit should be accepted");
+
+        // One line over the hard limit is rejected so the downstream paste stays bounded.
+        let too_long_prompt = (1..=(MAX_DISTILLED_PROMPT_LINES + 1))
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let r = emit_distilled_prompt(serde_json::json!({"prompt": too_long_prompt}));
+        assert!(r.is_err(), "prompt over line limit should error");
     }
 }


### PR DESCRIPTION
## Summary
- constrain distilled prompts to target about 10 lines with a hard 20-line maximum
- enforce the line limit in emit_distilled_prompt
- avoid capturing failed emit_distilled_prompt calls as successful distilled output

## Verification
- cargo test emit_distilled_prompt_validates_prompt_field
- cargo test distillation_system_prompt_mentions_emit_tool_and_cwd
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

Note: ./scripts/test.sh could not run because the local amaebi-dev:bookworm-slim image is missing.