### PR TITLE
Add supervisor task event wake-up tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaebi"
-version = "2026.6.9"
+version = "2026.7.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amaebi"
-version = "2026.6.9"
+version = "2026.7.1"
 edition = "2021"
 
 [[bin]]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -5233,11 +5233,31 @@ fn format_pane_alive_reminder(panes: &[(String, Option<String>)]) -> String {
          tool in every turn — do NOT reply with text only, except for \
          the three named escalation cases above.\n\
          \n\
+         **LLM wake-up protocol for long waits.**  Do not spend repeated \
+         turns merely confirming that a build, test suite, or simulator is \
+         still running.  When the downstream pane can run a long command \
+         under a small wrapper, steer it to tee stdout/stderr to a full log \
+         file and create explicit sentinel files for decision points such \
+         as `passed`, `failed`, `anomaly`, or `no_progress`.  Then use \
+         `wait_for_task_event` once to block until a sentinel appears or a \
+         timeout occurs.  The full log remains on disk; after wake-up, use \
+         the returned event/tail plus `read_file` or `tmux_capture_pane` \
+         as needed to make the decision yourself.  This preserves \
+         supervision context while avoiding no-decision polling turns.\n\
+         \n\
          Your supervision vocabulary:\n\
          - `tmux_capture_pane` — read the pane to see what Claude is doing.\n\
          - `tmux_wait` — pause until the pane falls idle.  This is the \
          correct way to \"wait and see\"; a text reply saying \"I'll wait\" \
-         is forbidden.\n\
+         is forbidden.  Prefer `wait_for_task_event` for long wrapped \
+         build/test/simulator waits that can write sentinel files.\n\
+         - `wait_for_task_event` — block until one of several sentinel \
+         files appears, returning the event label, event payload, and an \
+         optional log tail.  Use it as the LLM wake-up protocol after you \
+         have steered Claude/Codex to keep the complete log in a file and \
+         write sentinel files at decision points.  This tool does NOT \
+         replace your judgment; it only wakes you when there is something \
+         to judge.\n\
          - `tmux_send_text` — paste a correction / new instruction into \
          Claude (e.g. \"try the other branch\", \"also run the benchmarks\").  \
          This is how you STEER Claude without killing and restarting.\n\

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -666,7 +666,9 @@ async fn read_file_tail(path: &str, lines: usize, max_bytes: u64) -> Result<Stri
     if start > 0 {
         text = match text.find('\n') {
             Some(pos) => text[pos + 1..].to_owned(),
-            None => String::new(),
+            // The sampled window can be entirely inside one very long line.
+            // Keep that partial line rather than reporting an empty tail.
+            None => text,
         };
     }
 
@@ -1557,7 +1559,7 @@ fn chat_tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
                     "properties": {
                         "events": {
                             "type": "array",
-                            "description": "Sentinel files to watch. The first file that appears wakes the supervisor.",
+                            "description": "Sentinel files to watch. On each poll, the first listed event whose file exists wakes the supervisor; order events by priority if multiple files may exist.",
                             "items": {
                                 "type": "object",
                                 "properties": {
@@ -2473,6 +2475,17 @@ mod tests {
             err.contains("'events' must not be empty"),
             "unexpected error: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn read_file_tail_keeps_partial_long_line_when_no_newline_boundary() {
+        let tmp = TempDir::new().unwrap();
+        let log = tmp.path().join("single-line.log");
+        std::fs::write(&log, "abcdefghijklmnopqrstuvwxyz").unwrap();
+
+        let tail = read_file_tail(log.to_str().unwrap(), 1, 8).await.unwrap();
+
+        assert_eq!(tail, "stuvwxyz");
     }
 
     // ---- tmux_wait normalize_for_idle_check --------------------------------

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -660,8 +660,9 @@ async fn read_file_tail(path: &str, lines: usize, max_bytes: u64) -> Result<Stri
     let start = len.saturating_sub(max_bytes);
     file.seek(SeekFrom::Start(start)).await?;
 
+    let mut limited = (&mut file).take(max_bytes);
     let mut buf = Vec::new();
-    file.read_to_end(&mut buf).await?;
+    limited.read_to_end(&mut buf).await?;
     let mut text = String::from_utf8_lossy(&buf).into_owned();
     if start > 0 {
         text = match text.find('\n') {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,8 +1,10 @@
 use std::collections::{HashMap, HashSet};
+use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::process::Command;
 
 use crate::sandbox::{docker::DockerSandboxConfig, DockerSandbox, NoopSandbox, Sandbox};
@@ -122,6 +124,7 @@ impl ToolExecutor for LocalExecutor {
             "tmux_send_key" => tmux_send_key(args).await,
             "tmux_wait" => tmux_wait(args).await,
             "wait_for_file" => wait_for_file(args).await,
+            "wait_for_task_event" => wait_for_task_event(args).await,
             "tmux_rename_pane" => tmux_rename_pane(args).await,
             "read_file" => read_file(args).await,
             "edit_file" => edit_file(args).await,
@@ -488,6 +491,191 @@ async fn wait_for_file(args: serde_json::Value) -> Result<String> {
         }
         tokio::time::sleep(std::time::Duration::from_millis(poll_ms).min(remaining)).await;
     }
+}
+
+const DEFAULT_TASK_EVENT_TAIL_LINES: usize = 80;
+const MAX_TASK_EVENT_TAIL_LINES: usize = 1_000;
+const MAX_TASK_EVENT_PAYLOAD_BYTES: u64 = 16 * 1024;
+const MAX_TASK_EVENT_LOG_TAIL_BYTES: u64 = 256 * 1024;
+
+#[derive(Debug, Clone)]
+struct TaskEventSpec {
+    name: String,
+    path: String,
+}
+
+/// Block until one of several task event sentinel files appears.
+///
+/// This is intentionally a mechanical wake-up primitive: scripts or downstream
+/// panes decide when to create event files, but the LLM still decides what the
+/// event means and what to do next. Full logs remain on disk; this tool returns
+/// only the event metadata plus an optional tail for fast triage.
+async fn wait_for_task_event(args: serde_json::Value) -> Result<String> {
+    let events = parse_task_event_specs(&args)?;
+    let timeout_secs = args["timeout_secs"].as_u64().unwrap_or(300).min(86_400);
+    let poll_ms = args["poll_interval_ms"].as_u64().unwrap_or(500).max(1);
+    let log_path = args["log_path"].as_str().map(str::to_owned);
+    let tail_lines = args["tail_lines"]
+        .as_u64()
+        .map(|v| (v as usize).min(MAX_TASK_EVENT_TAIL_LINES))
+        .unwrap_or(DEFAULT_TASK_EVENT_TAIL_LINES);
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+
+    loop {
+        for event in &events {
+            match tokio::fs::metadata(&event.path).await {
+                Ok(m) if m.is_file() => {
+                    return format_task_event_result(event, log_path.as_deref(), tail_lines).await;
+                }
+                Ok(_) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "wait_for_task_event: error checking '{}': {e}",
+                        event.path
+                    ));
+                }
+            }
+        }
+
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return format_task_event_timeout(
+                &events,
+                timeout_secs,
+                log_path.as_deref(),
+                tail_lines,
+            )
+            .await;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(poll_ms).min(remaining)).await;
+    }
+}
+
+fn parse_task_event_specs(args: &serde_json::Value) -> Result<Vec<TaskEventSpec>> {
+    let raw = args["events"]
+        .as_array()
+        .context("wait_for_task_event: missing array argument 'events'")?;
+    if raw.is_empty() {
+        anyhow::bail!("wait_for_task_event: 'events' must not be empty");
+    }
+
+    let mut events = Vec::with_capacity(raw.len());
+    for (idx, event) in raw.iter().enumerate() {
+        let name = event["name"]
+            .as_str()
+            .with_context(|| format!("wait_for_task_event: events[{idx}].name must be a string"))?;
+        let path = event["path"]
+            .as_str()
+            .with_context(|| format!("wait_for_task_event: events[{idx}].path must be a string"))?;
+        if name.trim().is_empty() {
+            anyhow::bail!("wait_for_task_event: events[{idx}].name must be non-empty");
+        }
+        if path.trim().is_empty() {
+            anyhow::bail!("wait_for_task_event: events[{idx}].path must be non-empty");
+        }
+        events.push(TaskEventSpec {
+            name: name.to_owned(),
+            path: path.to_owned(),
+        });
+    }
+
+    Ok(events)
+}
+
+async fn format_task_event_result(
+    event: &TaskEventSpec,
+    log_path: Option<&str>,
+    tail_lines: usize,
+) -> Result<String> {
+    let mut out = format!(
+        "event: {}\nevent_path: {}\nevent_payload:\n{}",
+        event.name,
+        event.path,
+        read_task_event_payload(&event.path).await?
+    );
+    append_optional_log_tail(&mut out, log_path, tail_lines).await?;
+    Ok(out)
+}
+
+async fn format_task_event_timeout(
+    events: &[TaskEventSpec],
+    timeout_secs: u64,
+    log_path: Option<&str>,
+    tail_lines: usize,
+) -> Result<String> {
+    let mut out =
+        format!("timeout: no task event appeared within {timeout_secs}s\nwatched_events:");
+    for event in events {
+        out.push_str(&format!("\n- {}: {}", event.name, event.path));
+    }
+    append_optional_log_tail(&mut out, log_path, tail_lines).await?;
+    Ok(out)
+}
+
+async fn read_task_event_payload(path: &str) -> Result<String> {
+    read_file_prefix(path, MAX_TASK_EVENT_PAYLOAD_BYTES)
+        .await
+        .with_context(|| format!("wait_for_task_event: reading event payload '{path}'"))
+}
+
+async fn append_optional_log_tail(
+    out: &mut String,
+    log_path: Option<&str>,
+    tail_lines: usize,
+) -> Result<()> {
+    let Some(path) = log_path else {
+        return Ok(());
+    };
+    out.push_str(&format!("\nlog_path: {path}\nlog_tail:\n"));
+    match read_file_tail(path, tail_lines, MAX_TASK_EVENT_LOG_TAIL_BYTES).await {
+        Ok(tail) => out.push_str(&tail),
+        Err(e) => out.push_str(&format!("[unable to read log tail: {e}]")),
+    }
+    Ok(())
+}
+
+async fn read_file_prefix(path: &str, max_bytes: u64) -> Result<String> {
+    let mut file = tokio::fs::File::open(path).await?;
+    let mut limited = (&mut file).take(max_bytes + 1);
+    let mut buf = Vec::new();
+    limited.read_to_end(&mut buf).await?;
+    let truncated = buf.len() as u64 > max_bytes;
+    if truncated {
+        buf.truncate(max_bytes as usize);
+    }
+    let mut text = String::from_utf8_lossy(&buf).into_owned();
+    if truncated {
+        text.push_str("\n[truncated]");
+    }
+    Ok(text)
+}
+
+async fn read_file_tail(path: &str, lines: usize, max_bytes: u64) -> Result<String> {
+    if lines == 0 {
+        return Ok(String::new());
+    }
+    let mut file = tokio::fs::File::open(path).await?;
+    let len = file.metadata().await?.len();
+    let start = len.saturating_sub(max_bytes);
+    file.seek(SeekFrom::Start(start)).await?;
+
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).await?;
+    let mut text = String::from_utf8_lossy(&buf).into_owned();
+    if start > 0 {
+        text = match text.find('\n') {
+            Some(pos) => text[pos + 1..].to_owned(),
+            None => String::new(),
+        };
+    }
+
+    let collected: Vec<&str> = text.lines().rev().take(lines).collect();
+    let mut tail = collected.into_iter().rev().collect::<Vec<_>>().join("\n");
+    if text.ends_with('\n') && !tail.is_empty() {
+        tail.push('\n');
+    }
+    Ok(tail)
 }
 
 /// Rename a tmux pane by setting its title.
@@ -1353,6 +1541,67 @@ fn chat_tool_schemas(include_spawn_agent: bool) -> Vec<serde_json::Value> {
         serde_json::json!({
             "type": "function",
             "function": {
+                "name": "wait_for_task_event",
+                "description": "Block until one of several task-event sentinel files appears, \
+                                then return the event name, event file payload, and optional \
+                                tail of a full log file. Use this for an LLM wake-up protocol: \
+                                first steer the downstream pane to run a long build/test/simulator \
+                                command with stdout/stderr tee'd to a log file and to write \
+                                sentinel files for decision points such as passed, failed, \
+                                anomaly, or no_progress; then call this tool once instead of \
+                                repeatedly polling tmux_capture_pane. This tool does not judge \
+                                the event or summarize the task; the supervisor still decides \
+                                the next action and can read the full log_path when needed.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "events": {
+                            "type": "array",
+                            "description": "Sentinel files to watch. The first file that appears wakes the supervisor.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Event label to return, e.g. 'passed', 'failed', 'anomaly', 'no_progress'."
+                                    },
+                                    "path": {
+                                        "type": "string",
+                                        "description": "Absolute or relative path to the sentinel file."
+                                    }
+                                },
+                                "required": ["name", "path"]
+                            }
+                        },
+                        "timeout_secs": {
+                            "type": "integer",
+                            "description": "Hard timeout in seconds before returning a timeout status. Default: 300. Maximum: 86400.",
+                            "minimum": 0,
+                            "maximum": 86400
+                        },
+                        "poll_interval_ms": {
+                            "type": "integer",
+                            "description": "How often to check sentinel files, in milliseconds. Minimum: 1. Default: 500.",
+                            "minimum": 1
+                        },
+                        "log_path": {
+                            "type": "string",
+                            "description": "Optional path to the full log file for the running task. The full log remains on disk."
+                        },
+                        "tail_lines": {
+                            "type": "integer",
+                            "description": "Optional number of log tail lines to return for triage. Default: 80. Maximum: 1000.",
+                            "minimum": 0,
+                            "maximum": 1000
+                        }
+                    },
+                    "required": ["events"]
+                }
+            }
+        }),
+        serde_json::json!({
+            "type": "function",
+            "function": {
                 "name": "tmux_rename_pane",
                 "description": "Set the title of a tmux pane using 'tmux select-pane -T'. \
                                 Useful for labelling panes with the current task.",
@@ -1625,6 +1874,7 @@ mod tests {
             "tmux_send_key",
             "tmux_wait",
             "wait_for_file",
+            "wait_for_task_event",
             "read_file",
             "edit_file",
             "spawn_agent",
@@ -2156,6 +2406,73 @@ mod tests {
         .await
         .unwrap();
         assert!(result.starts_with("timeout:"), "got: {result}");
+    }
+
+    // ---- wait_for_task_event -------------------------------------------
+
+    #[tokio::test]
+    async fn wait_for_task_event_returns_event_payload_and_log_tail() {
+        let tmp = TempDir::new().unwrap();
+        let passed = tmp.path().join("passed.event");
+        let failed = tmp.path().join("failed.event");
+        let log = tmp.path().join("task.log");
+        std::fs::write(&passed, "exit_code=0\n").unwrap();
+        std::fs::write(&log, "line 1\nline 2\nline 3\n").unwrap();
+
+        let result = wait_for_task_event(serde_json::json!({
+            "events": [
+                {"name": "failed", "path": failed.to_str().unwrap()},
+                {"name": "passed", "path": passed.to_str().unwrap()}
+            ],
+            "log_path": log.to_str().unwrap(),
+            "tail_lines": 2,
+            "timeout_secs": 5
+        }))
+        .await
+        .unwrap();
+
+        assert!(result.contains("event: passed"), "got: {result}");
+        assert!(result.contains("exit_code=0"), "got: {result}");
+        assert!(result.contains("log_path:"), "got: {result}");
+        assert!(!result.contains("line 1"), "got: {result}");
+        assert!(result.contains("line 2\nline 3"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn wait_for_task_event_times_out_with_watched_events() {
+        let tmp = TempDir::new().unwrap();
+        let passed = tmp.path().join("passed.event");
+        let result = wait_for_task_event(serde_json::json!({
+            "events": [
+                {"name": "passed", "path": passed.to_str().unwrap()}
+            ],
+            "timeout_secs": 0,
+            "poll_interval_ms": 10
+        }))
+        .await
+        .unwrap();
+
+        assert!(
+            result.starts_with("timeout: no task event appeared within 0s"),
+            "got: {result}"
+        );
+        assert!(result.contains("watched_events:"), "got: {result}");
+        assert!(result.contains("passed:"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn wait_for_task_event_rejects_empty_event_list() {
+        let err = wait_for_task_event(serde_json::json!({
+            "events": []
+        }))
+        .await
+        .expect_err("empty event list should be rejected")
+        .to_string();
+
+        assert!(
+            err.contains("'events' must not be empty"),
+            "unexpected error: {err}"
+        );
     }
 
     // ---- tmux_wait normalize_for_idle_check --------------------------------

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -658,13 +658,25 @@ async fn read_file_tail(path: &str, lines: usize, max_bytes: u64) -> Result<Stri
     let mut file = tokio::fs::File::open(path).await?;
     let len = file.metadata().await?.len();
     let start = len.saturating_sub(max_bytes);
-    file.seek(SeekFrom::Start(start)).await?;
+    let read_start = start.saturating_sub(1);
+    file.seek(SeekFrom::Start(read_start)).await?;
 
-    let mut limited = (&mut file).take(max_bytes);
+    let read_limit = if start > 0 {
+        max_bytes.saturating_add(1)
+    } else {
+        max_bytes
+    };
+    let mut limited = (&mut file).take(read_limit);
     let mut buf = Vec::new();
     limited.read_to_end(&mut buf).await?;
-    let mut text = String::from_utf8_lossy(&buf).into_owned();
-    if start > 0 {
+    let starts_at_line_boundary = start == 0 || buf.first() == Some(&b'\n');
+    let window = if start > 0 && !buf.is_empty() {
+        &buf[1..]
+    } else {
+        &buf
+    };
+    let mut text = String::from_utf8_lossy(window).into_owned();
+    if start > 0 && !starts_at_line_boundary {
         text = match text.find('\n') {
             Some(pos) => text[pos + 1..].to_owned(),
             // The sampled window can be entirely inside one very long line.
@@ -2487,6 +2499,17 @@ mod tests {
         let tail = read_file_tail(log.to_str().unwrap(), 1, 8).await.unwrap();
 
         assert_eq!(tail, "stuvwxyz");
+    }
+
+    #[tokio::test]
+    async fn read_file_tail_keeps_full_line_when_window_starts_at_line_boundary() {
+        let tmp = TempDir::new().unwrap();
+        let log = tmp.path().join("line-boundary.log");
+        std::fs::write(&log, "0123456789\nabcdef\n").unwrap();
+
+        let tail = read_file_tail(log.to_str().unwrap(), 1, 7).await.unwrap();
+
+        assert_eq!(tail, "abcdef\n");
     }
 
     // ---- tmux_wait normalize_for_idle_check --------------------------------

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -517,7 +517,7 @@ async fn wait_for_task_event(args: serde_json::Value) -> Result<String> {
     let log_path = args["log_path"].as_str().map(str::to_owned);
     let tail_lines = args["tail_lines"]
         .as_u64()
-        .map(|v| (v as usize).min(MAX_TASK_EVENT_TAIL_LINES))
+        .map(|v| v.min(MAX_TASK_EVENT_TAIL_LINES as u64) as usize)
         .unwrap_or(DEFAULT_TASK_EVENT_TAIL_LINES);
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2544,10 +2544,9 @@ fn assistant_heading(text: &str) -> Option<(String, Style)> {
         ("###", r)
     } else if let Some(r) = trimmed.strip_prefix("## ") {
         ("##", r)
-    } else if let Some(r) = trimmed.strip_prefix("# ") {
-        ("#", r)
     } else {
-        return None;
+        let r = trimmed.strip_prefix("# ")?;
+        ("#", r)
     };
     let style = match hashes {
         "#" => Style::default()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -111,6 +111,79 @@ async fn test_tool_call_roundtrip() {
     );
 }
 
+/// Mock returns a wait_for_task_event tool call → daemon blocks until a
+/// sentinel appears → tool result is sent back to the model with event details.
+#[tokio::test]
+async fn test_wait_for_task_event_tool_roundtrip() {
+    let tmp = tempfile::TempDir::new().expect("temp event dir");
+    let log_path = tmp.path().join("task.log");
+    let passed_path = tmp.path().join("passed.event");
+    let failed_path = tmp.path().join("failed.event");
+
+    let log_for_writer = log_path.clone();
+    let passed_for_writer = passed_path.clone();
+    tokio::spawn(async move {
+        tokio::fs::write(&log_for_writer, "line 1\n")
+            .await
+            .expect("write initial log");
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        tokio::fs::write(&log_for_writer, "line 1\nline 2\nline 3\n")
+            .await
+            .expect("write final log");
+        tokio::fs::write(&passed_for_writer, "exit_code=0\nsource=mock-integration\n")
+            .await
+            .expect("write passed event");
+    });
+
+    let server = MockLlmServer::start().await;
+    let args = serde_json::json!({
+        "events": [
+            {"name": "failed", "path": failed_path},
+            {"name": "passed", "path": passed_path}
+        ],
+        "timeout_secs": 5,
+        "poll_interval_ms": 20,
+        "log_path": log_path,
+        "tail_lines": 2
+    });
+    server.enqueue(ScriptedResponse::tool_call(
+        "call-event-001",
+        "wait_for_task_event",
+        args.to_string(),
+    ));
+    server.enqueue(ScriptedResponse::text_chunks(vec!["event observed"]));
+
+    let daemon = start_daemon(&server.url()).await.expect("start_daemon");
+    let client = connect_client(&daemon.socket);
+
+    let responses = send_message(&client, "wait for task event")
+        .await
+        .expect("send_message");
+    let text = collect_text(&responses);
+    assert!(
+        text.contains("event observed"),
+        "expected final text in response, got: {text:?}"
+    );
+
+    let reqs = server.take_requests();
+    assert_eq!(
+        reqs.len(),
+        2,
+        "expected initial request and tool-result follow-up, got {}",
+        reqs.len()
+    );
+    let follow_up = serde_json::to_string(&reqs[1].body).expect("serialize request body");
+    assert!(follow_up.contains("event: passed"), "{follow_up}");
+    assert!(follow_up.contains("exit_code=0"), "{follow_up}");
+    assert!(follow_up.contains("source=mock-integration"), "{follow_up}");
+    assert!(follow_up.contains("line 2"), "{follow_up}");
+    assert!(follow_up.contains("line 3"), "{follow_up}");
+    assert!(
+        !follow_up.contains("line 1\\nline 2\\nline 3"),
+        "tool result should include only the requested tail, got: {follow_up}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // 3. max_completion_tokens sent correctly
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `wait_for_task_event` so supervisor loops can block on task sentinel files instead of repeatedly polling tmux pane output
- return event payload plus optional log tail while keeping the complete log on disk for follow-up inspection
- update the /claude supervisor reminder to describe the LLM wake-up protocol for long build/test/simulator waits
- add unit and mock-LLM integration coverage for the new tool path

## Verification
- `cargo test wait_for_task_event`
- `cargo test tool_schemas_have_expected_names`
- `cargo test test_wait_for_task_event_tool_roundtrip -- --nocapture`
- `./scripts/test.sh`
- `./scripts/test.sh --filter test_wait_for_task_event_tool_roundtrip`

## Manual smoke
- tmux window 3 produced a log and `passed.event` sentinel under `/tmp/amaebi-wakeup-test2`
- tmux window 2 ran the mock-LLM roundtrip test that forces the daemon through `wait_for_task_event` and verifies the event payload/log tail returned to the model
