### PR TITLE
fix(supervision): require downstream validation evidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.6.7"
+version = "2026.6.8"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.6.7"
+version = "2026.6.8"
 edition = "2021"
 
 [[bin]]

--- a/src/client.rs
+++ b/src/client.rs
@@ -657,7 +657,13 @@ pub(crate) fn format_task_released(
         ));
     }
     if let Some(s) = summary {
-        out.push_str(&format!("  summary: {s}\n"));
+        let mut lines = s.lines();
+        if let Some(first) = lines.next() {
+            out.push_str(&format!("  summary: {first}\n"));
+            for line in lines {
+                out.push_str(&format!("           {line}\n"));
+            }
+        }
     }
     if !pane_tail.trim().is_empty() {
         out.push_str("  --- pane tail ---\n");
@@ -5705,6 +5711,23 @@ mod tests {
         let out =
             format_task_released("%54", &[], None, Some("all tests pass"), None, false, "", 0);
         assert!(out.contains("  summary: all tests pass\n"));
+    }
+
+    #[test]
+    fn format_task_released_indents_multiline_summary() {
+        let out = format_task_released(
+            "%54",
+            &[],
+            None,
+            Some("all tests pass\n\nvalidation evidence:\ncargo test passed"),
+            None,
+            false,
+            "",
+            0,
+        );
+        assert!(out.contains(
+            "  summary: all tests pass\n           \n           validation evidence:\n           cargo test passed\n"
+        ));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5248,13 +5248,14 @@ fn format_pane_alive_reminder(panes: &[(String, Option<String>)]) -> String {
          is `tmux_send_text`.\n\
          - `task_done` — declare the task goal verified and release the \
          pane.  Requires `pane_id` + a short `summary` of what Claude \
-         accomplished.  Only call it AFTER you have actually observed \
-         Claude's output (via `tmux_capture_pane`) and judged the work \
-         complete — do not call it on the first turn just to exit.  See \
-         anti-pattern #3 above for when NOT to call it.  Once ALL panes \
-         are released, this reminder disappears and you can reply with \
-         plain text again.  This is the ONLY way to exit supervision \
-         cleanly.\n\
+         accomplished + `validation_evidence` copied or summarized from \
+         the downstream pane's validation commands and results.  Only \
+         call it AFTER you have actually observed Claude's output (via \
+         `tmux_capture_pane`) and judged the work complete — do not call \
+         it on the first turn just to exit.  See anti-pattern #3 above \
+         for when NOT to call it.  Once ALL panes are released, this \
+         reminder disappears and you can reply with plain text again.  \
+         This is the ONLY way to exit supervision cleanly.\n\
          \n\
          **Downstream-validated acceptance.**  The task description above \
          contains acceptance criteria (tests to pass, performance / \

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6142,10 +6142,17 @@ where
                                 args["summary"].as_str(),
                                 args["validation_evidence"].as_str(),
                             ) {
-                                (Some(p), Some(s), Some(v)) => Some((
-                                    p.to_string(),
-                                    format!("{s}\n\nvalidation evidence:\n{}", v.trim()),
-                                )),
+                                (Some(p), Some(s), Some(v)) => {
+                                    let pane_id = p.trim();
+                                    let summary = s.trim();
+                                    let validation_evidence = v.trim();
+                                    Some((
+                                        pane_id.to_string(),
+                                        format!(
+                                            "{summary}\n\nvalidation evidence:\n{validation_evidence}"
+                                        ),
+                                    ))
+                                }
                                 _ => None,
                             }
                         } else {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5162,8 +5162,9 @@ fn format_pane_alive_reminder(panes: &[(String, Option<String>)]) -> String {
          feasible path forward and keep Claude working (see the next \
          section).\n\
          3. **Verify** — only call `task_done` when the user's goal is \
-         FULLY met.  \"Mostly done\" / \"next session\" / \"handed off\" \
-         is NOT done.\n\
+         FULLY met and the downstream Claude/Codex pane has actually run \
+         the required validation.  \"Mostly done\" / \"next session\" / \
+         \"handed off\" / \"I only built it\" is NOT done.\n\
          \n\
          You must NOT do the task yourself.  `edit_file` is FORBIDDEN.  \
          Running builds, compilers, or long-running commands yourself is \
@@ -5255,20 +5256,35 @@ fn format_pane_alive_reminder(panes: &[(String, Option<String>)]) -> String {
          plain text again.  This is the ONLY way to exit supervision \
          cleanly.\n\
          \n\
-         **Acceptance-driven verification.**  The task description above \
+         **Downstream-validated acceptance.**  The task description above \
          contains acceptance criteria (tests to pass, performance / \
          correctness invariants, numeric thresholds).  You MUST judge \
          `task_done` against THOSE criteria — not against Claude's \
-         self-reported summary.  Concretely:\n\
-         - Observe (via `tmux_capture_pane`) that the specified tests / \
-         benchmarks actually ran AND passed.\n\
-         - If the task specifies no-regression, compare the numbers you \
-         see in the pane against any baseline mentioned in the task.\n\
-         - If you cannot confirm the criteria from pane output alone, use \
-         `shell_command` (read-only: `git diff`, `grep`, run the test \
-         command yourself) to independently verify.\n\
-         - If criteria are NOT met, do NOT call `task_done`.  Instead \
-         steer Claude toward fixing the remaining failures.\n\
+         self-reported summary, not against a clean diff, and not against \
+         build success alone.  Verification must be performed by the \
+         downstream Claude/Codex pane you are supervising.\n\
+         \n\
+         Before `task_done`, the pane transcript must show:\n\
+         - The exact validation commands Claude/Codex ran (tests, simulator \
+         cases, benchmarks, accuracy checks, etc.).\n\
+         - Their pass/fail output and relevant numeric results.\n\
+         - For no-regression requests, both the new numbers and the \
+         baseline/comparison you used to judge regression risk.\n\
+         \n\
+         A changed test list, a committed test script, a build-only check, \
+         or a statement like \"I did not run the functional tests\" means \
+         validation is missing.  If validation evidence is missing or \
+         incomplete, do NOT run the tests yourself and do NOT call \
+         `task_done`.  Use `tmux_send_text` to tell Claude/Codex exactly \
+         which accuracy/performance/regression checks to run, then \
+         `tmux_wait` and inspect the pane output.  You may use read-only \
+         `shell_command` only to cross-check artifacts or parse existing \
+         outputs after the downstream pane has produced them; never use it \
+         to substitute for the downstream agent's validation run.\n\
+         \n\
+         If criteria are NOT met, do NOT call `task_done`.  Instead steer \
+         Claude/Codex toward fixing the remaining failures and rerunning \
+         the required validation.\n\
          \n\
          **Multi-step plan (≥3 steps).**  For tasks with three or more \
          distinct steps, maintain a plan as a markdown checklist inside \
@@ -6120,8 +6136,15 @@ where
                         // echo has gone into messages.  Extracted even when conn_id
                         // is None so validation errors surface the usual way.
                         let task_done_args: Option<(String, String)> = if tc.name == "task_done" {
-                            match (args["pane_id"].as_str(), args["summary"].as_str()) {
-                                (Some(p), Some(s)) => Some((p.to_string(), s.to_string())),
+                            match (
+                                args["pane_id"].as_str(),
+                                args["summary"].as_str(),
+                                args["validation_evidence"].as_str(),
+                            ) {
+                                (Some(p), Some(s), Some(v)) => Some((
+                                    p.to_string(),
+                                    format!("{s}\n\nvalidation evidence:\n{}", v.trim()),
+                                )),
                                 _ => None,
                             }
                         } else {
@@ -6195,7 +6218,9 @@ where
                         // happens here.  Runs only when a live conn holds panes
                         // (SubmitDetach / cron have conn_id=None and no held
                         // entries, so the release would be a no-op anyway).
-                        if let (Some((pane_id, summary)), Some(cid)) = (task_done_args, conn_id) {
+                        if let (Some((pane_id, summary)), Some(cid)) =
+                            (task_done_args.filter(|_| tool_succeeded), conn_id)
+                        {
                             if let Some(released) = release_held_entry(
                                 state,
                                 cid,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -578,7 +578,11 @@ fn task_done(args: serde_json::Value) -> Result<String> {
         .context("task_done: missing string argument 'pane_id'")?;
     let summary = args["summary"]
         .as_str()
-        .context("task_done: missing string argument 'summary'")?;
+        .context("task_done: missing string argument 'summary'")?
+        .trim();
+    if summary.is_empty() {
+        anyhow::bail!("task_done: 'summary' must be non-empty");
+    }
     let validation_evidence = args["validation_evidence"]
         .as_str()
         .context("task_done: missing string argument 'validation_evidence'")?
@@ -2093,6 +2097,21 @@ mod tests {
         assert!(
             required.iter().any(|v| v == "validation_evidence"),
             "task_done must require validation_evidence: {schema}"
+        );
+    }
+
+    #[test]
+    fn task_done_rejects_empty_summary() {
+        let err = task_done(serde_json::json!({
+            "pane_id": "%1",
+            "summary": "   ",
+            "validation_evidence": "cargo test passed"
+        }))
+        .expect_err("task_done should reject empty summary")
+        .to_string();
+        assert!(
+            err.contains("summary") && err.contains("non-empty"),
+            "error should mention non-empty summary: {err}"
         );
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -2076,21 +2076,16 @@ mod tests {
             .iter()
             .find(|s| s["function"]["name"] == "task_done")
             .expect("task_done schema must exist");
-        let desc = schema["function"]["description"]
-            .as_str()
-            .expect("task_done description must be a string");
-        for required in ["downstream", "tmux_send_text", "validation_evidence"] {
-            assert!(
-                desc.contains(required),
-                "task_done description should mention {required:?}: {desc}"
-            );
-        }
         let props = schema["function"]["parameters"]["properties"]
             .as_object()
             .expect("task_done properties must be an object");
         assert!(
             props.contains_key("validation_evidence"),
             "task_done must expose validation_evidence property: {schema}"
+        );
+        assert_eq!(
+            props["validation_evidence"]["type"], "string",
+            "validation_evidence must be a string property: {schema}"
         );
         let required = schema["function"]["parameters"]["required"]
             .as_array()

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -2076,19 +2076,22 @@ mod tests {
             .iter()
             .find(|s| s["function"]["name"] == "task_done")
             .expect("task_done schema must exist");
-        let desc = schema["function"]["description"].as_str().unwrap();
-        for required in [
-            "downstream Claude/Codex pane run",
-            "accuracy/performance",
-            "build-only check",
-            "tmux_send_text",
-            "validation_evidence",
-        ] {
+        let desc = schema["function"]["description"]
+            .as_str()
+            .expect("task_done description must be a string");
+        for required in ["downstream", "tmux_send_text", "validation_evidence"] {
             assert!(
                 desc.contains(required),
                 "task_done description should mention {required:?}: {desc}"
             );
         }
+        let props = schema["function"]["parameters"]["properties"]
+            .as_object()
+            .expect("task_done properties must be an object");
+        assert!(
+            props.contains_key("validation_evidence"),
+            "task_done must expose validation_evidence property: {schema}"
+        );
         let required = schema["function"]["parameters"]["required"]
             .as_array()
             .expect("task_done required fields must be an array");

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -579,7 +579,16 @@ fn task_done(args: serde_json::Value) -> Result<String> {
     let summary = args["summary"]
         .as_str()
         .context("task_done: missing string argument 'summary'")?;
-    Ok(format!("[task_done signalled pane={pane_id}]\n{summary}"))
+    let validation_evidence = args["validation_evidence"]
+        .as_str()
+        .context("task_done: missing string argument 'validation_evidence'")?
+        .trim();
+    if validation_evidence.is_empty() {
+        anyhow::bail!("task_done: 'validation_evidence' must be non-empty");
+    }
+    Ok(format!(
+        "[task_done signalled pane={pane_id}]\n{summary}\n\nvalidation evidence:\n{validation_evidence}"
+    ))
 }
 
 /// `emit_distilled_prompt` is the distillation analogue of `task_done`:
@@ -1182,9 +1191,15 @@ fn chat_tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
             "type": "function",
             "function": {
                 "name": "task_done",
-                "description": "Declare a /claude-launched pane's task complete.  Call this when \
-                                you have verified the task goal is met (tests pass, diff reviewed, \
-                                etc.) — NOT on speculation.  The daemon then releases amaebi's \
+                "description": "Declare a /claude-launched pane's task complete.  Call this only \
+                                after you have observed the downstream Claude/Codex pane run the \
+                                required validation (tests, benchmarks, accuracy/performance \
+                                checks) and pass the task's acceptance criteria.  A clean diff, \
+                                committed test script, build-only check, or self-report without \
+                                validation output is not enough.  If validation is missing, steer \
+                                the pane with tmux_send_text instead of calling task_done.  The \
+                                required validation_evidence argument must cite the downstream \
+                                pane's validation commands and results.  The daemon then releases amaebi's \
                                 ownership of the pane (pane lease, resource lease, task-notebook \
                                 lease) and streams a TaskReleased frame to the user with the pane \
                                 tail + worktree status + your summary.  The tmux pane and the \
@@ -1204,9 +1219,21 @@ fn chat_tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                             "description": "Your final summary of what was accomplished.  \
                                             Stream-rendered to the user AND archived to the \
                                             inbox for later review."
+                        },
+                        "validation_evidence": {
+                            "type": "string",
+                            "description": "Evidence copied or summarized from the downstream \
+                                            Claude/Codex pane output before release: exact \
+                                            validation commands it ran, pass/fail output, relevant \
+                                            accuracy/performance results, and baseline/no-regression \
+                                            comparison when applicable.  A build-only check, clean \
+                                            diff, committed test script, or self-report that tests \
+                                            were not run is not valid evidence.  If this evidence is \
+                                            missing, do not call task_done; use tmux_send_text to ask \
+                                            the pane to run the required validation."
                         }
                     },
-                    "required": ["pane_id", "summary"]
+                    "required": ["pane_id", "summary", "validation_evidence"]
                 }
             }
         }),
@@ -2037,6 +2064,63 @@ mod tests {
                 .iter()
                 .all(|s| s["function"]["name"] != "tmux_send_keys"),
             "legacy tmux_send_keys schema must be removed"
+        );
+    }
+
+    #[test]
+    fn task_done_schema_requires_downstream_validation_evidence() {
+        let schemas = tool_schemas(ToolMode::Chat {
+            include_spawn_agent: true,
+        });
+        let schema = schemas
+            .iter()
+            .find(|s| s["function"]["name"] == "task_done")
+            .expect("task_done schema must exist");
+        let desc = schema["function"]["description"].as_str().unwrap();
+        for required in [
+            "downstream Claude/Codex pane run",
+            "accuracy/performance",
+            "build-only check",
+            "tmux_send_text",
+            "validation_evidence",
+        ] {
+            assert!(
+                desc.contains(required),
+                "task_done description should mention {required:?}: {desc}"
+            );
+        }
+        let required = schema["function"]["parameters"]["required"]
+            .as_array()
+            .expect("task_done required fields must be an array");
+        assert!(
+            required.iter().any(|v| v == "validation_evidence"),
+            "task_done must require validation_evidence: {schema}"
+        );
+    }
+
+    #[test]
+    fn task_done_rejects_missing_validation_evidence() {
+        let err = task_done(serde_json::json!({
+            "pane_id": "%1",
+            "summary": "implemented"
+        }))
+        .expect_err("task_done should require validation evidence")
+        .to_string();
+        assert!(
+            err.contains("validation_evidence"),
+            "error should mention validation_evidence: {err}"
+        );
+
+        let err = task_done(serde_json::json!({
+            "pane_id": "%1",
+            "summary": "implemented",
+            "validation_evidence": "   "
+        }))
+        .expect_err("task_done should reject empty validation evidence")
+        .to_string();
+        assert!(
+            err.contains("non-empty"),
+            "error should mention non-empty evidence: {err}"
         );
     }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -575,7 +575,11 @@ fn subagent_default_model() -> String {
 fn task_done(args: serde_json::Value) -> Result<String> {
     let pane_id = args["pane_id"]
         .as_str()
-        .context("task_done: missing string argument 'pane_id'")?;
+        .context("task_done: missing string argument 'pane_id'")?
+        .trim();
+    if pane_id.is_empty() {
+        anyhow::bail!("task_done: 'pane_id' must be non-empty");
+    }
     let summary = args["summary"]
         .as_str()
         .context("task_done: missing string argument 'summary'")?
@@ -2097,6 +2101,21 @@ mod tests {
         assert!(
             required.iter().any(|v| v == "validation_evidence"),
             "task_done must require validation_evidence: {schema}"
+        );
+    }
+
+    #[test]
+    fn task_done_rejects_empty_pane_id() {
+        let err = task_done(serde_json::json!({
+            "pane_id": "   ",
+            "summary": "implemented",
+            "validation_evidence": "cargo test passed"
+        }))
+        .expect_err("task_done should reject empty pane_id")
+        .to_string();
+        assert!(
+            err.contains("pane_id") && err.contains("non-empty"),
+            "error should mention non-empty pane_id: {err}"
         );
     }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3296,15 +3296,17 @@ mod tests {
 
     #[test]
     fn shorten_cwd_replaces_home_prefix() {
-        // We can't poke HOME safely from a test (it's process-wide),
-        // but we can at least call shorten_cwd and assert that a
+        let _home_lock = crate::test_utils::HOME_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        // HOME is process-wide, so hold the shared test lock while
+        // reading it. We can at least call shorten_cwd and assert that a
         // path beneath the current HOME picks up the ~.  If HOME is
-        // unset (CI quirks) the function falls through and returns
-        // input verbatim — this test then becomes vacuous, which is
-        // acceptable as it can't fail.
+        // unset or `/` (CI/container quirks) the outside-HOME checks are
+        // not meaningful, so this test becomes vacuous.
         if let Ok(home) = std::env::var("HOME") {
-            if !home.is_empty() {
-                let home_trimmed = home.trim_end_matches('/');
+            let home_trimmed = home.trim_end_matches('/');
+            if !home_trimmed.is_empty() {
                 let inside = format!("{home_trimmed}/projects/foo");
                 let short = shorten_cwd(&inside);
                 assert_eq!(short, "~/projects/foo");
@@ -3317,10 +3319,10 @@ mod tests {
                 // stay verbatim, not become ~an/project).
                 let sibling = format!("{home_trimmed}sibling/project");
                 assert_eq!(shorten_cwd(&sibling), sibling);
+                // Outside-HOME path stays verbatim.
+                assert_eq!(shorten_cwd("/etc/hosts"), "/etc/hosts");
             }
         }
-        // Outside-HOME path stays verbatim.
-        assert_eq!(shorten_cwd("/etc/hosts"), "/etc/hosts");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2043,6 +2043,9 @@ fn shorten_cwd(cwd: &str) -> String {
     // /home/al exactly (and is still treated as a boundary on
     // /home/al/foo).
     let home_trimmed = home.trim_end_matches('/');
+    if home_trimmed.is_empty() {
+        return cwd.to_string();
+    }
     if cwd == home_trimmed {
         return "~".to_string();
     }
@@ -3302,8 +3305,8 @@ mod tests {
         // HOME is process-wide, so hold the shared test lock while
         // reading it. We can at least call shorten_cwd and assert that a
         // path beneath the current HOME picks up the ~.  If HOME is
-        // unset or `/` (CI/container quirks) the outside-HOME checks are
-        // not meaningful, so this test becomes vacuous.
+        // unset or `/` (CI/container quirks), the inside-HOME checks are
+        // not meaningful and are skipped.
         if let Ok(home) = std::env::var("HOME") {
             let home_trimmed = home.trim_end_matches('/');
             if !home_trimmed.is_empty() {
@@ -3319,10 +3322,10 @@ mod tests {
                 // stay verbatim, not become ~an/project).
                 let sibling = format!("{home_trimmed}sibling/project");
                 assert_eq!(shorten_cwd(&sibling), sibling);
-                // Outside-HOME path stays verbatim.
-                assert_eq!(shorten_cwd("/etc/hosts"), "/etc/hosts");
             }
         }
+        // Outside-HOME path stays verbatim even when HOME is `/`.
+        assert_eq!(shorten_cwd("/etc/hosts"), "/etc/hosts");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require supervisors to observe downstream Codex/Claude validation before `task_done`
- add required `validation_evidence` to `task_done` so release reports include commands/results
- prevent pane release when `task_done` validation fails

## Validation
- `cargo fmt --check`
- `cargo test task_done`
- `./scripts/test.sh` (passed in temporary clone `/tmp/amaebi-verify-Pw108j` to avoid rootless Docker UID write issues on the home bind mount)